### PR TITLE
Set eventSource to the EdgeEventHandle type in AEP Response Event Handle

### DIFF
--- a/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
+++ b/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
@@ -212,7 +212,10 @@ class NetworkResponseHandler {
     private func dispatchResponseEventWithData(_ eventData: [String: Any], requestId: String, isErrorResponseEvent: Bool, eventSource: String?) {
         guard !eventData.isEmpty else { return }
         var source = isErrorResponseEvent ? Constants.EventSource.ERROR_RESPONSE_CONTENT : Constants.EventSource.RESPONSE_CONTENT
-        source = eventSource ?? source
+        if let eventSource = eventSource, !eventSource.isEmpty {
+            source = eventSource
+        }
+
         let responseEvent = Event(name: isErrorResponseEvent ? Constants.EventName.ERROR_RESPONSE_CONTENT : Constants.EventName.RESPONSE_CONTENT,
                                   type: Constants.EventType.EDGE,
                                   source: source,

--- a/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
+++ b/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
@@ -208,7 +208,8 @@ class NetworkResponseHandler {
     ///   - eventData: Event data to be dispatched, should not be empty
     ///   - requestId: The request identifier associated with this response event, used for logging
     ///   - isErrorResponseEvent: indicates if this should be dispatched as an error or regular response content event
-    ///   - eventSource: an optional `String` to be used as the event source
+    ///   - eventSource: an optional `String` to be used as the event source.
+    ///   If `eventSource` is nil either Constants.EventSource.ERROR_RESPONSE_CONTENT or Constants.EventSource.RESPONSE_CONTENT will be used for the event source depending on `isErrorResponseEvent`
     private func dispatchResponseEventWithData(_ eventData: [String: Any], requestId: String, isErrorResponseEvent: Bool, eventSource: String?) {
         guard !eventData.isEmpty else { return }
         var source = isErrorResponseEvent ? Constants.EventSource.ERROR_RESPONSE_CONTENT : Constants.EventSource.RESPONSE_CONTENT

--- a/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
+++ b/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
@@ -531,7 +531,7 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
         setExpectationEvent(type: FunctionalTestConst.EventType.EDGE,
                             source: FunctionalTestConst.EventSource.REQUEST_CONTENT,
                             expectedCount: 1)
-        setExpectationEvent(type: FunctionalTestConst.EventType.EDGE,
+        setExpectationEvent(type: "personalization:decisions",
                             source: FunctionalTestConst.EventSource.RESPONSE_CONTENT,
                             expectedCount: 1)
         // swiftlint:disable:next line_length
@@ -556,7 +556,7 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
         let requestEvents = getDispatchedEventsWith(type: FunctionalTestConst.EventType.EDGE,
                                                     source: FunctionalTestConst.EventSource.REQUEST_CONTENT)
         let requestEventUUID = requestEvents[0].id.uuidString
-        let responseEvents = getDispatchedEventsWith(type: FunctionalTestConst.EventType.EDGE,
+        let responseEvents = getDispatchedEventsWith(type: "personalization:decisions",
                                                      source: FunctionalTestConst.EventSource.RESPONSE_CONTENT)
         guard let eventDataDict = responseEvents[0].data else {
             XCTFail("Failed to convert event data to [String: Any]")
@@ -622,7 +622,7 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
         setExpectationEvent(type: FunctionalTestConst.EventType.EDGE,
                             source: FunctionalTestConst.EventSource.REQUEST_CONTENT,
                             expectedCount: 1)
-        setExpectationEvent(type: FunctionalTestConst.EventType.EDGE,
+        setExpectationEvent(type: "personalization:decisions",
                             source: FunctionalTestConst.EventSource.RESPONSE_CONTENT,
                             expectedCount: 1)
         // swiftlint:disable:next line_length

--- a/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
+++ b/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
@@ -531,8 +531,8 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
         setExpectationEvent(type: FunctionalTestConst.EventType.EDGE,
                             source: FunctionalTestConst.EventSource.REQUEST_CONTENT,
                             expectedCount: 1)
-        setExpectationEvent(type: "personalization:decisions",
-                            source: FunctionalTestConst.EventSource.RESPONSE_CONTENT,
+        setExpectationEvent(type: FunctionalTestConst.EventType.EDGE,
+                            source: "personalization:decisions",
                             expectedCount: 1)
         // swiftlint:disable:next line_length
         let responseBody = "\u{0000}{\"requestId\": \"0ee43289-4a4e-469a-bf5c-1d8186919a26\",\"handle\": [{\"payload\": [{\"id\": \"AT:eyJhY3Rpdml0eUlkIjoiMTE3NTg4IiwiZXhwZXJpZW5jZUlkIjoiMSJ9\",\"scope\": \"buttonColor\",\"items\": [{                           \"schema\": \"https://ns.adobe.com/personalization/json-content-item\",\"data\": {\"content\": {\"value\": \"#D41DBA\"}}}]}],\"type\": \"personalization:decisions\",\"eventIndex\": 0}]}\n"
@@ -556,8 +556,8 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
         let requestEvents = getDispatchedEventsWith(type: FunctionalTestConst.EventType.EDGE,
                                                     source: FunctionalTestConst.EventSource.REQUEST_CONTENT)
         let requestEventUUID = requestEvents[0].id.uuidString
-        let responseEvents = getDispatchedEventsWith(type: "personalization:decisions",
-                                                     source: FunctionalTestConst.EventSource.RESPONSE_CONTENT)
+        let responseEvents = getDispatchedEventsWith(type: FunctionalTestConst.EventType.EDGE,
+                                                     source: "personalization:decisions")
         guard let eventDataDict = responseEvents[0].data else {
             XCTFail("Failed to convert event data to [String: Any]")
             return
@@ -622,8 +622,8 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
         setExpectationEvent(type: FunctionalTestConst.EventType.EDGE,
                             source: FunctionalTestConst.EventSource.REQUEST_CONTENT,
                             expectedCount: 1)
-        setExpectationEvent(type: "personalization:decisions",
-                            source: FunctionalTestConst.EventSource.RESPONSE_CONTENT,
+        setExpectationEvent(type: FunctionalTestConst.EventType.EDGE,
+                            source: "personalization:decisions",
                             expectedCount: 1)
         // swiftlint:disable:next line_length
         let responseBody = "\u{0000}{\"requestId\": \"0ee43289-4a4e-469a-bf5c-1d8186919a26\",\"handle\": [{\"payload\": [{\"id\": \"AT:eyJhY3Rpdml0eUlkIjoiMTE3NTg4IiwiZXhwZXJpZW5jZUlkIjoiMSJ9\",\"scope\": \"buttonColor\",\"items\": [{                           \"schema\": \"https://ns.adobe.com/personalization/json-content-item\",\"data\": {\"content\": {\"value\": \"#D41DBA\"}}}]}],\"type\": \"personalization:decisions\",\"eventIndex\": 0}]}\n"

--- a/Tests/FunctionalTests/NetworkResponseHandlerFunctionalTests.swift
+++ b/Tests/FunctionalTests/NetworkResponseHandlerFunctionalTests.swift
@@ -293,6 +293,73 @@ class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
         XCTAssertEqual(15552000, flattenReceivedData["payload[0].maxAge"] as? Int)
     }
 
+    func testProcessResponseOnSuccess_WhenOneEventHandle_emptyEventHandleType_dispatchesEvent() {
+        setExpectationEvent(type: FunctionalTestConst.EventType.EDGE, source: FunctionalTestConst.EventSource.RESPONSE_CONTENT, expectedCount: 1)
+        let jsonResponse = "{\n" +
+            "      \"requestId\": \"d81c93e5-7558-4996-a93c-489d550748b8\",\n" +
+            "      \"handle\": [" +
+            "           {\n" +
+            "            \"type\": \"\",\n" +
+            "            \"payload\": [\n" +
+            "                {\n" +
+            "                    \"key\": \"s_ecid\",\n" +
+            "                    \"value\": \"MCMID|29068398647607325310376254630528178721\",\n" +
+            "                    \"maxAge\": 15552000\n" +
+            "                }\n" +
+            "            ]\n" +
+            "        }],\n" +
+            "      \"errors\": []\n" +
+            "    }"
+        networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: "123")
+
+        let dispatchEvents = getDispatchedEventsWith(type: FunctionalTestConst.EventType.EDGE, source: FunctionalTestConst.EventSource.RESPONSE_CONTENT)
+        XCTAssertEqual(1, dispatchEvents.count)
+        guard let receivedData = dispatchEvents[0].data else {
+            XCTFail("Invalid event data")
+            return
+        }
+
+        let flattenReceivedData: [String: Any] = flattenDictionary(dict: receivedData)
+        XCTAssertEqual(5, flattenReceivedData.count)
+        XCTAssertEqual("123", flattenReceivedData["requestId"] as? String)
+        XCTAssertEqual("s_ecid", flattenReceivedData["payload[0].key"] as? String)
+        XCTAssertEqual("MCMID|29068398647607325310376254630528178721", flattenReceivedData["payload[0].value"] as? String)
+        XCTAssertEqual(15552000, flattenReceivedData["payload[0].maxAge"] as? Int)
+    }
+
+    func testProcessResponseOnSuccess_WhenOneEventHandle_nilEventHandleType_dispatchesEvent() {
+        setExpectationEvent(type: FunctionalTestConst.EventType.EDGE, source: FunctionalTestConst.EventSource.RESPONSE_CONTENT, expectedCount: 1)
+        let jsonResponse = "{\n" +
+            "      \"requestId\": \"d81c93e5-7558-4996-a93c-489d550748b8\",\n" +
+            "      \"handle\": [" +
+            "           {\n" +
+            "            \"payload\": [\n" +
+            "                {\n" +
+            "                    \"key\": \"s_ecid\",\n" +
+            "                    \"value\": \"MCMID|29068398647607325310376254630528178721\",\n" +
+            "                    \"maxAge\": 15552000\n" +
+            "                }\n" +
+            "            ]\n" +
+            "        }],\n" +
+            "      \"errors\": []\n" +
+            "    }"
+        networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: "123")
+
+        let dispatchEvents = getDispatchedEventsWith(type: FunctionalTestConst.EventType.EDGE, source: FunctionalTestConst.EventSource.RESPONSE_CONTENT)
+        XCTAssertEqual(1, dispatchEvents.count)
+        guard let receivedData = dispatchEvents[0].data else {
+            XCTFail("Invalid event data")
+            return
+        }
+
+        let flattenReceivedData: [String: Any] = flattenDictionary(dict: receivedData)
+        XCTAssertEqual(4, flattenReceivedData.count)
+        XCTAssertEqual("123", flattenReceivedData["requestId"] as? String)
+        XCTAssertEqual("s_ecid", flattenReceivedData["payload[0].key"] as? String)
+        XCTAssertEqual("MCMID|29068398647607325310376254630528178721", flattenReceivedData["payload[0].value"] as? String)
+        XCTAssertEqual(15552000, flattenReceivedData["payload[0].maxAge"] as? Int)
+    }
+
     func testProcessResponseOnSuccess_WhenTwoEventHandles_dispatchesTwoEvents() {
         setExpectationEvent(type: FunctionalTestConst.EventType.EDGE, source: FunctionalTestConst.EventSource.RESPONSE_CONTENT, expectedCount: 2)
         let jsonResponse = "{\n" +

--- a/Tests/FunctionalTests/NetworkResponseHandlerFunctionalTests.swift
+++ b/Tests/FunctionalTests/NetworkResponseHandlerFunctionalTests.swift
@@ -277,7 +277,7 @@ class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
             "    }"
         networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: "123")
 
-        let dispatchEvents = getDispatchedEventsWith(type: FunctionalTestConst.EventType.EDGE, source: FunctionalTestConst.EventSource.RESPONSE_CONTENT)
+        let dispatchEvents = getDispatchedEventsWith(type: "state:store", source: FunctionalTestConst.EventSource.RESPONSE_CONTENT)
         XCTAssertEqual(1, dispatchEvents.count)
         guard let receivedData = dispatchEvents[0].data else {
             XCTFail("Invalid event data")
@@ -322,7 +322,8 @@ class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
             "    }"
         networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: "123")
 
-        let dispatchEvents = getDispatchedEventsWith(type: FunctionalTestConst.EventType.EDGE, source: FunctionalTestConst.EventSource.RESPONSE_CONTENT)
+        var dispatchEvents = getDispatchedEventsWith(type: "state:store", source: FunctionalTestConst.EventSource.RESPONSE_CONTENT)
+        dispatchEvents += getDispatchedEventsWith(type: "identity:persist", source: FunctionalTestConst.EventSource.RESPONSE_CONTENT)
         XCTAssertEqual(2, dispatchEvents.count)
         // verify event 1
         guard let receivedData1 = dispatchEvents[0].data else {
@@ -380,8 +381,10 @@ class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
         networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: requestId)
 
         // verify event 1
-        let dispatchEvents = getDispatchedEventsWith(type: FunctionalTestConst.EventType.EDGE,
+        var dispatchEvents = getDispatchedEventsWith(type: "state:store",
                                                      source: FunctionalTestConst.EventSource.RESPONSE_CONTENT)
+        dispatchEvents += getDispatchedEventsWith(type: "pairedeventexample",
+                                                  source: FunctionalTestConst.EventSource.RESPONSE_CONTENT)
         XCTAssertEqual(2, dispatchEvents.count)
         guard let receivedData1 = dispatchEvents[0].data else {
             XCTFail("Invalid event data for event 1")
@@ -430,7 +433,7 @@ class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
         networkResponseHandler.addWaitingEvents(requestId: requestId, batchedEvents: [event1, event2])
         networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: requestId)
 
-        let dispatchEvents = getDispatchedEventsWith(type: FunctionalTestConst.EventType.EDGE, source: FunctionalTestConst.EventSource.RESPONSE_CONTENT)
+        let dispatchEvents = getDispatchedEventsWith(type: "pairedeventexample", source: FunctionalTestConst.EventSource.RESPONSE_CONTENT)
         XCTAssertEqual(1, dispatchEvents.count)
         guard let receivedData1 = dispatchEvents[0].data else {
             XCTFail("Invalid event data for event 1")
@@ -467,7 +470,7 @@ class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
         networkResponseHandler.addWaitingEvents(requestId: "567", batchedEvents: [event1, event2])
         networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: requestId)
 
-        let dispatchEvents = getDispatchedEventsWith(type: FunctionalTestConst.EventType.EDGE,
+        let dispatchEvents = getDispatchedEventsWith(type: "pairedeventexample",
                                                      source: FunctionalTestConst.EventSource.RESPONSE_CONTENT)
         XCTAssertEqual(1, dispatchEvents.count)
         guard let receivedData1 = dispatchEvents[0].data else {
@@ -515,7 +518,7 @@ class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
 
         networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: requestId)
 
-        let dispatchEvents = getDispatchedEventsWith(type: FunctionalTestConst.EventType.EDGE, source: FunctionalTestConst.EventSource.RESPONSE_CONTENT)
+        let dispatchEvents = getDispatchedEventsWith(type: "state:store", source: FunctionalTestConst.EventSource.RESPONSE_CONTENT)
         XCTAssertEqual(1, dispatchEvents.count)
         guard let receivedData1 = dispatchEvents[0].data else {
             XCTFail("Invalid event data for event 1")

--- a/Tests/FunctionalTests/NetworkResponseHandlerFunctionalTests.swift
+++ b/Tests/FunctionalTests/NetworkResponseHandlerFunctionalTests.swift
@@ -277,7 +277,7 @@ class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
             "    }"
         networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: "123")
 
-        let dispatchEvents = getDispatchedEventsWith(type: "state:store", source: FunctionalTestConst.EventSource.RESPONSE_CONTENT)
+        let dispatchEvents = getDispatchedEventsWith(type: FunctionalTestConst.EventType.EDGE, source: "state:store")
         XCTAssertEqual(1, dispatchEvents.count)
         guard let receivedData = dispatchEvents[0].data else {
             XCTFail("Invalid event data")
@@ -322,8 +322,8 @@ class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
             "    }"
         networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: "123")
 
-        var dispatchEvents = getDispatchedEventsWith(type: "state:store", source: FunctionalTestConst.EventSource.RESPONSE_CONTENT)
-        dispatchEvents += getDispatchedEventsWith(type: "identity:persist", source: FunctionalTestConst.EventSource.RESPONSE_CONTENT)
+        var dispatchEvents = getDispatchedEventsWith(type: FunctionalTestConst.EventType.EDGE, source: "state:store")
+        dispatchEvents += getDispatchedEventsWith(type: FunctionalTestConst.EventType.EDGE, source: "identity:persist")
         XCTAssertEqual(2, dispatchEvents.count)
         // verify event 1
         guard let receivedData1 = dispatchEvents[0].data else {
@@ -381,10 +381,10 @@ class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
         networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: requestId)
 
         // verify event 1
-        var dispatchEvents = getDispatchedEventsWith(type: "state:store",
-                                                     source: FunctionalTestConst.EventSource.RESPONSE_CONTENT)
-        dispatchEvents += getDispatchedEventsWith(type: "pairedeventexample",
-                                                  source: FunctionalTestConst.EventSource.RESPONSE_CONTENT)
+        var dispatchEvents = getDispatchedEventsWith(type: FunctionalTestConst.EventType.EDGE,
+                                                     source: "state:store")
+        dispatchEvents += getDispatchedEventsWith(type: FunctionalTestConst.EventType.EDGE,
+                                                  source: "pairedeventexample")
         XCTAssertEqual(2, dispatchEvents.count)
         guard let receivedData1 = dispatchEvents[0].data else {
             XCTFail("Invalid event data for event 1")
@@ -433,7 +433,7 @@ class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
         networkResponseHandler.addWaitingEvents(requestId: requestId, batchedEvents: [event1, event2])
         networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: requestId)
 
-        let dispatchEvents = getDispatchedEventsWith(type: "pairedeventexample", source: FunctionalTestConst.EventSource.RESPONSE_CONTENT)
+        let dispatchEvents = getDispatchedEventsWith(type: FunctionalTestConst.EventType.EDGE, source: "pairedeventexample")
         XCTAssertEqual(1, dispatchEvents.count)
         guard let receivedData1 = dispatchEvents[0].data else {
             XCTFail("Invalid event data for event 1")
@@ -470,8 +470,8 @@ class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
         networkResponseHandler.addWaitingEvents(requestId: "567", batchedEvents: [event1, event2])
         networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: requestId)
 
-        let dispatchEvents = getDispatchedEventsWith(type: "pairedeventexample",
-                                                     source: FunctionalTestConst.EventSource.RESPONSE_CONTENT)
+        let dispatchEvents = getDispatchedEventsWith(type: FunctionalTestConst.EventType.EDGE,
+                                                     source: "pairedeventexample")
         XCTAssertEqual(1, dispatchEvents.count)
         guard let receivedData1 = dispatchEvents[0].data else {
             XCTFail("Invalid event data for event 1")
@@ -518,7 +518,7 @@ class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
 
         networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: requestId)
 
-        let dispatchEvents = getDispatchedEventsWith(type: "state:store", source: FunctionalTestConst.EventSource.RESPONSE_CONTENT)
+        let dispatchEvents = getDispatchedEventsWith(type: FunctionalTestConst.EventType.EDGE, source: "state:store")
         XCTAssertEqual(1, dispatchEvents.count)
         guard let receivedData1 = dispatchEvents[0].data else {
             XCTFail("Invalid event data for event 1")

--- a/Tests/FunctionalTests/SampleFunctionalTests.swift
+++ b/Tests/FunctionalTests/SampleFunctionalTests.swift
@@ -117,7 +117,7 @@ class SampleFunctionalTests: FunctionalTestBase {
 
     func testSample_AssertNetworkRequestAndResponseEvent() {
         setExpectationEvent(type: FunctionalTestConst.EventType.EDGE, source: FunctionalTestConst.EventSource.REQUEST_CONTENT, expectedCount: 1)
-        setExpectationEvent(type: FunctionalTestConst.EventType.EDGE, source: FunctionalTestConst.EventSource.RESPONSE_CONTENT, expectedCount: 1)
+        setExpectationEvent(type: "identity:exchange", source: FunctionalTestConst.EventSource.RESPONSE_CONTENT, expectedCount: 1)
         // swiftlint:disable:next line_length
         let responseBody = "\u{0000}{\"requestId\":\"ded17427-c993-4182-8d94-2a169c1a23e2\",\"handle\":[{\"type\":\"identity:exchange\",\"payload\":[{\"type\":\"url\",\"id\":411,\"spec\":{\"url\":\"//cm.everesttech.net/cm/dd?d_uuid=42985602780892980519057012517360930936\",\"hideReferrer\":false,\"ttlMinutes\":10080}}]}]}\n"
         let httpConnection: HttpConnection = HttpConnection(data: responseBody.data(using: .utf8),

--- a/Tests/FunctionalTests/SampleFunctionalTests.swift
+++ b/Tests/FunctionalTests/SampleFunctionalTests.swift
@@ -117,7 +117,7 @@ class SampleFunctionalTests: FunctionalTestBase {
 
     func testSample_AssertNetworkRequestAndResponseEvent() {
         setExpectationEvent(type: FunctionalTestConst.EventType.EDGE, source: FunctionalTestConst.EventSource.REQUEST_CONTENT, expectedCount: 1)
-        setExpectationEvent(type: "identity:exchange", source: FunctionalTestConst.EventSource.RESPONSE_CONTENT, expectedCount: 1)
+        setExpectationEvent(type: FunctionalTestConst.EventType.EDGE, source: "identity:exchange", expectedCount: 1)
         // swiftlint:disable:next line_length
         let responseBody = "\u{0000}{\"requestId\":\"ded17427-c993-4182-8d94-2a169c1a23e2\",\"handle\":[{\"type\":\"identity:exchange\",\"payload\":[{\"type\":\"url\",\"id\":411,\"spec\":{\"url\":\"//cm.everesttech.net/cm/dd?d_uuid=42985602780892980519057012517360930936\",\"hideReferrer\":false,\"ttlMinutes\":10080}}]}]}\n"
         let httpConnection: HttpConnection = HttpConnection(data: responseBody.data(using: .utf8),


### PR DESCRIPTION
Sets the event source for edge response events to the value of the handle type.
More info: https://github.com/adobe/aepsdk-edge-ios/issues/108