### PR TITLE
[AMSDK-9827] Set min target to iOS 10 for testing and update unit tests

### DIFF
--- a/build/xcode/ACPExperiencePlatform.xcodeproj/project.pbxproj
+++ b/build/xcode/ACPExperiencePlatform.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		D42FB8E124635FA200E9321C /* MockResponseCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = D42FB8E024635FA200E9321C /* MockResponseCallback.swift */; };
 		D44BBB75248DC54F00775DAC /* CountDownLatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44BBB74248DC54F00775DAC /* CountDownLatch.swift */; };
 		D44BBB76248DEDB400775DAC /* CountDownLatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44BBB74248DC54F00775DAC /* CountDownLatch.swift */; };
+		D44BBB982492F5C900775DAC /* UnitTestAssertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44BBB972492F5C900775DAC /* UnitTestAssertions.swift */; };
 		D46553ED2469FBE100A150E2 /* ExperiencePlatformResponseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46553EC2469FBE100A150E2 /* ExperiencePlatformResponseHandler.swift */; };
 		D46553EF246A046800A150E2 /* ThreadSafeDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46553EE246A046800A150E2 /* ThreadSafeDictionary.swift */; };
 		D46553F1246A123900A150E2 /* RequestCallbackHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46553F0246A123900A150E2 /* RequestCallbackHandlerTests.swift */; };
@@ -326,7 +327,7 @@
 		BF947F98244150530057A6CC /* KeyValueStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyValueStore.swift; sourceTree = "<group>"; };
 		BF947F9C244181FF0057A6CC /* MockKeyValueStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockKeyValueStore.swift; sourceTree = "<group>"; };
 		BF947F9F244569190057A6CC /* EdgeRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeRequestTests.swift; sourceTree = "<group>"; };
-		BF947FA1244587520057A6CC /* TestUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TestUtils.swift; path = ../../../code/testUtilsShared/TestUtils.swift; sourceTree = "<group>"; };
+		BF947FA1244587520057A6CC /* TestUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUtils.swift; sourceTree = "<group>"; };
 		BF947FA3244613FB0057A6CC /* RequestMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestMetadataTests.swift; sourceTree = "<group>"; };
 		BF947FA5244619E80057A6CC /* RequestContextDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestContextDataTests.swift; sourceTree = "<group>"; };
 		D2D776EBFDA183603FE9E178 /* Pods-unitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-unitTests.debug.xcconfig"; path = "Target Support Files/Pods-unitTests/Pods-unitTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -344,6 +345,7 @@
 		D42FB8DE24635B6200E9321C /* AEPServiceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPServiceProvider.swift; sourceTree = "<group>"; };
 		D42FB8E024635FA200E9321C /* MockResponseCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockResponseCallback.swift; sourceTree = "<group>"; };
 		D44BBB74248DC54F00775DAC /* CountDownLatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountDownLatch.swift; sourceTree = "<group>"; };
+		D44BBB972492F5C900775DAC /* UnitTestAssertions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitTestAssertions.swift; sourceTree = "<group>"; };
 		D46553EC2469FBE100A150E2 /* ExperiencePlatformResponseHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperiencePlatformResponseHandler.swift; sourceTree = "<group>"; };
 		D46553EE246A046800A150E2 /* ThreadSafeDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadSafeDictionary.swift; sourceTree = "<group>"; };
 		D46553F0246A123900A150E2 /* RequestCallbackHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestCallbackHandlerTests.swift; sourceTree = "<group>"; };
@@ -627,7 +629,8 @@
 			children = (
 				BF947FA1244587520057A6CC /* TestUtils.swift */,
 			);
-			path = testUtilsShared;
+			name = testUtilsShared;
+			path = ../../code/testUtilsShared;
 			sourceTree = "<group>";
 		};
 		D4D5B4DE242EBB1600CAB6E4 = {
@@ -780,6 +783,7 @@
 				BF947F9C244181FF0057A6CC /* MockKeyValueStore.swift */,
 				D42FB8E024635FA200E9321C /* MockResponseCallback.swift */,
 				D46553F2246A138800A150E2 /* MockExperiencePlatformResponseHandler.swift */,
+				D44BBB972492F5C900775DAC /* UnitTestAssertions.swift */,
 			);
 			name = utils;
 			sourceTree = "<group>";
@@ -1293,6 +1297,7 @@
 				BF947F7E243EA1300057A6CC /* RequestBuilderTests.swift in Sources */,
 				BF947F88243F2EF70057A6CC /* StoreResponsePayloadTests.swift in Sources */,
 				BF947F9E244182B30057A6CC /* StoreResponsePayloadManagerTests.swift in Sources */,
+				D44BBB982492F5C900775DAC /* UnitTestAssertions.swift in Sources */,
 				BF947F74243BA0E10057A6CC /* KonductorConfigTests.swift in Sources */,
 				BF947FA6244619E80057A6CC /* RequestContextDataTests.swift in Sources */,
 				D4F74FE92447A92800379258 /* MockURLSession.swift in Sources */,
