### PR TITLE
[DEV] Fixed intermittent functional test failure on shared state events count

### DIFF
--- a/code/functionalTests/FunctionalTestsWithNoConfiguration.swift
+++ b/code/functionalTests/FunctionalTestsWithNoConfiguration.swift
@@ -26,9 +26,11 @@ class FunctionalTestsWithNoConfiguration: FunctionalTestBase {
         FunctionalTestUtils.resetUserDefaults()
         FunctionalTestBase.debugEnabled = false
         
+        setExpectationEvent(type: FunctionalTestConst.EventType.eventHub, source: FunctionalTestConst.EventSource.booted, count: 1)
         setExpectationEvent(type: FunctionalTestConst.EventType.eventHub, source: FunctionalTestConst.EventSource.sharedState, count:1)
         do {
             try ACPCore.registerExtension(TestableExperiencePlatformInternal.self)
+            ACPCore.start(nil)
         } catch {
             XCTFail("Failed test setUp: \(error.localizedDescription)")
         }

--- a/code/functionalTests/util/FunctionalTestBase.swift
+++ b/code/functionalTests/util/FunctionalTestBase.swift
@@ -50,21 +50,10 @@ class FunctionalTestBase : XCTestCase {
     public override func setUp() {
         super.setUp()
         if FunctionalTestBase.firstRun {
-            let startLatch: CountDownLatch = CountDownLatch(1)
-            setExpectationEvent(type: FunctionalTestConst.EventType.eventHub, source: FunctionalTestConst.EventSource.booted, count: 1)
-            // event hub shared state containing registered versions
-            setExpectationEvent(type: FunctionalTestConst.EventType.eventHub, source: FunctionalTestConst.EventSource.sharedState, count: 1)
             guard let _ = try? ACPCore.registerExtension(InstrumentedExtension.self) else {
                 log("Unable to register the InstrumentedExtension")
                 return
             }
-            ACPCore.start {
-                startLatch.countDown()
-            }
-            
-            XCTAssertEqual(DispatchTimeoutResult.success, startLatch.await(timeout: 2))
-            assertExpectedEvents(ignoreUnexpectedEvents: false)
-            resetTestExpectations()
         }
         FunctionalTestBase.firstRun = false
         

--- a/code/functionalTests/util/FunctionalTestUtils.swift
+++ b/code/functionalTests/util/FunctionalTestUtils.swift
@@ -11,6 +11,7 @@
 //
 
 import Foundation
+@testable import AEPExperiencePlatform
 
 public class FunctionalTestUtils {
     
@@ -21,6 +22,13 @@ public class FunctionalTestUtils {
         dictionary.keys.forEach { key in
             defaults.removeObject(forKey: key)
         }
+        
+        // force reset overridden config
+        defaults.set(nil, forKey: "Adobe.AdobeMobile_ConfigState.config.overridden.map")
+        
+        // remove from suites
+        let store = NamedUserDefaultsStore(name: "AEPExperiencePlatform")
+        store.removeAll()
         
         print("resetUserDefaults - Removed all user defaults")
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

- Moved ACPCore.start in the functional test class after all the extensions are registered. 
- Remove overridden config and data from swift datastore between tests

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- [AMSDK-10287](https://jira.corp.adobe.com/browse/AMSDK-10287)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
