### PR TITLE
Attempt to fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
 
   build-and-test:
     macos:
-      xcode: 11.1.0 # Specify the Xcode version to use
+      xcode: 11.6.0 # Specify the Xcode version to use
 
     steps:
       - checkout


### PR DESCRIPTION
Upgrading our CI Xcode version to be on par with Core.
Fixes this issue: https://app.circleci.com/pipelines/github/adobe/aepsdk-edge-ios/264/workflows/fb4b7e34-60d4-45ac-8364-a31da941c07f/jobs/282