### PR TITLE
Conform generic network errors to EdgeEventError type

### DIFF
--- a/Sources/EdgeNetworkHandlers/EdgeEventError.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeEventError.swift
@@ -32,6 +32,24 @@ struct EdgeEventError: Codable, Equatable {
     /// A report for the error containing additional information
     let report: EdgeErrorReport?
 
+    init(title: String?, detail: String?, status: Int?, type: String?, eventIndex: Int?, report: EdgeErrorReport?) {
+        self.title = title
+        self.detail = detail
+        self.status = status
+        self.type = type
+        self.eventIndex = eventIndex
+        self.report = report
+    }
+
+    init(title: String?, detail: String?) {
+        self.title = title
+        self.detail = detail
+        self.status = nil
+        self.type = nil
+        self.eventIndex = nil
+        self.report = nil
+    }
+
     // MARK: - Codable
     enum CodingKeys: String, CodingKey {
         case title

--- a/Sources/EdgeNetworkHandlers/EdgeNetworkService.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeNetworkService.swift
@@ -40,7 +40,7 @@ enum HttpResponseCodes: Int {
 class EdgeNetworkService {
     private let SELF_TAG: String = "EdgeNetworkService"
     private let DEFAULT_GENERIC_ERROR_MESSAGE = "Request to Experience Edge failed with an unknown exception"
-    private let DEFAULT_NAMESPACE = "global"
+    private let DEFAULT_GENERIC_ERROR_TITLE = "Unexpected Error"
     private let recoverableNetworkErrorCodes: [Int] = [HttpResponseCodes.clientTimeout.rawValue,
                                                        HttpResponseCodes.tooManyRequests.rawValue,
                                                        HttpResponseCodes.badGateway.rawValue,
@@ -261,9 +261,9 @@ class EdgeNetworkService {
         var unwrappedErrorMessage = plainTextErrorMessage ?? DEFAULT_GENERIC_ERROR_MESSAGE
         unwrappedErrorMessage = unwrappedErrorMessage.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        let errorDictionary = [EdgeConstants.JsonKeys.Response.Error.MESSAGE: unwrappedErrorMessage,
-                               EdgeConstants.JsonKeys.Response.Error.NAMESPACE: DEFAULT_NAMESPACE]
-        guard let json = try? JSONSerialization.data(withJSONObject: errorDictionary, options: []) else {
+        let eventError = EdgeEventError(title: DEFAULT_GENERIC_ERROR_TITLE, detail: unwrappedErrorMessage)
+
+        guard let json = try? JSONEncoder().encode(eventError) else {
             Log.debug(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Failed to serialize the error message.")
             return nil
         }

--- a/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
+++ b/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
@@ -124,9 +124,6 @@ class NetworkResponseHandler {
             dispatchEventErrors(errorsArray: edgeResponse.errors, requestId: requestId)
         } else if let edgeErrorResponse = try? JSONDecoder().decode(EdgeEventError.self, from: data) {
             // generic server error, return the error as is
-            Log.warning(label: LOG_TAG,
-                        "processResponseOnError - The conversion to JSON failed for server " +
-                            "error response: \(jsonError), request id \(requestId), attempting to decode as a fatal error")
             dispatchEventErrors(errorsArray: [edgeErrorResponse], requestId: requestId)
         } else {
             Log.warning(label: LOG_TAG,

--- a/Tests/UnitTests/EdgeNetworkServiceTests.swift
+++ b/Tests/UnitTests/EdgeNetworkServiceTests.swift
@@ -224,8 +224,8 @@ class EdgeNetworkServiceTests: XCTestCase {
                                     XCTAssertTrue(self.mockResponseCallback.onErrorCalled)
                                     XCTAssertEqual(1, self.mockResponseCallback.onErrorJsonError.capacity)
                                     let errorJson = self.mockResponseCallback.onErrorJsonError[0]
-                                    XCTAssertTrue(errorJson.contains("\"namespace\":\"global\""))
-                                    XCTAssertTrue(errorJson.contains("\"message\":\"service unavailable\""))
+                                    XCTAssertTrue(errorJson.contains("\"title\":\"Unexpected Error\""))
+                                    XCTAssertTrue(errorJson.contains("\"detail\":\"service unavailable\""))
                                     expectation.fulfill()
                                  })
 
@@ -253,8 +253,8 @@ class EdgeNetworkServiceTests: XCTestCase {
                                     XCTAssertTrue(self.mockResponseCallback.onErrorCalled)
                                     XCTAssertEqual(1, self.mockResponseCallback.onErrorJsonError.capacity)
                                     let errorJson = self.mockResponseCallback.onErrorJsonError[0]
-                                    XCTAssertTrue(errorJson.contains("\"namespace\":\"global\""))
-                                    XCTAssertTrue(errorJson.contains("\"message\":\"Request to Experience Edge failed with an unknown exception\""))
+                                    XCTAssertTrue(errorJson.contains("\"title\":\"Unexpected Error\""))
+                                    XCTAssertTrue(errorJson.contains("\"detail\":\"Request to Experience Edge failed with an unknown exception\""))
                                     expectation.fulfill()
                                  })
 
@@ -284,8 +284,8 @@ class EdgeNetworkServiceTests: XCTestCase {
                                     XCTAssertTrue(self.mockResponseCallback.onErrorCalled)
                                     XCTAssertEqual(1, self.mockResponseCallback.onErrorJsonError.capacity)
                                     let errorJson = self.mockResponseCallback.onErrorJsonError[0]
-                                    XCTAssertTrue(errorJson.contains("\"namespace\":\"global\""))
-                                    XCTAssertTrue(errorJson.contains("\"message\":\"Internal Server Error\""))
+                                    XCTAssertTrue(errorJson.contains("\"title\":\"Unexpected Error\""))
+                                    XCTAssertTrue(errorJson.contains("\"detail\":\"Internal Server Error\""))
                                     expectation.fulfill()
                                  })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Generic network errors generated by the EdgeNetworkService would fail to be handled by the NetworkResponseHandler as they failed to encode to type EdgeEventError. This fix changes the generic network errors to conform to EdgeEventError so they are correctly handled and dispatched.

## Related Issue

MOB-14451

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