@@ -1466,7 +1471,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = FKGEE875K4;
 				INFOPLIST_FILE = ../../code/functionalTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1476,6 +1481,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TVOS_DEPLOYMENT_TARGET = 10.0;
 				VALID_ARCHS = "$(inherited)";
 			};
 			name = Debug;
@@ -1487,7 +1493,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = FKGEE875K4;
 				INFOPLIST_FILE = ../../code/functionalTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1497,6 +1503,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TVOS_DEPLOYMENT_TARGET = 10.0;
 				VALID_ARCHS = "$(inherited)";
 			};
 			name = Release;
@@ -1674,7 +1681,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = FKGEE875K4;
 				INFOPLIST_FILE = ../../code/unitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1684,7 +1691,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TVOS_DEPLOYMENT_TARGET = 11.0;
+				TVOS_DEPLOYMENT_TARGET = 10.0;
 				VALID_ARCHS = "$(inherited)";
 			};
 			name = Debug;
@@ -1696,7 +1703,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = FKGEE875K4;
 				INFOPLIST_FILE = ../../code/unitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1706,7 +1713,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TVOS_DEPLOYMENT_TARGET = 11.0;
+				TVOS_DEPLOYMENT_TARGET = 10.0;
 				VALID_ARCHS = "$(inherited)";
 			};
 			name = Release;
@@ -1729,6 +1736,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TVOS_DEPLOYMENT_TARGET = 10.0;
 				VALID_ARCHS = "$(inherited)";
 				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
@@ -1752,6 +1760,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TVOS_DEPLOYMENT_TARGET = 10.0;
 				VALID_ARCHS = "$(inherited)";
 				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};

