### PR TITLE
[AMSDK-11328] Check for consent registration based on hub shared state

### DIFF
--- a/Sources/Edge.swift
+++ b/Sources/Edge.swift
@@ -195,7 +195,7 @@ public class Edge: NSObject, Extension {
     /// - Returns: true if events can be processed at the moment, false otherwise
     private func canProcessEvents(event: Event) -> Bool {
         guard let state = state else { return false }
-        state.bootupIfNeeded(event: event, getXDMSharedState: getXDMSharedState(extensionName:event:barrier:))
+        state.bootupIfNeeded(event: event, getSharedState: getSharedState(extensionName:event:barrier:))
         return true
     }
 

--- a/Sources/EdgeConstants.swift
+++ b/Sources/EdgeConstants.swift
@@ -42,7 +42,6 @@ enum EdgeConstants {
         static let REQUEST_EVENT_ID = "requestEventId"
         static let DATASET_ID = "datasetId"
         static let CONSENTS = "consents"
-        static let EXTENSIONS = "extensions"
     }
 
     enum DataStoreKeys {
@@ -81,6 +80,7 @@ enum EdgeConstants {
 
         enum Hub {
             static let SHARED_OWNER_NAME = "com.adobe.module.eventhub"
+            static let EXTENSIONS = "extensions"
         }
     }
 

--- a/Sources/EdgeConstants.swift
+++ b/Sources/EdgeConstants.swift
@@ -42,6 +42,7 @@ enum EdgeConstants {
         static let REQUEST_EVENT_ID = "requestEventId"
         static let DATASET_ID = "datasetId"
         static let CONSENTS = "consents"
+        static let EXTENSIONS = "extensions"
     }
 
     enum DataStoreKeys {
@@ -76,6 +77,10 @@ enum EdgeConstants {
             static let CONSENTS = "consents"
             static let COLLECT = "collect"
             static let VAL = "val"
+        }
+
+        enum Hub {
+            static let SHARED_OWNER_NAME = "com.adobe.module.eventhub"
         }
     }
 

--- a/Sources/EdgeState.swift
+++ b/Sources/EdgeState.swift
@@ -38,14 +38,18 @@ class EdgeState {
         guard !hasBooted else { return }
 
         // check if consent extension is registered
+        var consentRegistered = false
         if let registeredExtensionsWithHub = getSharedState(EdgeConstants.SharedState.Hub.SHARED_OWNER_NAME, event, false)?.value,
-           let extensions = registeredExtensionsWithHub[EdgeConstants.EventDataKeys.EXTENSIONS] as? [String: Any],
+           let extensions = registeredExtensionsWithHub[EdgeConstants.SharedState.Hub.EXTENSIONS] as? [String: Any],
            extensions[EdgeConstants.SharedState.Consent.SHARED_OWNER_NAME] as? [String: Any] != nil {
-            // keep consent pending until the consent preferences update event is received
-        } else {
+            consentRegistered = true
+        }
+
+        if !consentRegistered {
             Log.warning(label: LOG_TAG, "Consent extension is not registered yet, using default collect status (yes)")
             updateCurrentConsent(status: EdgeConstants.Defaults.COLLECT_CONSENT_YES)
         }
+        // else keep consent pending until the consent preferences update event is received
 
         hasBooted = true
         Log.debug(label: LOG_TAG, "Edge has successfully booted up")

--- a/Sources/EdgeState.swift
+++ b/Sources/EdgeState.swift
@@ -33,20 +33,19 @@ class EdgeState {
     ///
     /// - Parameters:
     ///   - event: The `Event` triggering the bootup
-    ///   - getXDMSharedState: used to fetch the Consent data
-    func bootupIfNeeded(event: Event, getXDMSharedState: @escaping (_ name: String, _ event: Event?, _ barrier: Bool) -> SharedStateResult?) {
+    ///   - getSharedState: used to fetch the `Event Hub` shared state
+    func bootupIfNeeded(event: Event, getSharedState: @escaping (_ name: String, _ event: Event?, _ barrier: Bool) -> SharedStateResult?) {
         guard !hasBooted else { return }
 
         // check if consent extension is registered
-        if let consentSharedState = getXDMSharedState(EdgeConstants.SharedState.Consent.SHARED_OWNER_NAME, nil, false) {
-            currentCollectConsent = ConsentStatus.getCollectConsentOrDefault(eventData: consentSharedState.value ?? [:])
+        if let registeredExtensionsWithHub = getSharedState(EdgeConstants.SharedState.Hub.SHARED_OWNER_NAME, event, false)?.value,
+           let extensions = registeredExtensionsWithHub[EdgeConstants.EventDataKeys.EXTENSIONS] as? [String: Any],
+           extensions[EdgeConstants.SharedState.Consent.SHARED_OWNER_NAME] as? [String: Any] != nil {
+            // keep consent pending until the consent preferences update event is received
         } else {
             Log.warning(label: LOG_TAG, "Consent extension is not registered yet, using default collect status (yes)")
-            currentCollectConsent = EdgeConstants.Defaults.COLLECT_CONSENT_YES
+            updateCurrentConsent(status: EdgeConstants.Defaults.COLLECT_CONSENT_YES)
         }
-
-        // update hitQueue based on current collect consent status
-        hitQueue.handleCollectConsentChange(status: currentCollectConsent)
 
         hasBooted = true
         Log.debug(label: LOG_TAG, "Edge has successfully booted up")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Updated the implementation as this task is now unblocked by https://github.com/adobe/aepsdk-core-ios/issues/570

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
