### PR TITLE
[AMSDK-10494][DO NOT MERGE] XDM Shared State POC 

### DIFF
--- a/AEPEdge.xcodeproj/project.pbxproj
+++ b/AEPEdge.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		1CB57B262460F2B6000B2DA5 /* EdgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB57B242460EF0C000B2DA5 /* EdgeTests.swift */; };
 		1CCD27D82459EEB900E912B2 /* XDMFormattersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CCD27C72458CB8000E912B2 /* XDMFormattersTests.swift */; };
 		1CCD27DC245A240F00E912B2 /* ExperienceEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CCD27C82458CB8000E912B2 /* ExperienceEventTests.swift */; };
+		21A2566C253764DE0028B296 /* Extension+XDM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A2566B253764DE0028B296 /* Extension+XDM.swift */; };
 		240E3C9924EF357100D44993 /* MockDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 240E3C9824EF357100D44993 /* MockDataStore.swift */; };
 		240E3C9A24EF357100D44993 /* MockDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 240E3C9824EF357100D44993 /* MockDataStore.swift */; };
 		5804F75855E57988DC5C245B /* Pods_UnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 38ACBDAC9AE339F84DF409D1 /* Pods_UnitTests.framework */; };
@@ -241,6 +242,7 @@
 		1CCD27CE24592B2800E912B2 /* XDMFormatters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XDMFormatters.swift; sourceTree = "<group>"; };
 		1CCD27CF24592B2800E912B2 /* XDMProtocols.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XDMProtocols.swift; sourceTree = "<group>"; };
 		1ED3CB89A749953625CC5616 /* Pods-AEPCommerceDemoApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPCommerceDemoApp.release.xcconfig"; path = "Target Support Files/Pods-AEPCommerceDemoApp/Pods-AEPCommerceDemoApp.release.xcconfig"; sourceTree = "<group>"; };
+		21A2566B253764DE0028B296 /* Extension+XDM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension+XDM.swift"; sourceTree = "<group>"; };
 		240E3C9824EF357100D44993 /* MockDataStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockDataStore.swift; sourceTree = "<group>"; };
 		38ACBDAC9AE339F84DF409D1 /* Pods_UnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		48A9314EEF94AB3655402E38 /* Pods_AEPDemoAppSwiftUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AEPDemoAppSwiftUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -669,6 +671,7 @@
 				D42FB8D02461086200E9321C /* EdgeNetworkHandlers */,
 				BF947F63243565CC0057A6CC /* Constants.swift */,
 				BF947F62243565CC0057A6CC /* Edge.swift */,
+				21A2566B253764DE0028B296 /* Extension+XDM.swift */,
 				D4967534251130D3001F5F95 /* Info.plist */,
 				D4D66AA2251910FB00B4866D /* AEPEdge.h */,
 			);
@@ -1338,6 +1341,7 @@
 				D4C6B444251A76CB0038F4F9 /* NetworkResponseHandler.swift in Sources */,
 				D4C6B445251A76CB0038F4F9 /* RequestBuilder.swift in Sources */,
 				D4C6B446251A76CB0038F4F9 /* RequestContextData.swift in Sources */,
+				21A2566C253764DE0028B296 /* Extension+XDM.swift in Sources */,
 				D4C6B447251A76CB0038F4F9 /* RequestMetadata.swift in Sources */,
 				D4C6B448251A76CB0038F4F9 /* ResponseCallback.swift in Sources */,
 				D4C6B449251A76CB0038F4F9 /* ResponseCallbackHandler.swift in Sources */,

