### PR TITLE
[AMSDK-11384] Persist reset timestamp

### DIFF
--- a/Sources/EdgeConstants.swift
+++ b/Sources/EdgeConstants.swift
@@ -47,7 +47,7 @@ enum EdgeConstants {
     enum DataStoreKeys {
         static let STORE_NAME = "AEPEdge"
         static let STORE_PAYLOADS = "storePayloads"
-        static let RESET_DATE = "reset.date"
+        static let RESET_IDENTITIES_DATE = "reset.identities.date"
     }
 
     enum SharedState {

--- a/Sources/EdgeConstants.swift
+++ b/Sources/EdgeConstants.swift
@@ -47,6 +47,7 @@ enum EdgeConstants {
     enum DataStoreKeys {
         static let STORE_NAME = "AEPEdge"
         static let STORE_PAYLOADS = "storePayloads"
+        static let RESET_DATE = "reset.date"
     }
 
     enum SharedState {

--- a/Sources/EdgeNetworkHandlers/Atomic.swift
+++ b/Sources/EdgeNetworkHandlers/Atomic.swift
@@ -14,7 +14,7 @@ import Foundation
 
 /// Represents a thread-safe type for read and write operations
 final class Atomic<A> {
-    private let queue = DispatchQueue(label: "Atomic type serial queue")
+    private let queue = DispatchQueue(label: "com.adobe.atomic.queue")
     private var _value: A
 
     /// Creates a new `Atomic` type with `value`

--- a/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
+++ b/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
@@ -29,7 +29,7 @@ class NetworkResponseHandler {
     private var lastResetDate = Atomic<Date>(Date(timeIntervalSince1970: 0))
 
     init() {
-        lastResetDate = Atomic<Date>(loadResetDateFromPersistence())
+        lastResetDate = Atomic<Date>(loadResetDateFromPersistence() ?? Date(timeIntervalSince1970: 0))
     }
 
     /// Adds the requestId in the internal `sentEventsWaitingResponse` with the associated list of events.
@@ -82,7 +82,7 @@ class NetworkResponseHandler {
     /// - Parameter date: a `Date`
     func setLastReset(date: Date) {
         lastResetDate.mutate {$0 = date}
-        dataStore.set(key: EdgeConstants.DataStoreKeys.RESET_DATE, value: date.timeIntervalSince1970)
+        dataStore.set(key: EdgeConstants.DataStoreKeys.RESET_IDENTITIES_DATE, value: date.timeIntervalSince1970)
     }
 
     /// Decodes the response as `EdgeResponse` and handles the event handles, errors and warnings received from the server
@@ -348,10 +348,10 @@ class NetworkResponseHandler {
         return false
     }
 
-    /// Loads the reset date from persistence, if not present defaults to the earliest `Date` possible, `Date().timeIntervalSince1970`.
-    /// - Returns: the `Date` representing the earliest known reset date
-    private func loadResetDateFromPersistence() -> Date {
-        let storedResetDate = dataStore.getDouble(key: EdgeConstants.DataStoreKeys.RESET_DATE)
-        return Date(timeIntervalSince1970: storedResetDate ?? Date().timeIntervalSince1970)
+    /// Loads the reset date from persistence, if not found returns nil
+    /// - Returns: the `Date` representing the earliest known reset date, nil if not found
+    private func loadResetDateFromPersistence() -> Date? {
+        guard let storedResetDate = dataStore.getDouble(key: EdgeConstants.DataStoreKeys.RESET_IDENTITIES_DATE) else { return nil }
+        return Date(timeIntervalSince1970: storedResetDate)
     }
 }

--- a/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
+++ b/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
@@ -20,12 +20,17 @@ import Foundation
 class NetworkResponseHandler {
     private let LOG_TAG = "NetworkResponseHandler"
     private let serialQueue = DispatchQueue(label: "com.adobe.edge.eventsDictionary") // serial queue for atomic operations
+    private let dataStore = NamedCollectionDataStore(name: EdgeConstants.EXTENSION_NAME)
 
     // the order of the request events matter for matching them with the response events
     private var sentEventsWaitingResponse = ThreadSafeDictionary<String, [(uuid: String, date: Date)]>()
 
     /// Date of the last generic identity reset request event, for more info see `shouldIgnoreStorePayload`
     private var lastResetDate = Atomic<Date>(Date(timeIntervalSince1970: 0))
+
+    init() {
+        lastResetDate = Atomic<Date>(loadResetDateFromPersistence())
+    }
 
     /// Adds the requestId in the internal `sentEventsWaitingResponse` with the associated list of events.
     /// This list should maintain the order of the received events for matching with the response event index.
@@ -77,6 +82,7 @@ class NetworkResponseHandler {
     /// - Parameter date: a `Date`
     func setLastReset(date: Date) {
         lastResetDate.mutate {$0 = date}
+        dataStore.set(key: EdgeConstants.DataStoreKeys.RESET_DATE, value: date.timeIntervalSince1970)
     }
 
     /// Decodes the response as `EdgeResponse` and handles the event handles, errors and warnings received from the server
@@ -340,5 +346,12 @@ class NetworkResponseHandler {
         }
 
         return false
+    }
+
+    /// Loads the reset date from persistence, if not present defaults to the earliest `Date` possible, `Date().timeIntervalSince1970`.
+    /// - Returns: the `Date` representing the earliest known reset date
+    private func loadResetDateFromPersistence() -> Date {
+        let storedResetDate = dataStore.getDouble(key: EdgeConstants.DataStoreKeys.RESET_DATE)
+        return Date(timeIntervalSince1970: storedResetDate ?? Date().timeIntervalSince1970)
     }
 }

--- a/Tests/FunctionalTests/NetworkResponseHandlerFunctionalTests.swift
+++ b/Tests/FunctionalTests/NetworkResponseHandlerFunctionalTests.swift
@@ -260,7 +260,7 @@ class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
 
     /// Tests that when an event is processed after a reset event that the store payloads are saved
     func testProcessResponseOnSuccess_afterResetEvent_savesStorePayloads() {
-        networkResponseHandler.setLastReset(date: Date()) // date is before `event.timestamp`
+        networkResponseHandler.setLastReset(date: Date(timeIntervalSince1970: Date().timeIntervalSince1970 - 10)) // date is before `event.timestamp`
         let event = Event(name: "test", type: "test-type", source: "test-source", data: nil)
 
         networkResponseHandler.addWaitingEvents(requestId: "d81c93e5-7558-4996-a93c-489d550748b8",
@@ -294,7 +294,7 @@ class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
         networkResponseHandler.addWaitingEvents(requestId: "d81c93e5-7558-4996-a93c-489d550748b8",
                                                 batchedEvents: [event])
 
-        networkResponseHandler.setLastReset(date: Date()) // date is after `event.timestamp`
+        networkResponseHandler.setLastReset(date: Date(timeIntervalSince1970: Date().timeIntervalSince1970 + 10)) // date is after `event.timestamp` // date is after `event.timestamp`
 
         setExpectationEvent(type: FunctionalTestConst.EventType.EDGE, source: FunctionalTestConst.EventSource.RESPONSE_CONTENT, expectedCount: 1)
         let jsonResponse = "{\n" +
@@ -321,7 +321,7 @@ class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
 
     /// Tests that when an event is processed after a persisted reset event that the store payloads are saved
     func testProcessResponseOnSuccess_afterPersistedResetEvent_savesStorePayloads() {
-        dataStore.set(key: EdgeConstants.DataStoreKeys.RESET_IDENTITIES_DATE, value: Date().timeIntervalSince1970) // date is before `event.timestamp`
+        dataStore.set(key: EdgeConstants.DataStoreKeys.RESET_IDENTITIES_DATE, value: Date().timeIntervalSince1970 - 10) // date is before `event.timestamp`
         networkResponseHandler = NetworkResponseHandler() // loads reset time on init
 
         let event = Event(name: "test", type: "test-type", source: "test-source", data: nil)
@@ -356,7 +356,7 @@ class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
     func testProcessResponseOnSuccess_beforePersistedResetEvent_doesNotSaveStorePayloads() {
         let event = Event(name: "test", type: "test-type", source: "test-source", data: nil)
 
-        dataStore.set(key: EdgeConstants.DataStoreKeys.RESET_IDENTITIES_DATE, value: Date().timeIntervalSince1970) // date is after `event.timestamp`
+        dataStore.set(key: EdgeConstants.DataStoreKeys.RESET_IDENTITIES_DATE, value: Date().timeIntervalSince1970 + 10) // date is after `event.timestamp`
         networkResponseHandler = NetworkResponseHandler() // loads reset time on init
         networkResponseHandler.addWaitingEvents(requestId: "d81c93e5-7558-4996-a93c-489d550748b8",
                                                 batchedEvents: [event])

--- a/Tests/FunctionalTests/NetworkResponseHandlerFunctionalTests.swift
+++ b/Tests/FunctionalTests/NetworkResponseHandlerFunctionalTests.swift
@@ -24,7 +24,6 @@ class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
     override func setUp() {
         super.setUp()
         MobileCore.registerExtensions([InstrumentedExtension.self]) // start MobileCore
-        ServiceProvider.shared.namedKeyValueService = MockDataStore()
         continueAfterFailure = false
     }
 

--- a/Tests/FunctionalTests/NetworkResponseHandlerFunctionalTests.swift
+++ b/Tests/FunctionalTests/NetworkResponseHandlerFunctionalTests.swift
@@ -321,7 +321,7 @@ class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
 
     /// Tests that when an event is processed after a persisted reset event that the store payloads are saved
     func testProcessResponseOnSuccess_afterPersistedResetEvent_savesStorePayloads() {
-        dataStore.set(key: EdgeConstants.DataStoreKeys.RESET_DATE, value: Date().timeIntervalSince1970) // date is before `event.timestamp`
+        dataStore.set(key: EdgeConstants.DataStoreKeys.RESET_IDENTITIES_DATE, value: Date().timeIntervalSince1970) // date is before `event.timestamp`
         networkResponseHandler = NetworkResponseHandler() // loads reset time on init
 
         let event = Event(name: "test", type: "test-type", source: "test-source", data: nil)
@@ -356,7 +356,7 @@ class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
     func testProcessResponseOnSuccess_beforePersistedResetEvent_doesNotSaveStorePayloads() {
         let event = Event(name: "test", type: "test-type", source: "test-source", data: nil)
 
-        dataStore.set(key: EdgeConstants.DataStoreKeys.RESET_DATE, value: Date().timeIntervalSince1970) // date is after `event.timestamp`
+        dataStore.set(key: EdgeConstants.DataStoreKeys.RESET_IDENTITIES_DATE, value: Date().timeIntervalSince1970) // date is after `event.timestamp`
         networkResponseHandler = NetworkResponseHandler() // loads reset time on init
         networkResponseHandler.addWaitingEvents(requestId: "d81c93e5-7558-4996-a93c-489d550748b8",
                                                 batchedEvents: [event])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Persists the last reset timestamp so we can inspect it between sessions:
https://jira.corp.adobe.com/browse/AMSDK-11384

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
