### PR TITLE
Build then persist Edge hits

### DIFF
--- a/Sources/EdgeNetworkHandlers/ConsentEdgeHit.swift
+++ b/Sources/EdgeNetworkHandlers/ConsentEdgeHit.swift
@@ -10,12 +10,15 @@
 // governing permissions and limitations under the License.
 //
 
+import AEPCore
 import Foundation
 
 /// Implementation of `EdgeHit` for Consent update requests
 struct ConsentEdgeHit: EdgeHit, Codable {
     let configId: String
-    let requestId: String = UUID().uuidString
+    let requestId: String
+    var headers: [String: String]
+    var listOfEvents: [Event]?
 
     /// The `EdgeConsentUpdate` for the corresponding hit
     let consents: EdgeConsentUpdate

--- a/Sources/EdgeNetworkHandlers/ConsentEdgeHit.swift
+++ b/Sources/EdgeNetworkHandlers/ConsentEdgeHit.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 /// Implementation of `EdgeHit` for Consent update requests
-struct ConsentEdgeHit: EdgeHit {
+struct ConsentEdgeHit: EdgeHit, Codable {
     let configId: String
     let requestId: String = UUID().uuidString
 

--- a/Sources/EdgeNetworkHandlers/EdgeConsentPayload.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeConsentPayload.swift
@@ -13,7 +13,7 @@
 import AEPServices
 import Foundation
 
-struct EdgeConsentPayload: Encodable {
+struct EdgeConsentPayload: Codable {
     /// The consent standard to be used for this request
     let standard: String
 

--- a/Sources/EdgeNetworkHandlers/EdgeConsentUpdate.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeConsentUpdate.swift
@@ -15,7 +15,7 @@ import Foundation
 
 /// A request for sending a consent update to the Adobe Experience Edge.
 /// An `EdgeConsentUpdate` is the top-level request object sent to Experience Edge to the set-consent endpoint.
-struct EdgeConsentUpdate: Encodable {
+struct EdgeConsentUpdate: Codable {
     /// The IdentityMap at the moment of this request
     let identityMap: [String: AnyCodable]?
 

--- a/Sources/EdgeNetworkHandlers/EdgeHit.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeHit.swift
@@ -21,6 +21,12 @@ protocol EdgeHit: Codable {
     /// Unique identifier for this hit
     var requestId: String { get }
 
+    /// Request headers for this hit
+    var headers: [String: String] { get }
+
+    /// Returns the list of `Event`s for this hit
+    var listOfEvents: [Event]? { get }
+
     /// The `ExperienceEdgeRequestType` to be used for this `EdgeHit`
     func getType() -> ExperienceEdgeRequestType
 

--- a/Sources/EdgeNetworkHandlers/EdgeHit.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeHit.swift
@@ -14,7 +14,7 @@ import AEPCore
 import Foundation
 
 /// Protocol used for defining hits to Experience Edge service
-protocol EdgeHit {
+protocol EdgeHit: Codable {
     /// The Edge configuration identifier
     var configId: String { get }
 
@@ -27,6 +27,6 @@ protocol EdgeHit {
     /// The network request payload for this `EdgeHit`
     func getPayload() -> String?
 
-    /// Retrieves the `Streaming` settings for this `EdgHit` or nil if not enabled
+    /// Retrieves the `Streaming` settings for this `EdgeHit` or nil if not enabled
     func getStreamingSettings() -> Streaming?
 }

--- a/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
@@ -19,21 +19,12 @@ class EdgeHitProcessor: HitProcessing {
     private let LOG_TAG = "EdgeHitProcessor"
     private var networkService: EdgeNetworkService
     private var networkResponseHandler: NetworkResponseHandler
-    private var getSharedState: (String, Event?) -> SharedStateResult?
-    private var getXDMSharedState: (String, Event?) -> SharedStateResult?
-    private var readyForEvent: (Event) -> Bool
     private var entityRetryIntervalMapping = ThreadSafeDictionary<String, TimeInterval>()
 
     init(networkService: EdgeNetworkService,
-         networkResponseHandler: NetworkResponseHandler,
-         getSharedState: @escaping (String, Event?) -> SharedStateResult?,
-         getXDMSharedState: @escaping (String, Event?) -> SharedStateResult?,
-         readyForEvent: @escaping (Event) -> Bool) {
+         networkResponseHandler: NetworkResponseHandler) {
         self.networkService = networkService
         self.networkResponseHandler = networkResponseHandler
-        self.getSharedState = getSharedState
-        self.getXDMSharedState = getXDMSharedState
-        self.readyForEvent = readyForEvent
     }
 
     // MARK: HitProcessing
@@ -43,74 +34,24 @@ class EdgeHitProcessor: HitProcessing {
     }
 
     func processHit(entity: DataEntity, completion: @escaping (Bool) -> Void) {
-        guard let data = entity.data, let event = try? JSONDecoder().decode(Event.self, from: data),
-              let eventData = event.data, !eventData.isEmpty
-        else {
+        guard let data = entity.data else {
             // can't convert data to hit, unrecoverable error, move to next hit
-            Log.debug(label: LOG_TAG, "processHit - Failed to decode edge hit with id '\(entity.uniqueIdentifier)' or empty data.")
+            Log.debug(label: LOG_TAG, "processHit - data is empty for entity '\(entity.uniqueIdentifier), dropping hit.")
             completion(true)
             return
         }
 
-        guard readyForEvent(event) else {
-            Log.debug(label: LOG_TAG, "processHit - readyForEvent returned false, will retry hit with id '\(entity.uniqueIdentifier)'.")
-            completion(false)
-            return
-        }
-
-        // fetch config shared state, this should be resolved based on readyForEvent check
-        guard let configId = getEdgeConfigId(event: event) else {
-            completion(true)
-            return // drop current event
-        }
-
-        // get IdentityMap from Identity shared state, this should be resolved based on readyForEvent check
-        guard let identityState =
-                getXDMSharedState(EdgeConstants.SharedState.Identity.STATE_OWNER_NAME,
-                                  event)?.value else {
-            Log.warning(label: LOG_TAG,
-                        "processHit - Unable to process the event '\(event.id.uuidString)', " +
-                            "Identity shared state is nil.")
-            completion(true)
-            return // drop current event
-        }
-
-        // Build Request object
-        let requestBuilder = RequestBuilder()
-        // attach identity map
-        requestBuilder.xdmPayloads[EdgeConstants.SharedState.Identity.IDENTITY_MAP] =
-            AnyCodable(identityState[EdgeConstants.SharedState.Identity.IDENTITY_MAP])
-
-        if event.isExperienceEvent {
-            requestBuilder.enableResponseStreaming(recordSeparator: EdgeConstants.Defaults.RECORD_SEPARATOR,
-                                                   lineFeed: EdgeConstants.Defaults.LINE_FEED)
-
-            // Build and send the network request to Experience Edge
-            let listOfEvents: [Event] = [event]
-            guard let requestPayload = requestBuilder.getPayloadWithExperienceEvents(listOfEvents) else {
-                Log.debug(label: LOG_TAG,
-                          "processHit - Failed to build the request payload, dropping current event '\(event.id.uuidString)'.")
-                completion(true)
-                return
-            }
-
-            let edgeHit = ExperienceEventsEdgeHit(configId: configId, request: requestPayload)
+        if let edgeHit = try? JSONDecoder().decode(ExperienceEventsEdgeHit.self, from: data) {
             // NOTE: the order of these events needs to be maintained as they were sent in the network request
             // otherwise the response callback cannot be matched
             networkResponseHandler.addWaitingEvents(requestId: edgeHit.requestId,
-                                                    batchedEvents: listOfEvents)
-            sendHit(entityId: entity.uniqueIdentifier, edgeHit: edgeHit, headers: getRequestHeaders(event), completion: completion)
-        } else if event.isUpdateConsentEvent {
-            // Build and send the consent network request to Experience Edge
-            guard let consentPayload = requestBuilder.getConsentPayload(event) else {
-                Log.debug(label: LOG_TAG,
-                          "processHit - Failed to build the consent payload, dropping current event '\(event.id.uuidString)'.")
-                completion(true)
-                return
-            }
-
-            let edgeHit = ConsentEdgeHit(configId: configId, consents: consentPayload)
-            sendHit(entityId: entity.uniqueIdentifier, edgeHit: edgeHit, headers: getRequestHeaders(event), completion: completion)
+                                                    batchedEvents: edgeHit.listOfEvents ?? [])
+            sendHit(entityId: entity.uniqueIdentifier, edgeHit: edgeHit, headers: edgeHit.headers, completion: completion)
+        } else if let consentEdgeHit = try? JSONDecoder().decode(ConsentEdgeHit.self, from: data) {
+            sendHit(entityId: entity.uniqueIdentifier, edgeHit: consentEdgeHit, headers: consentEdgeHit.headers, completion: completion)
+        } else {
+            // unknown hit type, move to next
+            completion(true)
         }
     }
 
@@ -140,44 +81,6 @@ class EdgeHitProcessor: HitProcessing {
             self?.entityRetryIntervalMapping[entityId] = success ? nil : retryInterval
             completion(success)
         }
-    }
-
-    /// Extracts the Edge Configuration identifier from the Configuration Shared State
-    /// - Parameter event: current event for which the configuration is required
-    /// - Returns: the Edge Configuration Id if found, nil otherwise
-    private func getEdgeConfigId(event: Event) -> String? {
-        guard let configSharedState =
-                getSharedState(EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
-                               event)?.value else {
-            Log.warning(label: LOG_TAG,
-                        "getEdgeConfigId - Unable to process the event '\(event.id.uuidString)', Configuration shared state is nil.")
-            return nil
-        }
-
-        guard let configId =
-                configSharedState[EdgeConstants.SharedState.Configuration.CONFIG_ID] as? String,
-              !configId.isEmpty else {
-            Log.warning(label: LOG_TAG,
-                        "getEdgeConfigId - Unable to process the event '\(event.id.uuidString)' " +
-                            "because of invalid edge.configId in configuration.")
-            return nil
-        }
-
-        return configId
-    }
-
-    /// Computes the request headers for provided `event`, including the `Assurance` integration identifier when `Assurance` is enabled
-    /// - Returns: the network request headers as `[String: String]`
-    private func getRequestHeaders(_ event: Event) -> [String: String] {
-        // get Assurance integration id and include it in to the requestHeaders
-        var requestHeaders: [String: String] = [:]
-        if let assuranceSharedState = getSharedState(EdgeConstants.SharedState.Assurance.STATE_OWNER_NAME, event)?.value {
-            if let assuranceIntegrationId = assuranceSharedState[EdgeConstants.SharedState.Assurance.INTEGRATION_ID] as? String {
-                requestHeaders[EdgeConstants.NetworkKeys.HEADER_KEY_AEP_VALIDATION_TOKEN] = assuranceIntegrationId
-            }
-        }
-
-        return requestHeaders
     }
 
 }

--- a/Sources/EdgeNetworkHandlers/EdgeNetworkService.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeNetworkService.swift
@@ -18,7 +18,7 @@ import Foundation
 ///     - interact - makes request and expects a response
 ///     - collect - makes request without expecting a response
 ///     - consent - sets user consent and expects a response
-enum ExperienceEdgeRequestType: String {
+enum ExperienceEdgeRequestType: String, Codable {
     case interact
     case collect
     case consent = "privacy/set-consent"

--- a/Sources/EdgeNetworkHandlers/EdgeRequest.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeRequest.swift
@@ -15,7 +15,7 @@ import Foundation
 
 /// A request for pushing events to the Adobe Experience Edge.
 /// An `EdgeRequest` is the top-level request object sent to Experience Edge.
-struct EdgeRequest: Encodable {
+struct EdgeRequest: Codable {
     /// Metadata passed to the Experience Cloud Solutions and even to the Edge itself with possibility of overriding at event level
     let meta: RequestMetadata?
 

--- a/Sources/EdgeNetworkHandlers/ExperienceEventsEdgeHit.swift
+++ b/Sources/EdgeNetworkHandlers/ExperienceEventsEdgeHit.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 /// Implementation of `EdgeHit` for ExperienceEvents requests
-struct ExperienceEventsEdgeHit: EdgeHit {
+struct ExperienceEventsEdgeHit: EdgeHit, Codable {
     let configId: String
     let requestId: String = UUID().uuidString
 

--- a/Sources/EdgeNetworkHandlers/ExperienceEventsEdgeHit.swift
+++ b/Sources/EdgeNetworkHandlers/ExperienceEventsEdgeHit.swift
@@ -10,12 +10,15 @@
 // governing permissions and limitations under the License.
 //
 
+import AEPCore
 import Foundation
 
 /// Implementation of `EdgeHit` for ExperienceEvents requests
 struct ExperienceEventsEdgeHit: EdgeHit, Codable {
     let configId: String
-    let requestId: String = UUID().uuidString
+    let requestId: String
+    let headers: [String: String]
+    let listOfEvents: [Event]?
 
     /// The `EdgeRequest` for the corresponding hit
     let request: EdgeRequest

--- a/Sources/EdgeNetworkHandlers/KonductorConfig.swift
+++ b/Sources/EdgeNetworkHandlers/KonductorConfig.swift
@@ -13,7 +13,7 @@ import Foundation
 
 /// Konductor configuration metadata.
 /// Is contained within the `RequestMetadata` request property.
-struct KonductorConfig: Encodable {
+struct KonductorConfig: Codable {
     /// Configure Konductor to provide the response fragments in a streaming fashion.
     let streaming: Streaming?
 }
@@ -38,7 +38,13 @@ struct Streaming {
     }
 }
 
-extension Streaming: Encodable {
+extension Streaming: Codable {
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: Streaming.CodingKeys.self)
+        recordSeparator = try? container.decode(String.self, forKey: .recordSeparator)
+        lineFeed = try? container.decode(String.self, forKey: .lineFeed)
+    }
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         if let unwrapped = recordSeparator { try container.encode(unwrapped, forKey: .recordSeparator)}

--- a/Sources/EdgeNetworkHandlers/RequestMetadata.swift
+++ b/Sources/EdgeNetworkHandlers/RequestMetadata.swift
@@ -14,7 +14,7 @@ import Foundation
 
 /// Metadata passed to Solutions and even to Experience Edge itself with possibility of overriding at event level.
 /// Is contained within the `EdgeRequest` request property.
-struct RequestMetadata: Encodable {
+struct RequestMetadata: Codable {
     let konductorConfig: KonductorConfig?
     let state: StateMetadata?
 }

--- a/Sources/EdgeNetworkHandlers/StateMetadata.swift
+++ b/Sources/EdgeNetworkHandlers/StateMetadata.swift
@@ -14,7 +14,7 @@ import Foundation
 
 /// Client side stored information.
 /// A property in the `RequestMetadata` object.
-struct StateMetadata: Encodable {
+struct StateMetadata: Codable {
     let entries: [StorePayload]?
 
     init(payload: [StorePayload]) {

--- a/Tests/UnitTests/EdgeExtensionTests.swift
+++ b/Tests/UnitTests/EdgeExtensionTests.swift
@@ -99,6 +99,10 @@ class EdgeExtensionTests: XCTestCase {
     }
 
     func testHandleConsentUpdate_validData_queues() {
+        mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
+                                        data: ([EdgeConstants.SharedState.Configuration.CONFIG_ID: "test-config-id"], .set))
+        mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Identity.STATE_OWNER_NAME,
+                                           data: ([:], .set))
         mockRuntime.simulateComingEvents(Event(name: "Consent update", type: EventType.edge, source: EventSource.updateConsent, data: ["consents": ["collect": ["val": "y"]]]))
 
         XCTAssertEqual(1, mockDataQueue.count())
@@ -122,6 +126,10 @@ class EdgeExtensionTests: XCTestCase {
 
     // MARK: Experience event
     func testHandleExperienceEventRequest_validData_consentYes_queues() {
+        mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
+                                        data: ([EdgeConstants.SharedState.Configuration.CONFIG_ID: "test-config-id"], .set))
+        mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Identity.STATE_OWNER_NAME,
+                                           data: ([:], .set))
         edge.state?.updateCurrentConsent(status: ConsentStatus.yes)
         mockRuntime.simulateComingEvents(experienceEvent)
 
@@ -129,6 +137,10 @@ class EdgeExtensionTests: XCTestCase {
     }
 
     func testHandleExperienceEventRequest_validData_consentPending_queues() {
+        mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
+                                        data: ([EdgeConstants.SharedState.Configuration.CONFIG_ID: "test-config-id"], .set))
+        mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Identity.STATE_OWNER_NAME,
+                                           data: ([:], .set))
         edge.state?.updateCurrentConsent(status: ConsentStatus.pending)
         mockRuntime.simulateComingEvents(experienceEvent)
 
@@ -162,6 +174,10 @@ class EdgeExtensionTests: XCTestCase {
     func testHandleExperienceEventRequest_consentXDMSharedStateInvalid_usesDefaultPending() {
         edge.state?.updateCurrentConsent(status: ConsentStatus.no)
         mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Consent.SHARED_OWNER_NAME, data: (["consents": ["invalid": "data"]], .set))
+        mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
+                                        data: ([EdgeConstants.SharedState.Configuration.CONFIG_ID: "test-config-id"], .set))
+        mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Identity.STATE_OWNER_NAME,
+                                           data: ([:], .set))
         mockRuntime.simulateComingEvents(experienceEvent)
 
         XCTAssertEqual(1, mockDataQueue.count())

--- a/Tests/UnitTests/EdgeExtensionTests.swift
+++ b/Tests/UnitTests/EdgeExtensionTests.swift
@@ -108,6 +108,22 @@ class EdgeExtensionTests: XCTestCase {
         XCTAssertEqual(1, mockDataQueue.count())
     }
 
+    func testHandleConsentUpdate_validData_noEdgeId_doesNotQueue() {
+        mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Identity.STATE_OWNER_NAME,
+                                           data: ([:], .set))
+        mockRuntime.simulateComingEvents(Event(name: "Consent update", type: EventType.edge, source: EventSource.updateConsent, data: ["consents": ["collect": ["val": "y"]]]))
+
+        XCTAssertEqual(0, mockDataQueue.count())
+    }
+
+    func testHandleConsentUpdate_validData_noIdentitySharedState_doesNotQueue() {
+        mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
+                                        data: ([EdgeConstants.SharedState.Configuration.CONFIG_ID: "test-config-id"], .set))
+        mockRuntime.simulateComingEvents(Event(name: "Consent update", type: EventType.edge, source: EventSource.updateConsent, data: ["consents": ["collect": ["val": "y"]]]))
+
+        XCTAssertEqual(0, mockDataQueue.count())
+    }
+
     // MARK: Consent preferences update
     func testHandlePreferencesUpdate_nilEmptyData_keepsPendingConsent() {
         mockRuntime.simulateComingEvents(
@@ -134,6 +150,24 @@ class EdgeExtensionTests: XCTestCase {
         mockRuntime.simulateComingEvents(experienceEvent)
 
         XCTAssertEqual(1, mockDataQueue.count())
+    }
+
+    func testHandleExperienceEventRequest_validData_consentYes_noEdgeId_DoesNotQueue() {
+        mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Identity.STATE_OWNER_NAME,
+                                           data: ([:], .set))
+        edge.state?.updateCurrentConsent(status: ConsentStatus.yes)
+        mockRuntime.simulateComingEvents(experienceEvent)
+
+        XCTAssertEqual(0, mockDataQueue.count())
+    }
+
+    func testHandleExperienceEventRequest_validData_consentYes_noIdentitySharedState_DoesNotQueue() {
+        mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
+                                        data: ([EdgeConstants.SharedState.Configuration.CONFIG_ID: "test-config-id"], .set))
+        edge.state?.updateCurrentConsent(status: ConsentStatus.yes)
+        mockRuntime.simulateComingEvents(experienceEvent)
+
+        XCTAssertEqual(0, mockDataQueue.count())
     }
 
     func testHandleExperienceEventRequest_validData_consentPending_queues() {

--- a/Tests/UnitTests/EdgeNetworkServiceTests.swift
+++ b/Tests/UnitTests/EdgeNetworkServiceTests.swift
@@ -20,7 +20,11 @@ class EdgeNetworkServiceTests: XCTestCase {
     private var mockNetworking = MockNetworking()
     private var mockResponseCallback = MockResponseCallback()
     private var networkService = EdgeNetworkService()
-    private let edgeHitPayload = ExperienceEventsEdgeHit(configId: "configIdExample", request: EdgeRequest(meta: nil, xdm: nil, events: [["test": "data"]])).getPayload()
+    private let edgeHitPayload = ExperienceEventsEdgeHit(configId: "configIdExample",
+                                                         requestId: UUID().uuidString,
+                                                         headers: ["test-header-key": "test-header-val"],
+                                                         listOfEvents: nil,
+                                                         request: EdgeRequest(meta: nil, xdm: nil, events: [["test": "data"]])).getPayload()
     private let url = URL(string: "https://test.com")! // swiftlint:disable:this force_unwrapping
     private let defaultNetworkingHeaders: [String] = ["User-Agent", "Accept-Language"]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Instead of just persisting the Event we now build the Edge hit then persist the entire hit.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