--- a/Sources/Constants.swift
+++ b/Sources/Constants.swift
@@ -65,6 +65,7 @@ enum Constants {
         enum Identity {
             static let STATE_OWNER_NAME = "com.adobe.module.identity"
             static let ECID = "mid"
+            static let IDENTITY_MAP "identityMap"
         }
         enum Assurance {
             static let STATE_OWNER_NAME = "com.adobe.assurance"

--- a/Sources/Constants.swift
+++ b/Sources/Constants.swift
@@ -65,7 +65,7 @@ enum Constants {
         enum Identity {
             static let STATE_OWNER_NAME = "com.adobe.module.identity"
             static let ECID = "mid"
-            static let IDENTITY_MAP "identityMap"
+            static let IDENTITY_MAP = "identityMap"
         }
         enum Assurance {
             static let STATE_OWNER_NAME = "com.adobe.assurance"

--- a/Sources/Edge.swift
+++ b/Sources/Edge.swift
@@ -104,7 +104,7 @@ public class Edge: NSObject, Extension {
 
         // Build and send the network request to Experience Edge
         let listOfEvents: [Event] = [event]
-        if let requestPayload = requestBuilder.getRequestPayload(listOfEvents) {
+        if let requestPayload = requestBuilder.getRequestPayload(listOfEvents, xdmSharedState: getXDMSharedState()?.value) {
             let requestId: String = UUID.init().uuidString
 
             // NOTE: the order of these events needs to be maintained as they were sent in the network request

--- a/Sources/EdgeNetworkHandlers/IdentityMap.swift
+++ b/Sources/EdgeNetworkHandlers/IdentityMap.swift
@@ -23,6 +23,11 @@ enum AuthenticationState: String, Codable {
 struct IdentityMap {
     private var items: [String: [IdentityItem]] = [:]
 
+    static func fromDict(dict: [String: Any]) -> IdentityMap? {
+        guard let data = try? JSONSerialization.data(withJSONObject: dict, options: []) else { return nil }
+        return try? JSONDecoder().decode(IdentityMap.self, from: data)
+    }
+    
     /// Adds an `IdentityItem` to this map. If an item is added which shares the same `namespace` and `id` as an item
     /// already in the map, then the new item replaces the existing item.
     /// - Parameters:

--- a/Sources/EdgeNetworkHandlers/RequestBuilder.swift
+++ b/Sources/EdgeNetworkHandlers/RequestBuilder.swift
@@ -67,9 +67,9 @@ class RequestBuilder {
         var contextData: RequestContextData?
         
         // attempt to read identity from XDM shared state
-        if let identityMap = xdmSharedState?["identityMap"] as? [String: Any] {
+        if let identityMap = xdmSharedState?[Constants.SharedState.Identity.IDENTITY_MAP] as? [String: Any] {
             var additionalData = xdmSharedState
-            additionalData?.removeValue(forKey: "identityMap") // remove identity map as its serialized on its own
+            additionalData?.removeValue(forKey: Constants.SharedState.Identity.IDENTITY_MAP) // remove identity map as its serialized on its own
             contextData = RequestContextData(identityMap: IdentityMap.fromDict(dict: identityMap), additionalData: AnyCodable.from(dictionary: additionalData))
         } else if let ecid = experienceCloudId {
             // fallback on ecid from Identity shared state if not available

--- a/Sources/EdgeNetworkHandlers/RequestContextData.swift
+++ b/Sources/EdgeNetworkHandlers/RequestContextData.swift
@@ -11,9 +11,11 @@
 //
 
 import Foundation
+import AEPServices
 
 /// Property that holds the global XDM context data within an `EdgeRequest` object.
 /// It is contained within the `EdgeRequest` request property.
 struct RequestContextData: Encodable {
     let identityMap: IdentityMap?
+    let additionalData: [String: AnyCodable]?
 }

--- a/Sources/Extension+XDM.swift
+++ b/Sources/Extension+XDM.swift
@@ -1,0 +1,29 @@
+//
+// Copyright 2020 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+
+import Foundation
+import AEPCore
+
+/// Provides functionality for setting and reading XDM shared state
+public extension Extension {
+    func createXDMSharedState(data: [String: Any]) {
+        let existingXDMSharedState = getXDMSharedState()?.value ?? [:]
+        // add the new shared state on-top of existing shared state
+        let newXDMSharedState = existingXDMSharedState.merging(data) { (_, new) in new }
+        createSharedState(data: newXDMSharedState, event: nil) // always version at latest, shared state is published to "com.adobe.edge"
+    }
+    
+    func getXDMSharedState() -> SharedStateResult? {
+        return getSharedState(extensionName: Constants.EXTENSION_NAME, event: nil)
+    }
+}

--- a/Sources/Extension+XDM.swift
+++ b/Sources/Extension+XDM.swift
@@ -16,6 +16,9 @@ import AEPCore
 
 /// Provides functionality for setting and reading XDM shared state
 public extension Extension {
+    
+    /// Appends `data` to the XDM shared state, if any of the keys in `data` map to existing keys in the XDM shared state, those values will be updated with the values in `data`.
+    /// - Parameter data: Data to be appended to XDM shared state
     func createXDMSharedState(data: [String: Any]) {
         let existingXDMSharedState = getXDMSharedState()?.value ?? [:]
         // add the new shared state on-top of existing shared state
@@ -23,6 +26,8 @@ public extension Extension {
         createSharedState(data: newXDMSharedState, event: nil) // always version at latest, shared state is published to "com.adobe.edge"
     }
     
+    /// Reads and returns the XDM shared state
+    /// - Returns: The XDM shared state
     func getXDMSharedState() -> SharedStateResult? {
         return getSharedState(extensionName: Constants.EXTENSION_NAME, event: nil)
     }


### PR DESCRIPTION
Quick POC of providing the XDM shared state APIs as an extension on extension. Extensions can conditionally check if the Edge extension is present, if so it can share the corresponding shared state. Then the Edge extension reads the shared state for each event and appends it to the request.

This shared state is stored on `com.adobe.edge` (the name of the edge extension).

Sample usage:
```swift
// Identity.swift
#if canImport(AEPEdge)
func sharedXdmState() { 
   let data = ...
   createXDMSharedState(data: data)
}
#endif
```