### PR TITLE
Make APIs compatible with ObjC

### DIFF
--- a/code/src/ExperiencePlatform.swift
+++ b/code/src/ExperiencePlatform.swift
@@ -14,15 +14,16 @@ import ACPCore
 
 private let logTag = "ExperiencePlatform"
 
-public class ExperiencePlatform {
+@objc(AEPExperiencePlatform)
+public class ExperiencePlatform: NSObject {
 
-    @available(*, unavailable) private init() {}
+    @available(*, unavailable) private override init() {}
     private static var responseCallbacksHandlers: [String: ([String: Any]) -> Void] = [:]
 
     /// Registers the AEPExperiencePlatform extension with the Mobile SDK. This method should be called only once in your application class
     /// from the AppDelegate's application:didFinishLaunchingWithOptions method. This call should be before any calls into ACPCore
     /// interface except setLogLevel.
-    public static func registerExtension() {
+    @objc public static func registerExtension() {
 
         do {
             try ACPCore.registerExtension(ExperiencePlatformInternal.self)
@@ -37,6 +38,7 @@ public class ExperiencePlatform {
     ///   - experiencePlatformEvent: Event to be sent to Adobe Data Platform
     ///   - responseHandler: Optional callback to be invoked when the response handles are received from
     ///                     Adobe Data Platform. It may be invoked on a different thread and may be invoked multiple times
+    @objc(sendEvent:responseHandler:)
     public static func sendEvent(experiencePlatformEvent: ExperiencePlatformEvent, responseHandler: ExperiencePlatformResponseHandler? = nil) {
 
         guard let xdmData = experiencePlatformEvent.xdm, !xdmData.isEmpty, let eventData = experiencePlatformEvent.asDictionary() else {

--- a/code/src/ExperiencePlatformEvent.swift
+++ b/code/src/ExperiencePlatformEvent.swift
@@ -12,7 +12,8 @@
 
 import Foundation
 
-public struct ExperiencePlatformEvent {
+@objc(AEPExperiencePlatformEvent)
+public class ExperiencePlatformEvent: NSObject {
 
     private let logTag = "ExperiencePlatformEvent"
 

--- a/code/src/ExperiencePlatformResponseHandler.swift
+++ b/code/src/ExperiencePlatformResponseHandler.swift
@@ -14,6 +14,7 @@ import Foundation
 
 /// Protocol that can be implemented in order to receive response(s) from the Adobe Experience Edge in the mobile application when
 /// `ExperiencePlatformEvent`s are sent through the `AEPExperiencePlatform`.
+@objc(AEPExperiencePlatformResponseHandler)
 public protocol ExperiencePlatformResponseHandler {
 
     /// This method is called when the response was successfully fetched from the Adobe Experience Edge for an associated event;


### PR DESCRIPTION
This PR exposes classes and APIs to Obj-C, however, we currently cannot import the ExEdge extension into a sample objc app without a fair amount of work. This is caused by it being a static lib. We should update the project to produce a framework rather than a static lib so it is consistent with the rest of the swift extensions and is easier to use in objc.