### PR TITLE
[AMSDK-9772] Adding Podspec

### DIFF
--- a/ACPExperiencePlatform.podspec
+++ b/ACPExperiencePlatform.podspec
@@ -1,14 +1,6 @@
-#
-# Be sure to run `pod lib lint ACPExperiencePlatform.podspec' to ensure this is a
-# valid spec before submitting.
-#
-# Any lines starting with a # are optional, but their use is encouraged
-# To learn more about a Podspec see https://guides.cocoapods.org/syntax/podspec.html
-#
-
 Pod::Spec.new do |s|
   s.name             = "ACPExperiencePlatform"
-  s.version          = "1.0.0-alpha-2"
+  s.version          = "1.0.0-alpha"
   s.summary          = "Experience Platform extension for Adobe Experience Cloud SDK. Written and maintained by Adobe."
 
   s.description      = <<-DESC

--- a/code/src/ExperiencePlatformInternal.swift
+++ b/code/src/ExperiencePlatformInternal.swift
@@ -62,7 +62,7 @@ class ExperiencePlatformInternal : ACPExtension {
     }
     
     override func version() -> String? {
-        "1.0.0-alpha-2"
+        "1.0.0-alpha"
     }
     
     override func onUnregister() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding Podspec for project.

- Adds ACPExperiencePlatform.podspec to project root which allows pulling the pod as source.
- A demo app which pulls the project source as a Pod will be in another PR, as the podspec needs to be submitted first.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using demo application using the Podspec in my private fork.
Ran `pod lib lint`. Will still receive warning that URL is not reachable as it is private.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
