### PR TITLE
Make public APIs ObjC Compatible

### DIFF
--- a/Sources/Edge+PublicAPI.swift
+++ b/Sources/Edge+PublicAPI.swift
@@ -22,7 +22,7 @@ public extension Edge {
     ///   - experienceEvent: Event to be sent to Adobe Experience Edge
     ///   - completion: Optional completion handler to be invoked when the request is complete, returning the associated response handles
     ///                 received from the Adobe Experience Edge. It may be invoked on a different thread.
-    static func sendEvent(experienceEvent: ExperienceEvent, _ completion: (([EdgeEventHandle]) -> Void)? = nil) {
+    @objc static func sendEvent(experienceEvent: ExperienceEvent, _ completion: (([EdgeEventHandle]) -> Void)? = nil) {
         guard let xdmData = experienceEvent.xdm, !xdmData.isEmpty, let eventData = experienceEvent.asDictionary() else {
             Log.debug(label: LOG_TAG, "Failed to dispatch the experience event because the XDM data was nil/empty.")
             return

--- a/Sources/ExperienceEvent.swift
+++ b/Sources/ExperienceEvent.swift
@@ -16,23 +16,23 @@ import Foundation
 public class ExperienceEvent: NSObject {
 
     /// XDM formatted data, use an `XDMSchema` implementation for a better XDM data injestion and format control
-    public let xdm: [String: Any]?
+    @objc public let xdm: [String: Any]?
 
     /// Optional free-form data associated with this event
-    public let data: [String: Any]?
+    @objc public let data: [String: Any]?
 
     /// Optional free-form query data associated with this event
-    public var query: [String: Any]?
+    @objc public var query: [String: Any]?
 
     /// Adobe Experience Platform dataset identifier, if not set the default dataset identifier set in the Edge Configuration is used
-    public let datasetIdentifier: String?
+    @objc public let datasetIdentifier: String?
 
     /// Initialize an Experience Event with the provided event data
     /// - Parameters:
     ///   - xdm:  XDM formatted data for this event, passed as a raw XDM Schema data dictionary.
     ///   - data: Any free form data in a [String : Any] dictionary structure.
     ///   - datasetIdentifier: The Experience Platform dataset identifier where this event should be sent to; if not provided, the default dataset identifier set in the Edge configuration is used
-    public init(xdm: [String: Any], data: [String: Any]? = nil, datasetIdentifier: String? = nil) {
+    @objc public init(xdm: [String: Any], data: [String: Any]? = nil, datasetIdentifier: String? = nil) {
         self.xdm = xdm
         self.data = data
         self.datasetIdentifier = datasetIdentifier


### PR DESCRIPTION
Our current APIs do not allow for creating an Event or sending an Event in ObjC.