### PR TITLE
Add consent update event to waiting events list

### DIFF
--- a/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
@@ -112,6 +112,7 @@ class EdgeHitProcessor: HitProcessing {
             }
 
             let edgeHit = ConsentEdgeHit(configId: configId, consents: consentPayload)
+            networkResponseHandler.addWaitingEvent(requestId: edgeHit.requestId, event: event)
             sendHit(entityId: entity.uniqueIdentifier, edgeHit: edgeHit, headers: getRequestHeaders(event), completion: completion)
         } else if event.isResetIdentitiesEvent {
             // reset stored payloads as part of processing the reset hit

--- a/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
+++ b/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
@@ -47,6 +47,15 @@ class NetworkResponseHandler {
         }
     }
 
+    /// Adds the requestId in the internal `sentEventsWaitingResponse` with the associated event.
+    /// If the same requestId was stored before, the new list will replace the existing event(s).
+    /// - Parameters:
+    ///   - requestId: batch request id
+    ///   - event: the event sent to ExEdge
+    func addWaitingEvent(requestId: String, event: Event) {
+        addWaitingEvents(requestId: requestId, batchedEvents: [event])
+    }
+
     /// Remove the requestId in the internal `sentEventsWaitingResponse` along with the associated list of events.
     /// - Parameter requestId: batch request id
     /// - Returns: the list of unique event ids associated with the requestId that were removed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Fixed a bug where the consent update request was not paired with the response handles.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
