### PR TITLE
Add additional test and remove dead code

### DIFF
--- a/Sources/EdgeNetworkHandlers/EdgeResponse.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeResponse.swift
@@ -17,7 +17,7 @@ import Foundation
 struct EdgeResponse: Codable {
 
     /// The request identifier associated with this response
-    let requestId: String?
+    let requestId: String
 
     /// List of event handles received from the Experience Edge  Network
     let handle: [EdgeEventHandle]?

--- a/Sources/EdgeNetworkHandlers/EdgeResponse.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeResponse.swift
@@ -17,7 +17,7 @@ import Foundation
 struct EdgeResponse: Codable {
 
     /// The request identifier associated with this response
-    let requestId: String
+    let requestId: String?
 
     /// List of event handles received from the Experience Edge  Network
     let handle: [EdgeEventHandle]?

--- a/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
+++ b/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
@@ -90,7 +90,8 @@ class NetworkResponseHandler {
         guard let data = jsonError.data(using: .utf8) else { return }
         Log.debug(label: LOG_TAG, "processResponseOnError - Processing server error response:\n \(jsonError), request id \(requestId)")
 
-        if let edgeResponse = try? JSONDecoder().decode(EdgeResponse.self, from: data), edgeResponse.errors != nil {
+        if let edgeResponse = try? JSONDecoder().decode(EdgeResponse.self, from: data) {
+            guard edgeResponse.errors != nil else { return }
             // this is an error coming from Konductor, read the error from the errors node
             dispatchEventErrors(errorsArray: edgeResponse.errors, requestId: requestId)
         } else if let edgeErrorResponse = try? JSONDecoder().decode(EdgeEventError.self, from: data) {

--- a/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
+++ b/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
@@ -88,31 +88,20 @@ class NetworkResponseHandler {
     ///   - requestId: request id associated with current response
     func processResponseOnError(jsonError: String, requestId: String) {
         guard let data = jsonError.data(using: .utf8) else { return }
-
-        // Attempt to decode as an `EdgeResponse` first
-        guard let edgeErrorResponse = try? JSONDecoder().decode(EdgeResponse.self, from: data) else {
-            Log.warning(label: LOG_TAG,
-                        "processResponseOnError - The conversion to JSON failed for server error response: \(jsonError), request id \(requestId)")
-            return
-        }
-
         Log.debug(label: LOG_TAG, "processResponseOnError - Processing server error response:\n \(jsonError), request id \(requestId)")
 
-        // Note: if the Edge error doesn't have an eventIndex it means that this error is a generic request error,
-        // otherwise it is an event specific error. There can be multiple errors returned for the same event
-        if edgeErrorResponse.errors != nil {
+        if let edgeResponse = try? JSONDecoder().decode(EdgeResponse.self, from: data), edgeResponse.errors != nil {
             // this is an error coming from Konductor, read the error from the errors node
-            dispatchEventErrors(errorsArray: edgeErrorResponse.errors, requestId: requestId)
-        } else {
+            dispatchEventErrors(errorsArray: edgeResponse.errors, requestId: requestId)
+        } else if let edgeErrorResponse = try? JSONDecoder().decode(EdgeEventError.self, from: data) {
             // generic server error, return the error as is
-            guard let genericErrorResponse = try? JSONDecoder().decode(EdgeEventError.self, from: data) else {
-                Log.warning(label: LOG_TAG,
-                            "processResponseOnError - The conversion to JSON failed for generic error response: \(jsonError), " +
-                                "request id \(requestId)")
-                return
-            }
-
-            dispatchEventErrors(errorsArray: [genericErrorResponse], requestId: requestId)
+            Log.warning(label: LOG_TAG,
+                                    "processResponseOnError - The conversion to JSON failed for server error response: \(jsonError), request id \(requestId), attempting to decode as a fatal error")
+            dispatchEventErrors(errorsArray: [edgeErrorResponse], requestId: requestId)
+        } else {
+            Log.warning(label: LOG_TAG,
+                                        "processResponseOnError - The conversion to JSON failed for generic error response: \(jsonError), " +
+                                            "request id \(requestId)")
         }
     }
 

--- a/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
+++ b/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
@@ -90,8 +90,7 @@ class NetworkResponseHandler {
         guard let data = jsonError.data(using: .utf8) else { return }
         Log.debug(label: LOG_TAG, "processResponseOnError - Processing server error response:\n \(jsonError), request id \(requestId)")
 
-        if let edgeResponse = try? JSONDecoder().decode(EdgeResponse.self, from: data) {
-            guard edgeResponse.errors != nil else { return }
+        if let edgeResponse = try? JSONDecoder().decode(EdgeResponse.self, from: data), edgeResponse.errors != nil {
             // this is an error coming from Konductor, read the error from the errors node
             dispatchEventErrors(errorsArray: edgeResponse.errors, requestId: requestId)
         } else if let edgeErrorResponse = try? JSONDecoder().decode(EdgeEventError.self, from: data) {

--- a/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
+++ b/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
@@ -91,16 +91,8 @@ class NetworkResponseHandler {
 
         // Attempt to decode as an `EdgeResponse` first
         guard let edgeErrorResponse = try? JSONDecoder().decode(EdgeResponse.self, from: data) else {
-
-            // If decoding as an `EdgeResponse` fails, attempt to decode as a generic `EdgeEventError`
-            if let edgeErrorResponse = try? JSONDecoder().decode(EdgeEventError.self, from: data) {
-                Log.debug(label: LOG_TAG, "processResponseOnError - Processing server error response:\n \(jsonError), request id \(requestId)")
-                dispatchEventErrors(errorsArray: [edgeErrorResponse], requestId: requestId)
-            } else {
-                Log.warning(label: LOG_TAG,
-                            "processResponseOnError - The conversion to JSON failed for server error response: \(jsonError), request id \(requestId)")
-            }
-
+            Log.warning(label: LOG_TAG,
+                        "processResponseOnError - The conversion to JSON failed for server error response: \(jsonError), request id \(requestId)")
             return
         }
 


### PR DESCRIPTION
This adds a real fatal error response test I received from Konductor by providing an invalid config id. This PR doesn't fix any bugs, but rather adds a new test and does some minor clean up.

I also took a minute to take another look at some of the decoding code, and realized that the decoding within the `guard` is redundant, and checking if `errors` is nil is sufficient. In the case a generic fetal error is returned, it will end up decoding into a `nil` `EdgeErrorResponse`, then when we check `redgeErrorResponse.errors` we'll realize that we need to decode it as a generic error.