### PR TITLE
Use ObjC friendly name that won't conflict with module name

### DIFF
--- a/code/src/ExperiencePlatform.swift
+++ b/code/src/ExperiencePlatform.swift
@@ -14,7 +14,7 @@ import ACPCore
 
 private let logTag = "ExperiencePlatform"
 
-@objc(AEPExperiencePlatform)
+@objc(AEPMobileExperiencePlatform)
 public class ExperiencePlatform: NSObject {
 
     @available(*, unavailable) private override init() {}


### PR DESCRIPTION
We found an issue that would only manifest in core where if you include the XCFramework into a swift app that it would have trouble distinguishing AEPCore (module) and AEPCore (objc class). We thought that this issue would not manifest since the prefixed class name is only being exported to objc. However, it turns out this is not the case and it still conflicts. 

To solve this we simply adding the AEPMobile prefix to our classes for now.