--- a/code/testUtilsShared/TestUtils.swift
+++ b/code/testUtilsShared/TestUtils.swift
@@ -20,7 +20,10 @@ func flattenDictionary(dict: [String : Any]) -> [String : Any] {
     
     func recursive(dict: [String : Any], out: inout [String : Any], currentKey: String = "") {
         if dict.isEmpty {
-            out[currentKey] = "isEmpty"
+            if currentKey.isEmpty {
+                out = [:]
+            } else {
+                out[currentKey] = "isEmpty"}
             return
         }
         for (key, val) in dict {
@@ -59,4 +62,19 @@ func flattenDictionary(dict: [String : Any]) -> [String : Any] {
 func timestampToISO8601(_ timestamp: Int) -> String {
     let date = Date(timeIntervalSince1970: TimeInterval(timestamp/1000))
     return ISO8601DateFormatter().string(from: date)
+}
+
+/// Attempts to convert provided data to [String: Any] using JSONSerialization.
+/// - Parameter data: data to be converted to [String: Any]
+/// - Returns: `data` as [String: Any] or empty if an error occured
+func asFlattenDictionary(data: Data?) -> [String: Any] {
+    guard let unwrappedData = data else {
+        return [:]
+    }
+    guard let dataAsDictionary = try? JSONSerialization.jsonObject(with: unwrappedData, options: []) as? [String: Any] else {
+        print("asFlattenDictionary - Unable to convert to [String: Any], data: \(String(data: unwrappedData, encoding: .utf8) ?? "")")
+        return [:]
+    }
+    
+    return flattenDictionary(dict: dataAsDictionary)
 }

--- a/code/unitTests/EdgeRequestTests.swift
+++ b/code/unitTests/EdgeRequestTests.swift
@@ -19,7 +19,7 @@ class EdgeRequestTests: XCTestCase {
         // Put setup code here. This method is called before the invocation of each test method in the class.
         continueAfterFailure = false // fail so nil checks stop execution
     }
-
+    
     func testEncode_allProperties() {
         let konductorConfig = KonductorConfig(streaming: Streaming(recordSeparator: "A", lineFeed: "B"))
         let requestMetadata = RequestMetadata(konductorConfig: konductorConfig, state: nil)
@@ -42,50 +42,20 @@ class EdgeRequestTests: XCTestCase {
         let edgeRequest = EdgeRequest(meta: requestMetadata, xdm: requestContext, events: events)
         
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.outputFormatting = [.prettyPrinted]
         encoder.dateEncodingStrategy = .iso8601
         
         let data = try? encoder.encode(edgeRequest)
-        
-        XCTAssertNotNil(data)
-        let expected = """
-        {
-          "events" : [
-            {
-              "data" : {
-                "key" : "value"
-              },
-              "xdm" : {
-                "device" : {
-                  "manufacturer" : "Atari",
-                  "type" : "mobile"
-                }
-              }
-            }
-          ],
-          "meta" : {
-            "konductorConfig" : {
-              "streaming" : {
-                "enabled" : true,
-                "lineFeed" : "B",
-                "recordSeparator" : "A"
-              }
-            }
-          },
-          "xdm" : {
-            "identityMap" : {
-              "email" : [
-                {
-                  "id" : "example@adobe.com"
-                }
-              ]
-            }
-          }
-        }
-        """
-        let jsonString = String(data: data!, encoding: .utf8)
-        print(jsonString!)
-        XCTAssertEqual(expected, jsonString)
+        let actualResult = asFlattenDictionary(data: data)
+        let expectedResult : [String: Any] =
+            [ "events[0].data.key": "value",
+              "events[0].xdm.device.manufacturer": "Atari",
+              "events[0].xdm.device.type": "mobile",
+              "meta.konductorConfig.streaming.enabled": true,
+              "meta.konductorConfig.streaming.recordSeparator": "A",
+              "meta.konductorConfig.streaming.lineFeed": "B",
+              "xdm.identityMap.email[0].id": "example@adobe.com"]
+        assertEqual(expectedResult, actualResult)
     }
     
     func testEncode_onlyRequestMetadata() {
@@ -96,28 +66,16 @@ class EdgeRequestTests: XCTestCase {
                                       events: nil)
         
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.outputFormatting = [.prettyPrinted]
         encoder.dateEncodingStrategy = .iso8601
         
         let data = try? encoder.encode(edgeRequest)
-        
-        XCTAssertNotNil(data)
-        let expected = """
-        {
-          "meta" : {
-            "konductorConfig" : {
-              "streaming" : {
-                "enabled" : true,
-                "lineFeed" : "B",
-                "recordSeparator" : "A"
-              }
-            }
-          }
-        }
-        """
-        let jsonString = String(data: data!, encoding: .utf8)
-        print(jsonString!)
-        XCTAssertEqual(expected, jsonString)
+        let actualResult = asFlattenDictionary(data: data)
+        let expectedResult : [String: Any] =
+            ["meta.konductorConfig.streaming.enabled": true,
+             "meta.konductorConfig.streaming.recordSeparator": "A",
+             "meta.konductorConfig.streaming.lineFeed": "B"]
+        assertEqual(expectedResult, actualResult)
     }
     
     func testEncode_onlyRequestContext() {
@@ -129,28 +87,14 @@ class EdgeRequestTests: XCTestCase {
                                       events: nil)
         
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.outputFormatting = [.prettyPrinted]
         encoder.dateEncodingStrategy = .iso8601
         
         let data = try? encoder.encode(edgeRequest)
         
-        XCTAssertNotNil(data)
-        let expected = """
-        {
-          "xdm" : {
-            "identityMap" : {
-              "email" : [
-                {
-                  "id" : "example@adobe.com"
-                }
-              ]
-            }
-          }
-        }
-        """
-        let jsonString = String(data: data!, encoding: .utf8)
-        print(jsonString!)
-        XCTAssertEqual(expected, jsonString)
+        let actualResult = asFlattenDictionary(data: data)
+        let expectedResult : [String: Any] = ["xdm.identityMap.email[0].id": "example@adobe.com"]
+        assertEqual(expectedResult, actualResult)
     }
     
     func testEncode_onlyEvents() {
@@ -181,44 +125,19 @@ class EdgeRequestTests: XCTestCase {
                                       events: events)
         
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.outputFormatting = [.prettyPrinted]
         encoder.dateEncodingStrategy = .iso8601
         
         let data = try? encoder.encode(edgeRequest)
-        
-        XCTAssertNotNil(data)
-        let expected = """
-        {
-          "events" : [
-            {
-              "data" : {
-                "key" : "value"
-              },
-              "xdm" : {
-                "device" : {
-                  "manufacturer" : "Atari",
-                  "type" : "mobile"
-                }
-              }
-            },
-            {
-              "xdm" : {
-                "test" : {
-                  "false" : false,
-                  "one" : 1,
-                  "true" : true,
-                  "zero" : 0
-                }
-              }
-            }
-          ]
-        }
-        """
-        let jsonString = String(data: data!, encoding: .utf8)
-        print(jsonString!)
-        XCTAssertEqual(expected, jsonString)
+        let actualResult = asFlattenDictionary(data: data)
+        let expectedResult : [String: Any] =
+            [ "events[0].data.key": "value",
+              "events[0].xdm.device.manufacturer": "Atari",
+              "events[0].xdm.device.type": "mobile",
+              "events[1].xdm.test.false": false,
+              "events[1].xdm.test.true": true,
+              "events[1].xdm.test.one": 1,
+              "events[1].xdm.test.zero": 0]
+        assertEqual(expectedResult, actualResult)
     }
-    
-    
 }
-

--- a/code/unitTests/IdentityMapTests.swift
+++ b/code/unitTests/IdentityMapTests.swift
@@ -20,10 +20,6 @@ class IdentityMapTests: XCTestCase {
         continueAfterFailure = false // fail so nil checks stop execution
     }
     
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-    
     // MARK: getItemsFor tests
     
     func testGetItemsFor() {
@@ -92,24 +88,15 @@ class IdentityMapTests: XCTestCase {
         identityMap.addItem(namespace: "space", id: "id", authenticationState: AuthenticationState.ambiguous, primary: false)
         
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.outputFormatting = [.prettyPrinted]
         
         let data = try? encoder.encode(identityMap)
-        
-        XCTAssertNotNil(data)
-        let expected = """
-            {
-              "space" : [
-                {
-                  "authenticationState" : "ambiguous",
-                  "id" : "id",
-                  "primary" : false
-                }
-              ]
-            }
-            """
-        let jsonString = String(data: data!, encoding: .utf8)
-        XCTAssertEqual(expected, jsonString)
+        let actualResult = asFlattenDictionary(data: data)
+        let expectedResult : [String: Any] =
+            [ "space[0].id": "id",
+              "space[0].authenticationState": "ambiguous",
+              "space[0].primary": false]
+        assertEqual(expectedResult, actualResult)
     }
     
     func testEncode_twoItems() {
@@ -118,29 +105,16 @@ class IdentityMapTests: XCTestCase {
         identityMap.addItem(namespace: "A", id: "123")
         
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.outputFormatting = [.prettyPrinted]
         
         let data = try? encoder.encode(identityMap)
-        
-        XCTAssertNotNil(data)
-        let expected = """
-            {
-              "A" : [
-                {
-                  "id" : "123"
-                }
-              ],
-              "space" : [
-                {
-                  "authenticationState" : "ambiguous",
-                  "id" : "id",
-                  "primary" : false
-                }
-              ]
-            }
-            """
-        let jsonString = String(data: data!, encoding: .utf8)
-        XCTAssertEqual(expected, jsonString)
+        let actualResult = asFlattenDictionary(data: data)
+        let expectedResult : [String: Any] =
+            [ "A[0].id": "123",
+              "space[0].id": "id",
+              "space[0].authenticationState": "ambiguous",
+              "space[0].primary": false]
+        assertEqual(expectedResult, actualResult)
     }
     
     func testEncode_twoItemsSameNamespace() {
@@ -149,27 +123,16 @@ class IdentityMapTests: XCTestCase {
         identityMap.addItem(namespace: "space", id: "123")
         
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.outputFormatting = [.prettyPrinted]
         
         let data = try? encoder.encode(identityMap)
-        
-        XCTAssertNotNil(data)
-        let expected = """
-            {
-              "space" : [
-                {
-                  "authenticationState" : "ambiguous",
-                  "id" : "id",
-                  "primary" : false
-                },
-                {
-                  "id" : "123"
-                }
-              ]
-            }
-            """
-        let jsonString = String(data: data!, encoding: .utf8)
-        XCTAssertEqual(expected, jsonString)
+        let actualResult = asFlattenDictionary(data: data)
+        let expectedResult : [String: Any] =
+            [ "space[0].id": "id",
+              "space[0].authenticationState": "ambiguous",
+              "space[0].primary": false,
+              "space[1].id": "123"]
+        assertEqual(expectedResult, actualResult)
     }
     
     // MARK: decoder tests

--- a/code/unitTests/KonductorConfigTests.swift
+++ b/code/unitTests/KonductorConfigTests.swift
@@ -20,118 +20,62 @@ class KonductorConfigTests: XCTestCase {
         continueAfterFailure = false // fail so nil checks stop execution
     }
     
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-    
     // MARK: Streaming encoder tests
     
     func testStreamingEncodeFromInitAll() {
-        let streaming = Streaming(recordSeparator: "A",
-                                  lineFeed: "B")
-        
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        
-        let streamingData = try? encoder.encode(streaming)
-        
-        XCTAssertNotNil(streamingData)
-        let expected = """
-            {
-              "enabled" : true,
-              "lineFeed" : "B",
-              "recordSeparator" : "A"
-            }
-            """
-        let jsonString = String(data: streamingData!, encoding: .utf8)
-        print(jsonString!)
-        
-        XCTAssertEqual(expected, jsonString)
-        
-    }
-    
-    func testStreamingEncodeFromParametersAll() {
         let streaming = Streaming(recordSeparator: "A", lineFeed: "B")
         
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.outputFormatting = [.prettyPrinted]
         
-        let streamingData = try? encoder.encode(streaming)
-        
-        XCTAssertNotNil(streamingData)
-        let expected = """
-            {
-              "enabled" : true,
-              "lineFeed" : "B",
-              "recordSeparator" : "A"
-            }
-            """
-        let jsonString = String(data: streamingData!, encoding: .utf8)
-        print(jsonString!)
-        
-        XCTAssertEqual(expected, jsonString)
+        let data = try? encoder.encode(streaming)
+        let actualResult = asFlattenDictionary(data: data)
+        let expectedResult : [String: Any] =
+            [ "enabled": true,
+              "lineFeed": "B",
+              "recordSeparator": "A"]
+        assertEqual(expectedResult, actualResult)
     }
     
     func testStreamingEncodeWithNilRecordSeparator() {
         let streaming = Streaming(recordSeparator: nil, lineFeed: "B")
         
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.outputFormatting = [.prettyPrinted]
         
-        let streamingData = try? encoder.encode(streaming)
-        
-        XCTAssertNotNil(streamingData)
-        let expected = """
-            {
-              "enabled" : false,
-              "lineFeed" : "B"
-            }
-            """
-        let jsonString = String(data: streamingData!, encoding: .utf8)
-        print(jsonString!)
-        
-        XCTAssertEqual(expected, jsonString)
+        let data = try? encoder.encode(streaming)
+        let actualResult = asFlattenDictionary(data: data)
+        let expectedResult : [String: Any] =
+            [ "enabled": false,
+              "lineFeed": "B"]
+        assertEqual(expectedResult, actualResult)
     }
     
     func testStreamingEncodeWithNilLineFeed() {
         let streaming = Streaming(recordSeparator: "A", lineFeed: nil)
         
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.outputFormatting = [.prettyPrinted]
         
-        let streamingData = try? encoder.encode(streaming)
-        
-        XCTAssertNotNil(streamingData)
-        let expected = """
-            {
-              "enabled" : false,
-              "recordSeparator" : "A"
-            }
-            """
-        let jsonString = String(data: streamingData!, encoding: .utf8)
-        print(jsonString!)
-        
-        XCTAssertEqual(expected, jsonString)
+        let data = try? encoder.encode(streaming)
+        let actualResult = asFlattenDictionary(data: data)
+        let expectedResult : [String: Any] =
+            [ "enabled": false,
+              "recordSeparator": "A"]
+        assertEqual(expectedResult, actualResult)
     }
     
     func testStreamingEncodeWithNilLineFeedAndRecordSeparator() {
         let streaming = Streaming(recordSeparator: nil, lineFeed: nil)
         
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.outputFormatting = [.prettyPrinted]
         
-        let streamingData = try? encoder.encode(streaming)
-        
-        XCTAssertNotNil(streamingData)
-        let expected = """
-            {
-              "enabled" : false
-            }
-            """
-        let jsonString = String(data: streamingData!, encoding: .utf8)
-        print(jsonString!)
-        
-        XCTAssertEqual(expected, jsonString)
+        let data = try? encoder.encode(streaming)
+        let actualResult = asFlattenDictionary(data: data)
+        let expectedResult : [String: Any] =
+            [ "enabled": false]
+        assertEqual(expectedResult, actualResult)
     }
     
     // MARK: KonductorConfig encoder tests
@@ -141,44 +85,27 @@ class KonductorConfigTests: XCTestCase {
         let config = KonductorConfig(streaming: streaming)
         
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.outputFormatting = [.prettyPrinted]
         
-        let jsonData = try? encoder.encode(config)
-        
-        XCTAssertNotNil(jsonData)
-        let expected = """
-            {
-              "streaming" : {
-                "enabled" : true,
-                "lineFeed" : "B",
-                "recordSeparator" : "A"
-              }
-            }
-            """
-        let jsonString = String(data: jsonData!, encoding: .utf8)
-        print(jsonString!)
-        
-        XCTAssertEqual(expected, jsonString)
+        let data = try? encoder.encode(config)
+        let actualResult = asFlattenDictionary(data: data)
+        let expectedResult : [String: Any] =
+            [ "streaming.enabled": true,
+              "streaming.lineFeed": "B",
+              "streaming.recordSeparator": "A"]
+        assertEqual(expectedResult, actualResult)
     }
     
     func testKonductorConfigEncodeEmptyParameters() {
         let config = KonductorConfig(streaming: nil)
         
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.outputFormatting = [.prettyPrinted]
         
-        let jsonData = try? encoder.encode(config)
-        
-        XCTAssertNotNil(jsonData)
-        let expected = """
-            {
-
-            }
-            """
-        let jsonString = String(data: jsonData!, encoding: .utf8)
-        print(jsonString!)
-        
-        XCTAssertEqual(expected, jsonString)
+        let data = try? encoder.encode(config)
+        let actualResult = asFlattenDictionary(data: data)
+        let expectedResult : [String: Any] = [:]
+        assertEqual(expectedResult, actualResult)
     }
     
 }

--- a/code/unitTests/RequestBuilderTests.swift
+++ b/code/unitTests/RequestBuilderTests.swift
@@ -21,15 +21,11 @@ class RequestBuilderTests: XCTestCase {
         continueAfterFailure = false // fail so nil checks stop execution
     }
     
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-    
     func testGetRequestPayload_allParameters_verifyMetadata() {
         let request = RequestBuilder()
         request.enableResponseStreaming(recordSeparator: "A", lineFeed: "B")
         request.experienceCloudId = "ecid"
-
+        
         
         let event = try? ACPExtensionEvent(name: "Request Test",
                                            type: "type",
@@ -52,66 +48,66 @@ class RequestBuilderTests: XCTestCase {
         let request = RequestBuilder()
         request.enableResponseStreaming(recordSeparator: "A", lineFeed: "B")
         request.experienceCloudId = "ecid"
-
+        
         var events: [ACPExtensionEvent] = []
-
+        
         events.append(try! ACPExtensionEvent(name: "Request Test 1",
-                                           type: "type",
-                                           source: "source",
-                                           data: ["xdm":["application":["name":"myapp"]]]))
-
+                                             type: "type",
+                                             source: "source",
+                                             data: ["xdm":["application":["name":"myapp"]]]))
+        
         events.append(try! ACPExtensionEvent(name: "Request Test 2",
                                              type: "type",
                                              source: "source",
                                              data: ["xdm":["environment":["type":"widget"]]]))
-
+        
         let requestPayload = request.getRequestPayload(events)
-
+        
         let flattenEvent0 = flattenDictionary(dict: requestPayload?.events?[0]["xdm"]?.dictionaryValue as! [String : Any])
         let flattenEvent1 = flattenDictionary(dict: requestPayload?.events?[1]["xdm"]?.dictionaryValue as! [String : Any])
         XCTAssertEqual("myapp", flattenEvent0["application.name"] as? String)
         XCTAssertEqual(events[0].eventUniqueIdentifier, flattenEvent0["_id"] as? String)
         XCTAssertEqual(timestampToISO8601(events[0].eventTimestamp), flattenEvent0["timestamp"] as? String)
-
+        
         XCTAssertEqual("widget", flattenEvent1["environment.type"] as? String)
         XCTAssertEqual(events[1].eventUniqueIdentifier, flattenEvent1["_id"] as? String)
         XCTAssertEqual(timestampToISO8601(events[1].eventTimestamp), flattenEvent1["timestamp"] as? String)
     }
-
+    
     func testGetRequestPayload_withStorePayload_responseContainsStateEntries() {
         let dataStore = MockKeyValueStore()
         let manager = StoreResponsePayloadManager(dataStore)
         manager.saveStorePayloads([StoreResponsePayload(payload: StorePayload(key: "key", value: "value", maxAge: 3600))])
-
+        
         let request = RequestBuilder(dataStore: dataStore)
         request.enableResponseStreaming(recordSeparator: "A", lineFeed: "B")
         request.experienceCloudId = "ecid"
-
+        
         let event = try? ACPExtensionEvent(name: "Request Test",
                                            type: "type",
                                            source: "source",
                                            data: ["data":["key":"value"]])
-
+        
         let requestPayload = request.getRequestPayload([event!])
-
+        
         XCTAssertEqual("key", requestPayload?.meta?.state?.entries?[0].key)
         XCTAssertEqual(3600.0, requestPayload?.meta?.state?.entries?[0].maxAge)
         XCTAssertEqual("value", requestPayload?.meta?.state?.entries?[0].value)
     }
-
+    
     func testGetRequestPayload_withoutStorePayload_responseDoesNotContainsStateEntries() {
         let request = RequestBuilder(dataStore: MockKeyValueStore())
         request.enableResponseStreaming(recordSeparator: "A", lineFeed: "B")
         request.experienceCloudId = "ecid"
-
-
+        
+        
         let event = try? ACPExtensionEvent(name: "Request Test",
                                            type: "type",
                                            source: "source",
                                            data: ["data":["key":"value"]])
-
+        
         let requestPayload = request.getRequestPayload([event!])
-
+        
         XCTAssertNil(requestPayload?.meta?.state)
     }
 }

--- a/code/unitTests/RequestContextDataTests.swift
+++ b/code/unitTests/RequestContextDataTests.swift
@@ -31,7 +31,7 @@ class RequestContextDataTests: XCTestCase {
         let context = RequestContextData(identityMap: nil)
         
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.outputFormatting = [.prettyPrinted]
         encoder.dateEncodingStrategy = .iso8601
         
         let data = try? encoder.encode(context)
@@ -51,7 +51,7 @@ class RequestContextDataTests: XCTestCase {
         let context = RequestContextData(identityMap: IdentityMap())
         
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.outputFormatting = [.prettyPrinted]
         encoder.dateEncodingStrategy = .iso8601
         
         let data = try? encoder.encode(context)

--- a/code/unitTests/RequestMetadataTests.swift
+++ b/code/unitTests/RequestMetadataTests.swift
@@ -21,31 +21,19 @@ class RequestMetadataTests: XCTestCase {
         continueAfterFailure = false // fail so nil checks stop execution
     }
     
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-    
     // MARK: encoder tests
     
     func testEncode_noParameters() {
         let metadata = RequestMetadata(konductorConfig: nil, state: nil)
         
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.outputFormatting = [.prettyPrinted]
         encoder.dateEncodingStrategy = .iso8601
         
         let data = try? encoder.encode(metadata)
-        
-        XCTAssertNotNil(data)
-        let expected = """
-            {
-
-            }
-            """
-        let jsonString = String(data: data!, encoding: .utf8)
-        print(jsonString!)
-        
-        XCTAssertEqual(expected, jsonString)
+        let actualResult = asFlattenDictionary(data: data)
+        let expectedResult : [String: Any] = [:]
+        assertEqual(expectedResult, actualResult)
     }
     
     func testEncode_paramKonductorConfig() {
@@ -53,23 +41,13 @@ class RequestMetadataTests: XCTestCase {
                                        state: nil)
         
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.outputFormatting = [.prettyPrinted]
         encoder.dateEncodingStrategy = .iso8601
         
         let data = try? encoder.encode(metadata)
-        
-        XCTAssertNotNil(data)
-        let expected = """
-            {
-              "konductorConfig" : {
-
-              }
-            }
-            """
-        let jsonString = String(data: data!, encoding: .utf8)
-        print(jsonString!)
-        
-        XCTAssertEqual(expected, jsonString)
+        let actualResult = asFlattenDictionary(data: data)
+        let expectedResult : [String: Any] = ["konductorConfig" : "isEmpty"]
+        assertEqual(expectedResult, actualResult)
     }
     
     func testEncode_paramStateMetadata() {
@@ -77,29 +55,16 @@ class RequestMetadataTests: XCTestCase {
         let metadata = RequestMetadata(konductorConfig: nil, state: StateMetadata(payload: [payload]))
         
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.outputFormatting = [.prettyPrinted]
         encoder.dateEncodingStrategy = .iso8601
         
         let data = try? encoder.encode(metadata)
-        
-        XCTAssertNotNil(data)
-        let expected = """
-            {
-              "state" : {
-                "entries" : [
-                  {
-                    "key" : "key",
-                    "maxAge" : 3600,
-                    "value" : "value"
-                  }
-                ]
-              }
-            }
-            """
-        let jsonString = String(data: data!, encoding: .utf8)
-        print(jsonString!)
-        
-        XCTAssertEqual(expected, jsonString)
+        let actualResult = asFlattenDictionary(data: data)
+        let expectedResult : [String: Any] =
+            ["state.entries[0].key" : "key",
+             "state.entries[0].maxAge" : 3600,
+             "state.entries[0].value" : "value"]
+        assertEqual(expectedResult, actualResult)
     }
     
     func testEncode_paramKonductorConfig_paramStateMetadata() {
@@ -108,32 +73,17 @@ class RequestMetadataTests: XCTestCase {
                                        state: StateMetadata(payload: [payload]))
         
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.outputFormatting = [.prettyPrinted]
         encoder.dateEncodingStrategy = .iso8601
         
         let data = try? encoder.encode(metadata)
-        
-        XCTAssertNotNil(data)
-        let expected = """
-            {
-              "konductorConfig" : {
-
-              },
-              "state" : {
-                "entries" : [
-                  {
-                    "key" : "key",
-                    "maxAge" : 3600,
-                    "value" : "value"
-                  }
-                ]
-              }
-            }
-            """
-        let jsonString = String(data: data!, encoding: .utf8)
-        print(jsonString!)
-        
-        XCTAssertEqual(expected, jsonString)
+        let actualResult = asFlattenDictionary(data: data)
+        let expectedResult : [String: Any] =
+            ["state.entries[0].key" : "key",
+             "state.entries[0].maxAge" : 3600,
+             "state.entries[0].value" : "value",
+             "konductorConfig": "isEmpty"]
+        assertEqual(expectedResult, actualResult)
     }
     
 }

--- a/code/unitTests/StateMetadataTests.swift
+++ b/code/unitTests/StateMetadataTests.swift
@@ -20,29 +20,19 @@ class StateMetadataTests: XCTestCase {
         continueAfterFailure = false // fail so nil checks stop execution
     }
     
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-    
     // MARK: Encoder tests
     
     func testInit_withEmptyMap_doesNotEncodeEntries() {
         let state = StateMetadata(payload: [])
         
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.outputFormatting = [.prettyPrinted]
         encoder.dateEncodingStrategy = .iso8601
         
         let data = try? encoder.encode(state)
-        
-        XCTAssertNotNil(data)
-        let expected = """
-        {
-
-        }
-        """
-        let jsonString = String(data: data!, encoding: .utf8)
-        XCTAssertEqual(expected, jsonString)
+        let actualResult = asFlattenDictionary(data: data)
+        let expectedResult : [String: Any] = [:]
+        assertEqual(expectedResult, actualResult)
     }
     
     func testEncode_singlePayload() {
@@ -50,25 +40,16 @@ class StateMetadataTests: XCTestCase {
         let state = StateMetadata(payload: payload)
         
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.outputFormatting = [.prettyPrinted]
         encoder.dateEncodingStrategy = .iso8601
         
         let data = try? encoder.encode(state)
-        
-        XCTAssertNotNil(data)
-        let expected = """
-        {
-          "entries" : [
-            {
-              "key" : "key",
-              "maxAge" : 3600,
-              "value" : "value"
-            }
-          ]
-        }
-        """
-        let jsonString = String(data: data!, encoding: .utf8)
-        XCTAssertEqual(expected, jsonString)
+        let actualResult = asFlattenDictionary(data: data)
+        let expectedResult : [String: Any] =
+            ["entries[0].key" : "key",
+             "entries[0].maxAge" : 3600,
+             "entries[0].value" : "value"]
+        assertEqual(expectedResult, actualResult)
     }
     
     func testEncode_multiplePayloads() {
@@ -81,26 +62,14 @@ class StateMetadataTests: XCTestCase {
         encoder.dateEncodingStrategy = .iso8601
         
         let data = try? encoder.encode(state)
-        
-        XCTAssertNotNil(data)
-        let expected = """
-        {
-          "entries" : [
-            {
-              "key" : "key",
-              "value" : "value",
-              "maxAge" : 3600
-            },
-            {
-              "key" : "key2",
-              "value" : "value2",
-              "maxAge" : 5
-            }
-          ]
-        }
-        """
-        let jsonString = String(data: data!, encoding: .utf8)
-        XCTAssertEqual(expected, jsonString)
+        let actualResult = asFlattenDictionary(data: data)
+        let expectedResult : [String: Any] =
+            ["entries[0].key" : "key",
+             "entries[0].maxAge" : 3600,
+             "entries[0].value" : "value",
+             "entries[1].key" : "key2",
+             "entries[1].maxAge" : 5,
+             "entries[1].value" : "value2"]
+        assertEqual(expectedResult, actualResult)
     }
-    
 }

--- a/code/unitTests/StoreResponsePayloadTests.swift
+++ b/code/unitTests/StoreResponsePayloadTests.swift
@@ -20,34 +20,23 @@ class StoreResponsePayloadTests: XCTestCase {
         continueAfterFailure = false // fail so nil checks stop execution
     }
     
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-    
     // MARK: encoder tests
-
+    
     func testEncode() {
         let payload = StoreResponsePayload(payload: StorePayload(key: "key", value: "value", maxAge: 3600))
-
+        
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.outputFormatting = [.prettyPrinted]
         encoder.dateEncodingStrategy = .iso8601
         
         let data = try? encoder.encode(payload)
-        
-        XCTAssertNotNil(data)
-        let expected = """
-           {
-             "expiryDate" : "\(ISO8601DateFormatter().string(from: payload.expiryDate))",
-             "payload" : {
-               "key" : "key",
-               "maxAge" : 3600,
-               "value" : "value"
-             }
-           }
-           """
-        let jsonString = String(data: data!, encoding: .utf8)
-        XCTAssertEqual(expected, jsonString)
+        let actualResult = asFlattenDictionary(data: data)
+        let expectedResult : [String: Any] =
+            [ "expiryDate": "\(ISO8601DateFormatter().string(from: payload.expiryDate))",
+                "payload.key": "key",
+                "payload.maxAge": 3600,
+                "payload.value": "value"]
+        assertEqual(expectedResult, actualResult)
     }
     
     // MARK: decoder tests
@@ -83,14 +72,14 @@ class StoreResponsePayloadTests: XCTestCase {
         let date = Date(timeIntervalSinceNow: 36000)
         let data = """
             {
-              "expiryDate" : "\(ISO8601DateFormatter().string(from: date))",
-              "payload" : {
-                "key" : "key",
-                "maxAge" : 3600,
-                "value" : "value"
-              }
+            "expiryDate" : "\(ISO8601DateFormatter().string(from: date))",
+            "payload" : {
+            "key" : "key",
+            "maxAge" : 3600,
+            "value" : "value"
             }
-        """.data(using: .utf8)
+            }
+            """.data(using: .utf8)
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         
@@ -98,7 +87,7 @@ class StoreResponsePayloadTests: XCTestCase {
             XCTFail("Failed to decode StoreResponsePayload.")
             return
         }
-
+        
         XCTAssertFalse(payload.isExpired)
     }
     
@@ -120,7 +109,7 @@ class StoreResponsePayloadTests: XCTestCase {
             XCTFail("Failed to decode StoreResponsePayload.")
             return
         }
-
+        
         XCTAssertTrue(payload.isExpired)
     }
 }

--- a/code/unitTests/UnitTestAssertions.swift
+++ b/code/unitTests/UnitTestAssertions.swift
@@ -1,0 +1,23 @@
+//
+// Copyright 2020 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+
+import Foundation
+import XCTest
+
+func assertEqual(_ expected: [String: Any], _ actual: [String: Any], _ message: String? = nil, file: StaticString = #file, line: UInt = #line) {
+    if let unwrappedMessage = message {
+        XCTAssertEqual(expected as NSObject, actual as NSObject, unwrappedMessage, file: file, line: line)
+    } else {
+        XCTAssertEqual(expected as NSObject, actual as NSObject, file: file, line: line)
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Set min target to iOS 10 for unit&functional tests
- Updated the unit tests that were using JSONEncoder .sortedKeys since this is supported in iOS 11+ (ref [here](https://developer.apple.com/documentation/foundation/jsonencoder/outputformatting/2919670-sortedkeys)).

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
[AMSDK-9827](https://jira.corp.adobe.com/browse/AMSDK-9827)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
