### PR TITLE
[MOB-14372] Use XDM timestamp if present

### DIFF
--- a/AEPEdge.xcodeproj/project.pbxproj
+++ b/AEPEdge.xcodeproj/project.pbxproj
@@ -1243,7 +1243,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nif which swiftlint >/dev/null; then\n    swiftlint lint --config ../.swiftlint.yml Sources\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n\n";
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nif which swiftlint >/dev/null; then\n    swiftlint lint --config ${SRCROOT}/.swiftlint.yml Sources\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n\n";
 		};
 		DCF202D068A8FE8F671EDC00 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Sources/EdgeNetworkHandlers/RequestBuilder.swift
+++ b/Sources/EdgeNetworkHandlers/RequestBuilder.swift
@@ -109,7 +109,13 @@ class RequestBuilder {
             }
 
             if var xdm = eventData[EdgeConstants.JsonKeys.XDM] as? [String: Any] {
-                xdm[EdgeConstants.JsonKeys.TIMESTAMP] = ISO8601DateFormatter().string(from: event.timestamp)
+
+                if xdm[EdgeConstants.JsonKeys.TIMESTAMP] == nil ||
+                    (xdm[EdgeConstants.JsonKeys.TIMESTAMP] as? String)?.isEmpty ?? true {
+                    // if no timestamp is provided in the xdm event payload, set the event timestamp
+                    xdm[EdgeConstants.JsonKeys.TIMESTAMP] = ISO8601DateFormatter().string(from: event.timestamp)
+                }
+
                 xdm[EdgeConstants.JsonKeys.EVENT_ID] = event.id.uuidString
                 eventData[EdgeConstants.JsonKeys.XDM] = xdm
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When xdm.timestamp is provided in the experience event payload preserve this value, otherwise set the event timestamp as xdm.timestamp.
Also sets the event timestamp when the provided value is nil or empty or has another type other than String.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
