### PR TITLE
sendEvent ObjC rename

### DIFF
--- a/Sources/Edge+PublicAPI.swift
+++ b/Sources/Edge+PublicAPI.swift
@@ -22,7 +22,7 @@ public extension Edge {
     ///   - experienceEvent: Event to be sent to Adobe Experience Edge
     ///   - completion: Optional completion handler to be invoked when the request is complete, returning the associated response handles
     ///                 received from the Adobe Experience Edge. It may be invoked on a different thread.
-    @objc(sendEvent:experienceEvent:)
+    @objc(sendExperienceEvent:completion:)
     static func sendEvent(experienceEvent: ExperienceEvent, _ completion: (([EdgeEventHandle]) -> Void)? = nil) {
         guard let xdmData = experienceEvent.xdm, !xdmData.isEmpty, let eventData = experienceEvent.asDictionary() else {
             Log.debug(label: LOG_TAG, "Failed to dispatch the experience event because the XDM data was nil/empty.")

--- a/Sources/Edge+PublicAPI.swift
+++ b/Sources/Edge+PublicAPI.swift
@@ -22,7 +22,8 @@ public extension Edge {
     ///   - experienceEvent: Event to be sent to Adobe Experience Edge
     ///   - completion: Optional completion handler to be invoked when the request is complete, returning the associated response handles
     ///                 received from the Adobe Experience Edge. It may be invoked on a different thread.
-    @objc static func sendEvent(experienceEvent: ExperienceEvent, _ completion: (([EdgeEventHandle]) -> Void)? = nil) {
+    @objc(sendEvent:experienceEvent:)
+    static func sendEvent(experienceEvent: ExperienceEvent, _ completion: (([EdgeEventHandle]) -> Void)? = nil) {
         guard let xdmData = experienceEvent.xdm, !xdmData.isEmpty, let eventData = experienceEvent.asDictionary() else {
             Log.debug(label: LOG_TAG, "Failed to dispatch the experience event because the XDM data was nil/empty.")
             return


### PR DESCRIPTION
```objectivec
[AEPMobileEdge sendExperienceEvent:event completion:^(NSArray<AEPEdgeEventHandle *> * _Nonnull handles) {
    AEPEdgeEventHandle *handle = handles.firstObject;
    NSDictionary *payload = handle.payload;
    NSString *type = handle.type;
}];
```