### PR TITLE
Attach ImplementationDetails to XDM payload for each request

### DIFF
--- a/AEPEdge.xcodeproj/project.pbxproj
+++ b/AEPEdge.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		BF0C0935246120B200892B5D /* NetworkResponseHandlerFunctionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4D5B53524325AB700CAB6E4 /* NetworkResponseHandlerFunctionalTests.swift */; };
 		BF0C09482465E42100892B5D /* TestableEdge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0C09472465E42100892B5D /* TestableEdge.swift */; };
 		BF0F924F27476E6C00378913 /* ImplementationDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0F924E27476E6C00378913 /* ImplementationDetails.swift */; };
+		BF0F92522756A57800378913 /* ImplementationDetailsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0F92502756A3EF00378913 /* ImplementationDetailsTests.swift */; };
 		BF4A717926DDAE4C00612434 /* AssuranceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4A717826DDAE4B00612434 /* AssuranceView.swift */; };
 		BF5EECE724983B7000C72622 /* AEPDemoConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5EECA3249839DC00C72622 /* AEPDemoConstants.swift */; };
 		BF5EECE824983B7000C72622 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5EECAF249839DC00C72622 /* AppDelegate.swift */; };
@@ -322,6 +323,7 @@
 		BF0C092324608EEC00892B5D /* NoConfigFunctionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoConfigFunctionalTests.swift; sourceTree = "<group>"; };
 		BF0C09472465E42100892B5D /* TestableEdge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestableEdge.swift; sourceTree = "<group>"; };
 		BF0F924E27476E6C00378913 /* ImplementationDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplementationDetails.swift; sourceTree = "<group>"; };
+		BF0F92502756A3EF00378913 /* ImplementationDetailsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplementationDetailsTests.swift; sourceTree = "<group>"; };
 		BF4A717826DDAE4B00612434 /* AssuranceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssuranceView.swift; sourceTree = "<group>"; };
 		BF5EEC9A249839DC00C72622 /* CartViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartViewController.swift; sourceTree = "<group>"; };
 		BF5EEC9B249839DC00C72622 /* CommerceUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommerceUtil.swift; sourceTree = "<group>"; };
@@ -753,6 +755,7 @@
 				BF947F87243F2EF70057A6CC /* StoreResponsePayloadTests.swift */,
 				BF947F9424414E3E0057A6CC /* StoreResponsePayloadManagerTests.swift */,
 				1CCD27C72458CB8000E912B2 /* XDMFormattersTests.swift */,
+				BF0F92502756A3EF00378913 /* ImplementationDetailsTests.swift */,
 			);
 			name = UnitTests;
 			path = Tests/UnitTests;
@@ -1437,6 +1440,7 @@
 				BF947F9E244182B30057A6CC /* StoreResponsePayloadManagerTests.swift in Sources */,
 				D45F2E8E25EE2166000AC350 /* TestableExtensionRuntime.swift in Sources */,
 				D44BBB982492F5C900775DAC /* UnitTestAssertions.swift in Sources */,
+				BF0F92522756A57800378913 /* ImplementationDetailsTests.swift in Sources */,
 				D49A628F250AE4F500B7C4A3 /* EventHub+Test.swift in Sources */,
 				BF947F74243BA0E10057A6CC /* KonductorConfigTests.swift in Sources */,
 				D45F2E7E25EE190A000AC350 /* MockHitProcessor.swift in Sources */,

--- a/AEPEdge.xcodeproj/project.pbxproj
+++ b/AEPEdge.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		BF024B7924C6238C002131E9 /* FakeIdentityExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF024B7824C6238C002131E9 /* FakeIdentityExtension.swift */; };
 		BF0C0935246120B200892B5D /* NetworkResponseHandlerFunctionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4D5B53524325AB700CAB6E4 /* NetworkResponseHandlerFunctionalTests.swift */; };
 		BF0C09482465E42100892B5D /* TestableEdge.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0C09472465E42100892B5D /* TestableEdge.swift */; };
+		BF0F924F27476E6C00378913 /* ImplementationDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0F924E27476E6C00378913 /* ImplementationDetails.swift */; };
 		BF4A717926DDAE4C00612434 /* AssuranceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4A717826DDAE4B00612434 /* AssuranceView.swift */; };
 		BF5EECE724983B7000C72622 /* AEPDemoConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5EECA3249839DC00C72622 /* AEPDemoConstants.swift */; };
 		BF5EECE824983B7000C72622 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5EECAF249839DC00C72622 /* AppDelegate.swift */; };
@@ -320,6 +321,7 @@
 		BF024B7E24C62BED002131E9 /* IdentityStateFunctionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityStateFunctionalTests.swift; sourceTree = "<group>"; };
 		BF0C092324608EEC00892B5D /* NoConfigFunctionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoConfigFunctionalTests.swift; sourceTree = "<group>"; };
 		BF0C09472465E42100892B5D /* TestableEdge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestableEdge.swift; sourceTree = "<group>"; };
+		BF0F924E27476E6C00378913 /* ImplementationDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplementationDetails.swift; sourceTree = "<group>"; };
 		BF4A717826DDAE4B00612434 /* AssuranceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssuranceView.swift; sourceTree = "<group>"; };
 		BF5EEC9A249839DC00C72622 /* CartViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartViewController.swift; sourceTree = "<group>"; };
 		BF5EEC9B249839DC00C72622 /* CommerceUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommerceUtil.swift; sourceTree = "<group>"; };
@@ -723,6 +725,7 @@
 				D4145FB425D5D0430019EA4C /* Event+Edge.swift */,
 				D4967534251130D3001F5F95 /* Info.plist */,
 				D4D66AA2251910FB00B4866D /* AEPEdge.h */,
+				BF0F924E27476E6C00378913 /* ImplementationDetails.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -1377,6 +1380,7 @@
 			files = (
 				D4EC0DBB25E73FF10026EBAA /* EdgeState.swift in Sources */,
 				D4C6B436251A76CB0038F4F9 /* XDMFormatters.swift in Sources */,
+				BF0F924F27476E6C00378913 /* ImplementationDetails.swift in Sources */,
 				D4C6B437251A76CB0038F4F9 /* XDMProtocols.swift in Sources */,
 				D4C6B438251A76CB0038F4F9 /* Edge+PublicAPI.swift in Sources */,
 				2198DEE22604F8BE008ADB6A /* Atomic.swift in Sources */,

--- a/AEPEdge.xcodeproj/project.pbxproj
+++ b/AEPEdge.xcodeproj/project.pbxproj
@@ -725,9 +725,9 @@
 				D4EC0D9625E6CEA00026EBAA /* EdgeHitQueueing+Consent.swift */,
 				D4EC0DBA25E73FF10026EBAA /* EdgeState.swift */,
 				D4145FB425D5D0430019EA4C /* Event+Edge.swift */,
+				BF0F924E27476E6C00378913 /* ImplementationDetails.swift */,
 				D4967534251130D3001F5F95 /* Info.plist */,
 				D4D66AA2251910FB00B4866D /* AEPEdge.h */,
-				BF0F924E27476E6C00378913 /* ImplementationDetails.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -737,16 +737,17 @@
 			children = (
 				D4F74FEC2447A95400379258 /* utils */,
 				D4D5B5252432599B00CAB6E4 /* Info.plist */,
-				D4A81DEB25658F0D0042B00A /* CompletionHandlerTests.swift */,
 				2198DEE726050458008ADB6A /* AtomicTests.swift */,
-				BF947F9F244569190057A6CC /* EdgeRequestTests.swift */,
-				21FFBD5825631E3E00B48A8F /* EdgeEventWarningTests.swift */,
+				D4A81DEB25658F0D0042B00A /* CompletionHandlerTests.swift */,
 				21FFBD6B2563321600B48A8F /* EdgeEventErrorTests.swift */,
+				21FFBD5825631E3E00B48A8F /* EdgeEventWarningTests.swift */,
 				D45F2E6F25ED8EE3000AC350 /* EdgeExtensionTests.swift */,
-				D4145F3F25D1D3200019EA4C /* EdgeHitTests.swift */,
 				216989B22555376A00B2752C /* EdgeHitProcessorTests.swift */,
+				D4145F3F25D1D3200019EA4C /* EdgeHitTests.swift */,
 				D4000F34245A53FB0052C536 /* EdgeNetworkServiceTests.swift */,
+				BF947F9F244569190057A6CC /* EdgeRequestTests.swift */,
 				1CCD27C82458CB8000E912B2 /* ExperienceEventTests.swift */,
+				BF0F92502756A3EF00378913 /* ImplementationDetailsTests.swift */,
 				BF947F73243BA0E10057A6CC /* KonductorConfigTests.swift */,
 				D46553F6246A384900A150E2 /* NetworkResponseHandlerTests.swift */,
 				BF947F7D243EA1300057A6CC /* RequestBuilderTests.swift */,
@@ -755,7 +756,6 @@
 				BF947F87243F2EF70057A6CC /* StoreResponsePayloadTests.swift */,
 				BF947F9424414E3E0057A6CC /* StoreResponsePayloadManagerTests.swift */,
 				1CCD27C72458CB8000E912B2 /* XDMFormattersTests.swift */,
-				BF0F92502756A3EF00378913 /* ImplementationDetailsTests.swift */,
 			);
 			name = UnitTests;
 			path = Tests/UnitTests;

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,21 +2,21 @@ PODS:
   - AEPAssurance (3.0.0):
     - AEPCore (>= 3.1.0)
     - AEPServices (>= 3.1.0)
-  - AEPCore (3.2.4):
+  - AEPCore (3.3.1):
     - AEPRulesEngine (= 1.0.1)
-    - AEPServices (= 3.2.4)
+    - AEPServices (= 3.3.1)
   - AEPEdgeConsent (1.0.0):
     - AEPCore (>= 3.1.0)
   - AEPEdgeIdentity (1.0.0):
     - AEPCore (>= 3.1.1)
-  - AEPIdentity (3.2.4):
-    - AEPCore (= 3.2.4)
-  - AEPLifecycle (3.2.4):
-    - AEPCore (= 3.2.4)
+  - AEPIdentity (3.3.1):
+    - AEPCore (= 3.3.1)
+  - AEPLifecycle (3.3.1):
+    - AEPCore (= 3.3.1)
   - AEPRulesEngine (1.0.1)
-  - AEPServices (3.2.4)
-  - AEPSignal (3.2.4):
-    - AEPCore (= 3.2.4)
+  - AEPServices (3.3.1)
+  - AEPSignal (3.3.1):
+    - AEPCore (= 3.3.1)
 
 DEPENDENCIES:
   - AEPAssurance
@@ -42,15 +42,15 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   AEPAssurance: 18068627111e366a851dc2166239f22b665101bd
-  AEPCore: 517f1375860222a12c6226c50d0782e51d27abf2
+  AEPCore: fc1398728b6b2a4dcc8dc96455f69ec144e087c0
   AEPEdgeConsent: dd46002b0c4bf55443f5441990e799248975713e
   AEPEdgeIdentity: 40d312b4434b710a46c1738ab2a221dda4cfd67e
-  AEPIdentity: 6580a2a0359931cb7e32be934341df7d86ca73ed
-  AEPLifecycle: d822d28e71d201debfcbfc0f1c60cdee61412925
+  AEPIdentity: 40aedf425fc7cc63dde579135b8c1c65497a42d2
+  AEPLifecycle: dc131d6744a55d71bc9009d65f3b3428645cbd23
   AEPRulesEngine: 5075ed294026a12e37bd26fe260f74604d205354
-  AEPServices: ffa6f91c0799f0a8651d89978a4b2a3d024ee6c4
-  AEPSignal: 0be73545905731da4768d5ece48faf29b2cae764
+  AEPServices: c49e7b6ef17ec9f874b015f68ac7d2436235282f
+  AEPSignal: 2d0dd4775c95797bf118300b74a1d9efcdbf8650
 
 PODFILE CHECKSUM: 047a30e8b8f93dfcf239634f40f9b4e3252b2d3e
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.11.2

--- a/Sources/Edge.swift
+++ b/Sources/Edge.swift
@@ -19,7 +19,7 @@ public class Edge: NSObject, Extension {
     private let SELF_TAG = "Edge"
     private var networkService: EdgeNetworkService = EdgeNetworkService()
     private var networkResponseHandler: NetworkResponseHandler?
-    private var implementationDetails: [String: Any]?
+    private var implementationDetails: [String: Any]? = ImplementationDetails.from(nil)
     internal var state: EdgeState?
 
     // MARK: - Extension

--- a/Sources/Edge.swift
+++ b/Sources/Edge.swift
@@ -19,7 +19,7 @@ public class Edge: NSObject, Extension {
     private let SELF_TAG = "Edge"
     private var networkService: EdgeNetworkService = EdgeNetworkService()
     private var networkResponseHandler: NetworkResponseHandler?
-    private var implementationDetails: [String: Any]? = ImplementationDetails.from(nil)
+    private var implementationDetails: [String: Any]?
     internal var state: EdgeState?
 
     // MARK: - Extension
@@ -190,7 +190,7 @@ public class Edge: NSObject, Extension {
 
         if data[EdgeConstants.SharedState.STATE_OWNER] as? String == EdgeConstants.SharedState.Hub.SHARED_OWNER_NAME {
             let hubState = getSharedState(extensionName: EdgeConstants.SharedState.Hub.SHARED_OWNER_NAME, event: event)
-            implementationDetails = ImplementationDetails.from(hubState?.value ?? nil)
+            implementationDetails = ImplementationDetails.from(hubState?.value)
         }
     }
 

--- a/Sources/Edge.swift
+++ b/Sources/Edge.swift
@@ -19,7 +19,6 @@ public class Edge: NSObject, Extension {
     private let SELF_TAG = "Edge"
     private var networkService: EdgeNetworkService = EdgeNetworkService()
     private var networkResponseHandler: NetworkResponseHandler?
-    private var implementationDetails: [String: Any]?
     internal var state: EdgeState?
 
     // MARK: - Extension
@@ -53,9 +52,6 @@ public class Edge: NSObject, Extension {
         registerListener(type: EventType.genericIdentity,
                          source: EventSource.requestReset,
                          listener: handleIdentitiesReset)
-        registerListener(type: EventType.hub,
-                         source: EventSource.sharedState,
-                         listener: handleSharedStateUpdate)
     }
 
     public func onUnregistered() {
@@ -179,21 +175,6 @@ public class Edge: NSObject, Extension {
         state?.hitQueue.queue(entity: entity)
     }
 
-    /// Handles shared state update events.
-    /// Updates `ImplementationDetails` if shared state event is from `EventHub`.
-    /// - Parameter event: current shared state update event
-    func handleSharedStateUpdate(_ event: Event) {
-        guard let data = event.data, !data.isEmpty else {
-            Log.trace(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Shared State update event \(event.id.uuidString) cannot be processed as it contains no data.")
-            return
-        }
-
-        if data[EdgeConstants.SharedState.STATE_OWNER] as? String == EdgeConstants.SharedState.Hub.SHARED_OWNER_NAME {
-            let hubState = getSharedState(extensionName: EdgeConstants.SharedState.Hub.SHARED_OWNER_NAME, event: event)
-            implementationDetails = ImplementationDetails.from(hubState?.value)
-        }
-    }
-
     /// Determines if the event should be ignored by the Edge extension. This method should be called after
     /// `readyForEvent` passed.
     ///
@@ -254,7 +235,7 @@ public class Edge: NSObject, Extension {
     /// Returns current `ImplementationDetails` for this session.
     /// - Returns: the `ImplementationDetails` for this session or nil if not yet set
     private func getImplementationDetails() -> [String: Any]? {
-        return implementationDetails
+        return state?.implementationDetails
     }
 
 }

--- a/Sources/EdgeConstants.swift
+++ b/Sources/EdgeConstants.swift
@@ -130,6 +130,7 @@ enum EdgeConstants {
             static let ENVIRONMENT_APP = "app"
             static let BASE_NAMESPACE = "https://ns.adobe.com/experience/mobilesdk/ios"
             static let WRAPPER_REACT_NATIVE = "reactnative"
+            static let UNKNOWN = "unknown"
         }
     }
 

--- a/Sources/EdgeConstants.swift
+++ b/Sources/EdgeConstants.swift
@@ -99,7 +99,7 @@ enum EdgeConstants {
         static let TIMESTAMP = "timestamp"
         static let EVENT_ID = "_id"
         static let META = "meta"
-        static let IMPLEMENTATION_DETAILS = "implementationdetails"
+        static let IMPLEMENTATION_DETAILS = "implementationDetails"
 
         enum CollectMetadata {
             static let COLLECT = "collect"

--- a/Sources/EdgeConstants.swift
+++ b/Sources/EdgeConstants.swift
@@ -85,6 +85,9 @@ enum EdgeConstants {
         enum Hub {
             static let SHARED_OWNER_NAME = "com.adobe.module.eventhub"
             static let EXTENSIONS = "extensions"
+            static let WRAPPER = "wrapper"
+            static let TYPE = "type"
+            static let VERSION = "version"
         }
     }
 
@@ -96,10 +99,17 @@ enum EdgeConstants {
         static let TIMESTAMP = "timestamp"
         static let EVENT_ID = "_id"
         static let META = "meta"
+        static let IMPLEMENTATION_DETAILS = "implementationdetails"
 
         enum CollectMetadata {
             static let COLLECT = "collect"
             static let DATASET_ID = "datasetId"
+        }
+
+        enum ImplementationDetails {
+            static let VERSION = "version"
+            static let NAME = "name"
+            static let ENVIRONMENT = "environment"
         }
 
         enum Response {
@@ -115,6 +125,12 @@ enum EdgeConstants {
     enum JsonValues {
         static let CONSENT_STANDARD = "Adobe"
         static let CONSENT_VERSION = "2.0"
+
+        enum ImplementationDetails {
+            static let ENVIRONMENT_APP = "app"
+            static let BASE_NAMESPACE = "https://ns.adobe.com/experience/mobilesdk/ios"
+            static let WRAPPER_REACT_NATIVE = "reactnative"
+        }
     }
 
     enum NetworkKeys {

--- a/Sources/EdgeConstants.swift
+++ b/Sources/EdgeConstants.swift
@@ -10,7 +10,6 @@
 // governing permissions and limitations under the License.
 //
 
-import AEPCore
 import Foundation
 
 enum EdgeConstants {

--- a/Sources/EdgeConstants.swift
+++ b/Sources/EdgeConstants.swift
@@ -129,6 +129,10 @@ enum EdgeConstants {
             static let ENVIRONMENT_APP = "app"
             static let BASE_NAMESPACE = "https://ns.adobe.com/experience/mobilesdk/ios"
             static let WRAPPER_REACT_NATIVE = "reactnative"
+            static let WRAPPER_CORDOVA = "cordova"
+            static let WRAPPER_FLUTTER = "flutter"
+            static let WRAPPER_UNITY = "unity"
+            static let WRAPPER_XAMARIN = "xamarin"
             static let UNKNOWN = "unknown"
         }
     }

--- a/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
@@ -22,18 +22,21 @@ class EdgeHitProcessor: HitProcessing {
     private var getSharedState: (String, Event?) -> SharedStateResult?
     private var getXDMSharedState: (String, Event?, Bool) -> SharedStateResult?
     private var readyForEvent: (Event) -> Bool
+    private var getImplementationDetails: () -> [String: Any]?
     private var entityRetryIntervalMapping = ThreadSafeDictionary<String, TimeInterval>()
 
     init(networkService: EdgeNetworkService,
          networkResponseHandler: NetworkResponseHandler,
          getSharedState: @escaping (String, Event?) -> SharedStateResult?,
          getXDMSharedState: @escaping (String, Event?, Bool) -> SharedStateResult?,
-         readyForEvent: @escaping (Event) -> Bool) {
+         readyForEvent: @escaping (Event) -> Bool,
+         getImplementationDetails: @escaping () -> [String: Any]?) {
         self.networkService = networkService
         self.networkResponseHandler = networkResponseHandler
         self.getSharedState = getSharedState
         self.getXDMSharedState = getXDMSharedState
         self.readyForEvent = readyForEvent
+        self.getImplementationDetails = getImplementationDetails
     }
 
     // MARK: HitProcessing
@@ -78,6 +81,10 @@ class EdgeHitProcessor: HitProcessing {
                 Log.debug(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Failed to process Experience event, data was nil or empty")
                 completion(true)
                 return
+            }
+
+            if let implementationDetails = getImplementationDetails() {
+                requestBuilder.xdmPayloads[EdgeConstants.JsonKeys.IMPLEMENTATION_DETAILS] = AnyCodable(implementationDetails)
             }
 
             // Build and send the network request to Experience Edge

--- a/Sources/EdgeState.swift
+++ b/Sources/EdgeState.swift
@@ -17,13 +17,19 @@ import Foundation
 /// Updates the state of the  `Edge` extension based on the Collect consent status
 class EdgeState {
     private let SELF_TAG = "EdgeState"
+    private let queue: DispatchQueue
+    private var _implementationDetails: [String: Any]?
     private(set) var hitQueue: HitQueuing
     private(set) var hasBooted = false
     private(set) var currentCollectConsent: ConsentStatus
-    private(set) var implementationDetails: [String: Any]?
+    private(set) var implementationDetails: [String: Any]? {
+        get { queue.sync { self._implementationDetails } }
+        set { queue.async { self._implementationDetails = newValue } }
+    }
 
     /// Creates a new `EdgeState` and initializes the required properties and sets the initial collect consent
     init(hitQueue: HitQueuing) {
+        self.queue = DispatchQueue(label: "com.adobe.edgestate.queue")
         self.hitQueue = hitQueue
         self.currentCollectConsent = EdgeConstants.Defaults.COLLECT_CONSENT_PENDING
         hitQueue.handleCollectConsentChange(status: currentCollectConsent)

--- a/Sources/ImplementationDetails.swift
+++ b/Sources/ImplementationDetails.swift
@@ -30,7 +30,10 @@ enum ImplementationDetails {
         // if core version is not found set to "unknown"
         let coreVersion: String = hubState[EdgeConstants.SharedState.Hub.VERSION] as? String ?? EdgeConstants.JsonValues.ImplementationDetails.UNKNOWN
 
-        let wrapperName: String = getWrapperName(from: hubState)
+        var wrapperName: String = getWrapperName(from: hubState)
+        if !wrapperName.isEmpty {
+            wrapperName = "/\(wrapperName)"
+        }
 
         return [
             EdgeConstants.JsonKeys.ImplementationDetails.VERSION: "\(coreVersion)+\(EdgeConstants.EXTENSION_VERSION)",
@@ -47,10 +50,10 @@ enum ImplementationDetails {
         if hubState[EdgeConstants.SharedState.Hub.WRAPPER] != nil {
             let typeString = (hubState[EdgeConstants.SharedState.Hub.WRAPPER] as? [String: Any])?[EdgeConstants.SharedState.Hub.TYPE] as? String
             if let wrapperTypeString = typeString, let wrapperType = WrapperType.init(rawValue: wrapperTypeString) {
-                return wrapperType == .none ? "" : "/\(wrapperType.stringValue)"
+                return wrapperType == .none ? "" : wrapperType.stringValue
             } else {
                 // "wrapper" entry exists but "type" not found. Unexpected, set to "unknown"
-                return "/\(EdgeConstants.JsonValues.ImplementationDetails.UNKNOWN)" // note forward slash
+                return EdgeConstants.JsonValues.ImplementationDetails.UNKNOWN
             }
         }
 

--- a/Sources/ImplementationDetails.swift
+++ b/Sources/ImplementationDetails.swift
@@ -10,6 +10,7 @@
 // governing permissions and limitations under the License.
 //
 
+import AEPCore
 import Foundation
 
 enum ImplementationDetails {
@@ -44,19 +45,36 @@ enum ImplementationDetails {
     /// - Returns: wrapper type name used in the Implementation Details namespace, or an empty string if no wrapper is set
     private static func getWrapperName(from hubState: [String: Any]) -> String {
         if hubState[EdgeConstants.SharedState.Hub.WRAPPER] != nil {
-            if let wrapperType = (hubState[EdgeConstants.SharedState.Hub.WRAPPER] as? [String: Any])?[EdgeConstants.SharedState.Hub.TYPE] as? String {
-                switch wrapperType {
-                case "R": // React Native
-                    return "/\(EdgeConstants.JsonValues.ImplementationDetails.WRAPPER_REACT_NATIVE)" // note forward slash
-                default:
-                    return "" // unsupported wrapper type defaults to none
-                }
+            let typeString = (hubState[EdgeConstants.SharedState.Hub.WRAPPER] as? [String: Any])?[EdgeConstants.SharedState.Hub.TYPE] as? String
+            if let wrapperTypeString = typeString, let wrapperType = WrapperType.init(rawValue: wrapperTypeString) {
+                return wrapperType == .none ? "" : "/\(wrapperType.stringValue)"
             } else {
                 // "wrapper" entry exists but "type" not found. Unexpected, set to "unknown"
                 return "/\(EdgeConstants.JsonValues.ImplementationDetails.UNKNOWN)" // note forward slash
             }
         }
 
-        return ""
+        return "" // No "wrapper" object in shared state, default to none
+    }
+}
+
+extension WrapperType {
+    var stringValue: String {
+        switch self {
+        case .none:
+            return ""
+        case .reactNative:
+            return EdgeConstants.JsonValues.ImplementationDetails.WRAPPER_REACT_NATIVE
+        case .flutter:
+            return EdgeConstants.JsonValues.ImplementationDetails.WRAPPER_FLUTTER
+        case .cordova:
+            return EdgeConstants.JsonValues.ImplementationDetails.WRAPPER_CORDOVA
+        case .unity:
+            return EdgeConstants.JsonValues.ImplementationDetails.WRAPPER_UNITY
+        case .xamarin:
+            return EdgeConstants.JsonValues.ImplementationDetails.WRAPPER_XAMARIN
+        default:
+            return EdgeConstants.JsonValues.ImplementationDetails.UNKNOWN
+        }
     }
 }

--- a/Sources/ImplementationDetails.swift
+++ b/Sources/ImplementationDetails.swift
@@ -10,8 +10,6 @@
 // governing permissions and limitations under the License.
 //
 
-import AEPCore
-import AEPServices
 import Foundation
 
 enum ImplementationDetails {

--- a/Sources/ImplementationDetails.swift
+++ b/Sources/ImplementationDetails.swift
@@ -21,7 +21,7 @@ enum ImplementationDetails {
     /// If the Mobile Core "wrapper" exists but the "type" cannot be parsed, then "unknown" is used for the wrapper type.
     /// If the "wrapper" does not exist in `hubState`, or the found wrapper type is not supported, then the default `WrapperType.None` is used.
     ///
-    /// - Parameter hubState: the shared state of the `EventHub`
+    /// - Parameter hubState: `EventHub` shared state`
     /// - Returns: the implementation details for current session, or nil if `hubState` is nil or empty
     static func from(_ hubState: [String: Any]?) -> [String: Any]? {
         guard let hubState = hubState, !hubState.isEmpty else {
@@ -31,26 +31,34 @@ enum ImplementationDetails {
         // if core version is not found set to "unknown"
         let coreVersion: String = hubState[EdgeConstants.SharedState.Hub.VERSION] as? String ?? EdgeConstants.JsonValues.ImplementationDetails.UNKNOWN
 
-        var wrapperName: String = ""
-
-        if hubState[EdgeConstants.SharedState.Hub.WRAPPER] != nil {
-            if let wrapperType = (hubState[EdgeConstants.SharedState.Hub.WRAPPER] as? [String: Any])?[EdgeConstants.SharedState.Hub.TYPE] as? String {
-                switch wrapperType {
-                case "R": // React Native
-                    wrapperName = "/\(EdgeConstants.JsonValues.ImplementationDetails.WRAPPER_REACT_NATIVE)" // note forward slash
-                default:
-                    wrapperName = "" // unsupported wrapper type defaults to none
-                }
-            } else {
-                // "wrapper" entry exists but "type" not found. Unexpected, set to "unknown"
-                wrapperName = "/\(EdgeConstants.JsonValues.ImplementationDetails.UNKNOWN)"
-            }
-        }
+        let wrapperName: String = getWrapperName(from: hubState)
 
         return [
             EdgeConstants.JsonKeys.ImplementationDetails.VERSION: "\(coreVersion)+\(EdgeConstants.EXTENSION_VERSION)",
             EdgeConstants.JsonKeys.ImplementationDetails.NAME: "\(EdgeConstants.JsonValues.ImplementationDetails.BASE_NAMESPACE)\(wrapperName)",
             EdgeConstants.JsonKeys.ImplementationDetails.ENVIRONMENT: EdgeConstants.JsonValues.ImplementationDetails.ENVIRONMENT_APP
         ]
+    }
+
+    /// Get the wrapper named used for the Implementation Details namespace from the Event Hub shared state.
+    ///
+    /// - Parameter hubState: `EventHub` shared state
+    /// - Returns: wrapper type name used in the Implementation Details namespace, or an empty string if no wrapper is set
+    private static func getWrapperName(from hubState: [String: Any]) -> String {
+        if hubState[EdgeConstants.SharedState.Hub.WRAPPER] != nil {
+            if let wrapperType = (hubState[EdgeConstants.SharedState.Hub.WRAPPER] as? [String: Any])?[EdgeConstants.SharedState.Hub.TYPE] as? String {
+                switch wrapperType {
+                case "R": // React Native
+                    return "/\(EdgeConstants.JsonValues.ImplementationDetails.WRAPPER_REACT_NATIVE)" // note forward slash
+                default:
+                    return "" // unsupported wrapper type defaults to none
+                }
+            } else {
+                // "wrapper" entry exists but "type" not found. Unexpected, set to "unknown"
+                return "/\(EdgeConstants.JsonValues.ImplementationDetails.UNKNOWN)" // note forward slash
+            }
+        }
+
+        return ""
     }
 }

--- a/Sources/ImplementationDetails.swift
+++ b/Sources/ImplementationDetails.swift
@@ -1,0 +1,36 @@
+//
+// Copyright 2021 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+import AEPCore
+import AEPServices
+import Foundation
+
+enum ImplementationDetails {
+    static func from(_ hubState: [String: Any]?) -> [String: Any] {
+        let coreVersion = hubState?[EdgeConstants.SharedState.Hub.VERSION] as? String
+        let wrapperType = (hubState?[EdgeConstants.SharedState.Hub.WRAPPER] as? [String: Any])?[EdgeConstants.SharedState.Hub.TYPE] as? String
+        var wrapperName: String
+
+        switch wrapperType {
+        case "R":
+            wrapperName = "/\(EdgeConstants.JsonValues.ImplementationDetails.WRAPPER_REACT_NATIVE)" // note forward slash
+        default:
+            wrapperName = ""
+        }
+
+        return [
+            EdgeConstants.JsonKeys.ImplementationDetails.VERSION: "\(coreVersion ?? "")+\(EdgeConstants.EXTENSION_VERSION)",
+            EdgeConstants.JsonKeys.ImplementationDetails.NAME: "\(EdgeConstants.JsonValues.ImplementationDetails.BASE_NAMESPACE)\(wrapperName)",
+            EdgeConstants.JsonKeys.ImplementationDetails.ENVIRONMENT: EdgeConstants.JsonValues.ImplementationDetails.ENVIRONMENT_APP
+        ]
+    }
+}

--- a/Sources/ImplementationDetails.swift
+++ b/Sources/ImplementationDetails.swift
@@ -15,20 +15,40 @@ import AEPServices
 import Foundation
 
 enum ImplementationDetails {
-    static func from(_ hubState: [String: Any]?) -> [String: Any] {
-        let coreVersion = hubState?[EdgeConstants.SharedState.Hub.VERSION] as? String
-        let wrapperType = (hubState?[EdgeConstants.SharedState.Hub.WRAPPER] as? [String: Any])?[EdgeConstants.SharedState.Hub.TYPE] as? String
-        var wrapperName: String
 
-        switch wrapperType {
-        case "R":
-            wrapperName = "/\(EdgeConstants.JsonValues.ImplementationDetails.WRAPPER_REACT_NATIVE)" // note forward slash
-        default:
-            wrapperName = ""
+    /// Builds and returns the Implementation Details for the current session. Parses the given `hubState` to retrieve the Mobile Core version and wrapper type.
+    /// If no Mobile Core version is found in `hubState`, then "unknown" is used.
+    /// If the Mobile Core "wrapper" exists but the "type" cannot be parsed, then "unknown" is used for the wrapper type.
+    /// If the "wrapper" does not exist in `hubState`, or the found wrapper type is not supported, then the default `WrapperType.None` is used.
+    ///
+    /// - Parameter hubState: the shared state of the `EventHub`
+    /// - Returns: the implementation details for current session, or nil if `hubState` is nil or empty
+    static func from(_ hubState: [String: Any]?) -> [String: Any]? {
+        guard let hubState = hubState, !hubState.isEmpty else {
+            return nil
+        }
+
+        // if core version is not found set to "unknown"
+        let coreVersion: String = hubState[EdgeConstants.SharedState.Hub.VERSION] as? String ?? EdgeConstants.JsonValues.ImplementationDetails.UNKNOWN
+
+        var wrapperName: String = ""
+
+        if hubState[EdgeConstants.SharedState.Hub.WRAPPER] != nil {
+            if let wrapperType = (hubState[EdgeConstants.SharedState.Hub.WRAPPER] as? [String: Any])?[EdgeConstants.SharedState.Hub.TYPE] as? String {
+                switch wrapperType {
+                case "R": // React Native
+                    wrapperName = "/\(EdgeConstants.JsonValues.ImplementationDetails.WRAPPER_REACT_NATIVE)" // note forward slash
+                default:
+                    wrapperName = "" // unsupported wrapper type defaults to none
+                }
+            } else {
+                // "wrapper" entry exists but "type" not found. Unexpected, set to "unknown"
+                wrapperName = "/\(EdgeConstants.JsonValues.ImplementationDetails.UNKNOWN)"
+            }
         }
 
         return [
-            EdgeConstants.JsonKeys.ImplementationDetails.VERSION: "\(coreVersion ?? "")+\(EdgeConstants.EXTENSION_VERSION)",
+            EdgeConstants.JsonKeys.ImplementationDetails.VERSION: "\(coreVersion)+\(EdgeConstants.EXTENSION_VERSION)",
             EdgeConstants.JsonKeys.ImplementationDetails.NAME: "\(EdgeConstants.JsonValues.ImplementationDetails.BASE_NAMESPACE)\(wrapperName)",
             EdgeConstants.JsonKeys.ImplementationDetails.ENVIRONMENT: EdgeConstants.JsonValues.ImplementationDetails.ENVIRONMENT_APP
         ]

--- a/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
+++ b/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
@@ -269,9 +269,9 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
         XCTAssertEqual(2, requestBody["events[0].xdm.testArray[1]"] as? Int)
         XCTAssertEqual(true, requestBody["events[0].xdm.testArray[2]"] as? Bool)
         XCTAssertEqual("val", requestBody["events[0].xdm.testDictionary.key"] as? String)
-        XCTAssertEqual("app", requestBody["xdm.implementationdetails.environment"] as? String)
-        XCTAssertEqual("\(MobileCore.extensionVersion)+\(Edge.extensionVersion)", requestBody["xdm.implementationdetails.version"] as? String)
-        XCTAssertEqual("https://ns.adobe.com/experience/mobilesdk/ios", requestBody["xdm.implementationdetails.name"] as? String)
+        XCTAssertEqual("app", requestBody["xdm.implementationDetails.environment"] as? String)
+        XCTAssertEqual("\(MobileCore.extensionVersion)+\(Edge.extensionVersion)", requestBody["xdm.implementationDetails.version"] as? String)
+        XCTAssertEqual("https://ns.adobe.com/experience/mobilesdk/ios", requestBody["xdm.implementationDetails.name"] as? String)
 
         let requestUrl = resultNetworkRequests[0].url
         XCTAssertTrue(requestUrl.absoluteURL.absoluteString.hasPrefix(FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR))
@@ -319,9 +319,9 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
         XCTAssertEqual(2, requestBody["events[0].data.testDataArray[1]"] as? Int)
         XCTAssertEqual(true, requestBody["events[0].data.testDataArray[2]"] as? Bool)
         XCTAssertEqual("val", requestBody["events[0].data.testDataDictionary.key"] as? String)
-        XCTAssertEqual("app", requestBody["xdm.implementationdetails.environment"] as? String)
-        XCTAssertEqual("\(MobileCore.extensionVersion)+\(Edge.extensionVersion)", requestBody["xdm.implementationdetails.version"] as? String)
-        XCTAssertEqual("https://ns.adobe.com/experience/mobilesdk/ios", requestBody["xdm.implementationdetails.name"] as? String)
+        XCTAssertEqual("app", requestBody["xdm.implementationDetails.environment"] as? String)
+        XCTAssertEqual("\(MobileCore.extensionVersion)+\(Edge.extensionVersion)", requestBody["xdm.implementationDetails.version"] as? String)
+        XCTAssertEqual("https://ns.adobe.com/experience/mobilesdk/ios", requestBody["xdm.implementationDetails.name"] as? String)
 
         let requestUrl = resultNetworkRequests[0].url
         XCTAssertTrue(requestUrl.absoluteURL.absoluteString.hasPrefix(FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR))
@@ -370,9 +370,9 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
         XCTAssertEqual(3.42, requestBody["events[0].xdm.doubleObject"] as? Double)
         XCTAssertEqual("testInnerObject", requestBody["events[0].xdm.xdmObject.innerKey"] as? String)
         XCTAssertEqual("abc123def", requestBody["events[0].meta.collect.datasetId"] as? String)
-        XCTAssertEqual("app", requestBody["xdm.implementationdetails.environment"] as? String)
-        XCTAssertEqual("\(MobileCore.extensionVersion)+\(Edge.extensionVersion)", requestBody["xdm.implementationdetails.version"] as? String)
-        XCTAssertEqual("https://ns.adobe.com/experience/mobilesdk/ios", requestBody["xdm.implementationdetails.name"] as? String)
+        XCTAssertEqual("app", requestBody["xdm.implementationDetails.environment"] as? String)
+        XCTAssertEqual("\(MobileCore.extensionVersion)+\(Edge.extensionVersion)", requestBody["xdm.implementationDetails.version"] as? String)
+        XCTAssertEqual("https://ns.adobe.com/experience/mobilesdk/ios", requestBody["xdm.implementationDetails.name"] as? String)
 
         let requestUrl = resultNetworkRequests[0].url
         XCTAssertTrue(requestUrl.absoluteURL.absoluteString.hasPrefix(FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR))

--- a/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
+++ b/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
@@ -252,7 +252,7 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
         assertNetworkRequestsCount()
         let resultNetworkRequests = getNetworkRequestsWith(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post)
         let requestBody = getFlattenNetworkRequestBody(resultNetworkRequests[0])
-        XCTAssertEqual(16, requestBody.count)
+        XCTAssertEqual(19, requestBody.count)
         XCTAssertEqual(true, requestBody["meta.konductorConfig.streaming.enabled"] as? Bool)
         XCTAssertEqual("\u{0000}", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
         XCTAssertEqual("\n", requestBody["meta.konductorConfig.streaming.lineFeed"] as? String)
@@ -269,6 +269,9 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
         XCTAssertEqual(2, requestBody["events[0].xdm.testArray[1]"] as? Int)
         XCTAssertEqual(true, requestBody["events[0].xdm.testArray[2]"] as? Bool)
         XCTAssertEqual("val", requestBody["events[0].xdm.testDictionary.key"] as? String)
+        XCTAssertEqual("app", requestBody["xdm.implementationdetails.environment"] as? String)
+        XCTAssertEqual("\(MobileCore.extensionVersion)+\(Edge.extensionVersion)", requestBody["xdm.implementationdetails.version"] as? String)
+        XCTAssertEqual("https://ns.adobe.com/experience/mobilesdk/ios", requestBody["xdm.implementationdetails.name"] as? String)
 
         let requestUrl = resultNetworkRequests[0].url
         XCTAssertTrue(requestUrl.absoluteURL.absoluteString.hasPrefix(FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR))
@@ -298,7 +301,7 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
         assertNetworkRequestsCount()
         let resultNetworkRequests = getNetworkRequestsWith(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post)
         let requestBody = getFlattenNetworkRequestBody(resultNetworkRequests[0])
-        XCTAssertEqual(17, requestBody.count)
+        XCTAssertEqual(20, requestBody.count)
         XCTAssertEqual(true, requestBody["meta.konductorConfig.streaming.enabled"] as? Bool)
         XCTAssertEqual("\u{0000}", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
         XCTAssertEqual("\n", requestBody["meta.konductorConfig.streaming.lineFeed"] as? String)
@@ -316,6 +319,9 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
         XCTAssertEqual(2, requestBody["events[0].data.testDataArray[1]"] as? Int)
         XCTAssertEqual(true, requestBody["events[0].data.testDataArray[2]"] as? Bool)
         XCTAssertEqual("val", requestBody["events[0].data.testDataDictionary.key"] as? String)
+        XCTAssertEqual("app", requestBody["xdm.implementationdetails.environment"] as? String)
+        XCTAssertEqual("\(MobileCore.extensionVersion)+\(Edge.extensionVersion)", requestBody["xdm.implementationdetails.version"] as? String)
+        XCTAssertEqual("https://ns.adobe.com/experience/mobilesdk/ios", requestBody["xdm.implementationdetails.name"] as? String)
 
         let requestUrl = resultNetworkRequests[0].url
         XCTAssertTrue(requestUrl.absoluteURL.absoluteString.hasPrefix(FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR))
@@ -349,7 +355,7 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
         assertNetworkRequestsCount()
         let resultNetworkRequests = getNetworkRequestsWith(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post)
         let requestBody = getFlattenNetworkRequestBody(resultNetworkRequests[0])
-        XCTAssertEqual(14, requestBody.count)
+        XCTAssertEqual(17, requestBody.count)
         XCTAssertEqual(true, requestBody["meta.konductorConfig.streaming.enabled"] as? Bool)
         XCTAssertEqual("\u{0000}", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
         XCTAssertEqual("\n", requestBody["meta.konductorConfig.streaming.lineFeed"] as? String)
@@ -364,6 +370,9 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
         XCTAssertEqual(3.42, requestBody["events[0].xdm.doubleObject"] as? Double)
         XCTAssertEqual("testInnerObject", requestBody["events[0].xdm.xdmObject.innerKey"] as? String)
         XCTAssertEqual("abc123def", requestBody["events[0].meta.collect.datasetId"] as? String)
+        XCTAssertEqual("app", requestBody["xdm.implementationdetails.environment"] as? String)
+        XCTAssertEqual("\(MobileCore.extensionVersion)+\(Edge.extensionVersion)", requestBody["xdm.implementationdetails.version"] as? String)
+        XCTAssertEqual("https://ns.adobe.com/experience/mobilesdk/ios", requestBody["xdm.implementationdetails.name"] as? String)
 
         let requestUrl = resultNetworkRequests[0].url
         XCTAssertTrue(requestUrl.absoluteURL.absoluteString.hasPrefix(FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR))
@@ -478,7 +487,7 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
         var resultNetworkRequests = getNetworkRequestsWith(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post)
         XCTAssertEqual(1, resultNetworkRequests.count)
         var requestBody = getFlattenNetworkRequestBody(resultNetworkRequests[0])
-        XCTAssertEqual(9, requestBody.count)
+        XCTAssertEqual(12, requestBody.count)
         resetTestExpectations()
 
         sleep(1)
@@ -491,7 +500,7 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
         resultNetworkRequests = getNetworkRequestsWith(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post)
         XCTAssertEqual(1, resultNetworkRequests.count)
         requestBody = getFlattenNetworkRequestBody(resultNetworkRequests[0])
-        XCTAssertEqual(15, requestBody.count)
+        XCTAssertEqual(18, requestBody.count)
 
         guard let firstStore = requestBody["meta.state.entries[0].key"] as? String,
               let index = firstStore == "kndctr_testOrg_AdobeOrg_identity" ? false : true else {
@@ -536,7 +545,7 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
         var resultNetworkRequests = getNetworkRequestsWith(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post)
         XCTAssertEqual(1, resultNetworkRequests.count)
         var requestBody = getFlattenNetworkRequestBody(resultNetworkRequests[0])
-        XCTAssertEqual(9, requestBody.count)
+        XCTAssertEqual(12, requestBody.count)
         resetTestExpectations()
 
         sleep(1)
@@ -549,7 +558,7 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
         resultNetworkRequests = getNetworkRequestsWith(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post)
         XCTAssertEqual(1, resultNetworkRequests.count)
         requestBody = getFlattenNetworkRequestBody(resultNetworkRequests[0])
-        XCTAssertEqual(15, requestBody.count)
+        XCTAssertEqual(18, requestBody.count)
 
         guard let firstStore = requestBody["meta.state.entries[0].key"] as? String,
               let index = firstStore == "kndctr_testOrg_AdobeOrg_identity" ? false : true else {
@@ -590,7 +599,7 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
         var resultNetworkRequests = getNetworkRequestsWith(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post)
         XCTAssertEqual(1, resultNetworkRequests.count)
         var requestBody = getFlattenNetworkRequestBody(resultNetworkRequests[0])
-        XCTAssertEqual(9, requestBody.count)
+        XCTAssertEqual(12, requestBody.count)
         resetTestExpectations()
 
         sleep(1)
@@ -607,7 +616,7 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
         resultNetworkRequests = getNetworkRequestsWith(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post)
         XCTAssertEqual(1, resultNetworkRequests.count)
         requestBody = getFlattenNetworkRequestBody(resultNetworkRequests[0])
-        XCTAssertEqual(9, requestBody.count)
+        XCTAssertEqual(12, requestBody.count)
 
         XCTAssertNil(requestBody["meta.state"]) // no state should be appended
     }

--- a/Tests/UnitTests/EdgeExtensionTests.swift
+++ b/Tests/UnitTests/EdgeExtensionTests.swift
@@ -92,6 +92,26 @@ class EdgeExtensionTests: XCTestCase {
         XCTAssertEqual(ConsentStatus.yes, edge.state?.currentCollectConsent)
     }
 
+    func testBootup_hubSharedState_setsImplementationDetails() {
+        let hubSharedState: [String: Any] = [
+            "wrapper": ["type": "R"],
+            "version": "3.0.0"
+        ]
+        mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Hub.SHARED_OWNER_NAME, data: (hubSharedState, .set))
+
+        // dummy event to invoke readyForEvent
+        _ = edge.readyForEvent(Event(name: "Dummy event", type: EventType.custom, source: EventSource.none, data: nil))
+
+        // verify
+        XCTAssertNotNil(edge.state?.implementationDetails)
+        let expectedDetails: [String: Any] = [
+            "version": "3.0.0+\(EdgeConstants.EXTENSION_VERSION)",
+            "environment": "app",
+            "name": "https://ns.adobe.com/experience/mobilesdk/ios/reactnative"
+        ]
+        XCTAssertTrue(expectedDetails == edge.state?.implementationDetails ?? [:])
+    }
+
     // MARK: Consent update request
     func testHandleConsentUpdate_nilEmptyData_doesNotQueue() {
         mockRuntime.simulateComingEvents(

--- a/Tests/UnitTests/EdgeHitProcessorTests.swift
+++ b/Tests/UnitTests/EdgeHitProcessorTests.swift
@@ -464,6 +464,108 @@ class EdgeHitProcessorTests: XCTestCase {
         XCTAssertTrue(storeResponsePayloadManager.getActiveStores().isEmpty)
     }
 
+    // MARK: Implementation Details
+
+    // tests Implementation Details added to Experience Events
+    func testProcessHit_experienceEvent_sendsNetworkRequest_withImplementationDetails() {
+        hitProcessor = EdgeHitProcessor(networkService: networkService,
+                                        networkResponseHandler: networkResponseHandler,
+                                        getSharedState: resolveSharedState(extensionName:event:),
+                                        getXDMSharedState: resolveXDMSharedState(extensionName:event:barrier:),
+                                        readyForEvent: readyForEvent(_:),
+                                        getImplementationDetails: {
+                                            return [
+                                                "name": "https://ns.adobe.com/experience/mobilesdk/ios",
+                                                "environment": "app",
+                                                "version": "3.3.1+1.0.0"
+                                            ]
+                                        })
+
+        mockNetworkService?.connectAsyncMockReturnConnection = HttpConnection(data: "{}".data(using: .utf8), response: HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil), error: nil)
+
+        let edgeEntity = EdgeDataEntity(event: experienceEvent, identityMap: [:])
+        let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
+
+        // test
+        assertProcessHit(entity: entity, sendsNetworkRequest: true, returns: true)
+
+        guard let requestPayload = mockNetworkService?.connectAsyncCalledWithNetworkRequest?.connectPayload else {
+            XCTFail("unexpected nil request connect payload")
+            return
+        }
+
+        let payload = asFlattenDictionary(data: requestPayload)
+
+        XCTAssertEqual("https://ns.adobe.com/experience/mobilesdk/ios", payload["xdm.implementationdetails.name"] as? String)
+        XCTAssertEqual("3.3.1+1.0.0", payload["xdm.implementationdetails.version"] as? String)
+        XCTAssertEqual("app", payload["xdm.implementationdetails.environment"] as? String)
+    }
+
+    // tests Implementation Details is not added to event when nil
+    func testProcessHit_experienceEvent_sendsNetworkRequest_withOutImplementationDetails_whenNil() {
+        hitProcessor = EdgeHitProcessor(networkService: networkService,
+                                        networkResponseHandler: networkResponseHandler,
+                                        getSharedState: resolveSharedState(extensionName:event:),
+                                        getXDMSharedState: resolveXDMSharedState(extensionName:event:barrier:),
+                                        readyForEvent: readyForEvent(_:),
+                                        getImplementationDetails: { return nil })
+
+        mockNetworkService?.connectAsyncMockReturnConnection = HttpConnection(data: "{}".data(using: .utf8), response: HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil), error: nil)
+
+        let edgeEntity = EdgeDataEntity(event: experienceEvent, identityMap: [:])
+        let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
+
+        // test
+        assertProcessHit(entity: entity, sendsNetworkRequest: true, returns: true)
+
+        guard let requestPayload = mockNetworkService?.connectAsyncCalledWithNetworkRequest?.connectPayload else {
+            XCTFail("unexpected nil request connect payload")
+            return
+        }
+
+        let payload = asFlattenDictionary(data: requestPayload)
+
+        XCTAssertNil(payload["xdm.implementationdetails.name"])
+        XCTAssertNil(payload["xdm.implementationdetails.version"])
+        XCTAssertNil(payload["xdm.implementationdetails.environment"])
+    }
+
+    // tests Implementation Details is not added to Consent events
+    func testProcessHit_consentEvent_sendsNetworkRequest_withoutImplementationDetails() {
+        hitProcessor = EdgeHitProcessor(networkService: networkService,
+                                        networkResponseHandler: networkResponseHandler,
+                                        getSharedState: resolveSharedState(extensionName:event:),
+                                        getXDMSharedState: resolveXDMSharedState(extensionName:event:barrier:),
+                                        readyForEvent: readyForEvent(_:),
+                                        getImplementationDetails: {
+                                            return [
+                                                "name": "https://ns.adobe.com/experience/mobilesdk/ios",
+                                                "environment": "app",
+                                                "version": "3.3.1+1.0.0"
+                                            ]
+                                        })
+
+        mockNetworkService?.connectAsyncMockReturnConnection = HttpConnection(data: "{}".data(using: .utf8), response: HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil), error: nil)
+
+        let edgeEntity = EdgeDataEntity(event: consentUpdateEvent, identityMap: [:])
+        let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
+
+        // test
+        assertProcessHit(entity: entity, sendsNetworkRequest: true, returns: true)
+
+        guard let requestPayload = mockNetworkService?.connectAsyncCalledWithNetworkRequest?.connectPayload else {
+            XCTFail("unexpected nil request connect payload")
+            return
+        }
+
+        let payload = asFlattenDictionary(data: requestPayload)
+
+        // Implementation Details are not added to Consent events
+        XCTAssertNil(payload["xdm.implementationdetails.name"])
+        XCTAssertNil(payload["xdm.implementationdetails.version"])
+        XCTAssertNil(payload["xdm.implementationdetails.environment"])
+    }
+
     func assertProcessHit(entity: DataEntity, sendsNetworkRequest: Bool, returns: Bool, line: UInt = #line) {
         let expectation = XCTestExpectation(description: "Callback should be invoked signaling if the hit was processed or not")
 

--- a/Tests/UnitTests/EdgeHitProcessorTests.swift
+++ b/Tests/UnitTests/EdgeHitProcessorTests.swift
@@ -502,7 +502,7 @@ class EdgeHitProcessorTests: XCTestCase {
     }
 
     // tests Implementation Details is not added to event when nil
-    func testProcessHit_experienceEvent_sendsNetworkRequest_withOutImplementationDetails_whenNil() {
+    func testProcessHit_experienceEvent_sendsNetworkRequest_withoutImplementationDetails_whenNil() {
         hitProcessor = EdgeHitProcessor(networkService: networkService,
                                         networkResponseHandler: networkResponseHandler,
                                         getSharedState: resolveSharedState(extensionName:event:),

--- a/Tests/UnitTests/EdgeHitProcessorTests.swift
+++ b/Tests/UnitTests/EdgeHitProcessorTests.swift
@@ -496,9 +496,9 @@ class EdgeHitProcessorTests: XCTestCase {
 
         let payload = asFlattenDictionary(data: requestPayload)
 
-        XCTAssertEqual("https://ns.adobe.com/experience/mobilesdk/ios", payload["xdm.implementationdetails.name"] as? String)
-        XCTAssertEqual("3.3.1+1.0.0", payload["xdm.implementationdetails.version"] as? String)
-        XCTAssertEqual("app", payload["xdm.implementationdetails.environment"] as? String)
+        XCTAssertEqual("https://ns.adobe.com/experience/mobilesdk/ios", payload["xdm.implementationDetails.name"] as? String)
+        XCTAssertEqual("3.3.1+1.0.0", payload["xdm.implementationDetails.version"] as? String)
+        XCTAssertEqual("app", payload["xdm.implementationDetails.environment"] as? String)
     }
 
     // tests Implementation Details is not added to event when nil
@@ -525,9 +525,9 @@ class EdgeHitProcessorTests: XCTestCase {
 
         let payload = asFlattenDictionary(data: requestPayload)
 
-        XCTAssertNil(payload["xdm.implementationdetails.name"])
-        XCTAssertNil(payload["xdm.implementationdetails.version"])
-        XCTAssertNil(payload["xdm.implementationdetails.environment"])
+        XCTAssertNil(payload["xdm.implementationDetails.name"])
+        XCTAssertNil(payload["xdm.implementationDetails.version"])
+        XCTAssertNil(payload["xdm.implementationDetails.environment"])
     }
 
     // tests Implementation Details is not added to Consent events
@@ -561,9 +561,9 @@ class EdgeHitProcessorTests: XCTestCase {
         let payload = asFlattenDictionary(data: requestPayload)
 
         // Implementation Details are not added to Consent events
-        XCTAssertNil(payload["xdm.implementationdetails.name"])
-        XCTAssertNil(payload["xdm.implementationdetails.version"])
-        XCTAssertNil(payload["xdm.implementationdetails.environment"])
+        XCTAssertNil(payload["xdm.implementationDetails.name"])
+        XCTAssertNil(payload["xdm.implementationDetails.version"])
+        XCTAssertNil(payload["xdm.implementationDetails.environment"])
     }
 
     func assertProcessHit(entity: DataEntity, sendsNetworkRequest: Bool, returns: Bool, line: UInt = #line) {

--- a/Tests/UnitTests/EdgeHitProcessorTests.swift
+++ b/Tests/UnitTests/EdgeHitProcessorTests.swift
@@ -45,7 +45,8 @@ class EdgeHitProcessorTests: XCTestCase {
                                         networkResponseHandler: networkResponseHandler,
                                         getSharedState: resolveSharedState(extensionName:event:),
                                         getXDMSharedState: resolveXDMSharedState(extensionName:event:barrier:),
-                                        readyForEvent: readyForEvent(_:))
+                                        readyForEvent: readyForEvent(_:),
+                                        getImplementationDetails: { return nil })
     }
 
     private func resolveSharedState(extensionName: String, event: Event?) -> SharedStateResult? {
@@ -110,7 +111,8 @@ class EdgeHitProcessorTests: XCTestCase {
                                         getXDMSharedState: resolveXDMSharedState(extensionName:event:barrier:),
                                         readyForEvent: { _ -> Bool in
                                             return false
-                                        })
+                                        },
+                                        getImplementationDetails: { return nil })
 
         // test
         assertProcessHit(entity: entity, sendsNetworkRequest: false, returns: false)
@@ -131,7 +133,8 @@ class EdgeHitProcessorTests: XCTestCase {
                                             return self.resolveSharedState(extensionName: extensionName, event: event)
                                         },
                                         getXDMSharedState: resolveXDMSharedState(extensionName:event:barrier:),
-                                        readyForEvent: readyForEvent(_:))
+                                        readyForEvent: readyForEvent(_:),
+                                        getImplementationDetails: { return nil })
 
         // test
         assertProcessHit(entity: entity, sendsNetworkRequest: false, returns: true)
@@ -152,7 +155,8 @@ class EdgeHitProcessorTests: XCTestCase {
                                             return self.resolveSharedState(extensionName: extensionName, event: event)
                                         },
                                         getXDMSharedState: resolveXDMSharedState(extensionName:event:barrier:),
-                                        readyForEvent: readyForEvent(_:))
+                                        readyForEvent: readyForEvent(_:),
+                                        getImplementationDetails: { return nil })
 
         // test
         assertProcessHit(entity: entity, sendsNetworkRequest: false, returns: true)
@@ -251,7 +255,8 @@ class EdgeHitProcessorTests: XCTestCase {
                                             return nil
                                         },
                                         getXDMSharedState: resolveXDMSharedState(extensionName:event:barrier:),
-                                        readyForEvent: readyForEvent(_:))
+                                        readyForEvent: readyForEvent(_:),
+                                        getImplementationDetails: { return nil })
         mockNetworkService?.connectAsyncMockReturnConnection = HttpConnection(data: "{}".data(using: .utf8), response: HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil), error: nil)
 
         let edgeEntity = EdgeDataEntity(event: experienceEvent, identityMap: [:])
@@ -275,7 +280,8 @@ class EdgeHitProcessorTests: XCTestCase {
                                             return nil
                                         },
                                         getXDMSharedState: resolveXDMSharedState(extensionName:event:barrier:),
-                                        readyForEvent: readyForEvent(_:))
+                                        readyForEvent: readyForEvent(_:),
+                                        getImplementationDetails: { return nil })
         mockNetworkService?.connectAsyncMockReturnConnection = HttpConnection(data: "{}".data(using: .utf8), response: HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil), error: nil)
 
         let edgeEntity = EdgeDataEntity(event: experienceEvent, identityMap: [:])
@@ -299,7 +305,8 @@ class EdgeHitProcessorTests: XCTestCase {
                                             return nil
                                         },
                                         getXDMSharedState: resolveXDMSharedState(extensionName:event:barrier:),
-                                        readyForEvent: readyForEvent(_:))
+                                        readyForEvent: readyForEvent(_:),
+                                        getImplementationDetails: { return nil })
         mockNetworkService?.connectAsyncMockReturnConnection = HttpConnection(data: "{}".data(using: .utf8), response: HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil), error: nil)
 
         let edgeEntity = EdgeDataEntity(event: experienceEvent, identityMap: [:])
@@ -323,7 +330,8 @@ class EdgeHitProcessorTests: XCTestCase {
                                             return nil
                                         },
                                         getXDMSharedState: resolveXDMSharedState(extensionName:event:barrier:),
-                                        readyForEvent: readyForEvent(_:))
+                                        readyForEvent: readyForEvent(_:),
+                                        getImplementationDetails: { return nil })
         mockNetworkService?.connectAsyncMockReturnConnection = HttpConnection(data: "{}".data(using: .utf8), response: HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil), error: nil)
 
         let edgeEntity = EdgeDataEntity(event: experienceEvent, identityMap: [:])

--- a/Tests/UnitTests/ImplementationDetailsTests.swift
+++ b/Tests/UnitTests/ImplementationDetailsTests.swift
@@ -1,0 +1,192 @@
+//
+// Copyright 2021 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+@testable import AEPEdge
+import XCTest
+
+class ImplementationDetailsTests: XCTestCase {
+
+    override func setUp() {
+        continueAfterFailure = false // fail so nil checks stop execution
+    }
+
+    // MARK: from tests
+
+    func testFrom_withVersion_withWrapperReact() {
+        let hubSharedState: [String: Any] = [
+            "version": "3.3.1",
+            "wrapper": ["type": "R"]
+        ]
+
+        let details = ImplementationDetails.from(hubSharedState)
+
+        let actualResult = flattenDictionary(dict: details)
+
+        let expectedResult: [String: Any] = [
+            "name": "\(EdgeConstants.JsonValues.ImplementationDetails.BASE_NAMESPACE)/\(EdgeConstants.JsonValues.ImplementationDetails.WRAPPER_REACT_NATIVE)",
+            "environment": "app",
+            "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
+        ]
+        assertEqual(expectedResult, actualResult)
+    }
+
+    func testFrom_withVersion_withWrapperNone() {
+        let hubSharedState: [String: Any] = [
+            "version": "3.3.1",
+            "wrapper": ["type": "N"]
+        ]
+
+        let details = ImplementationDetails.from(hubSharedState)
+
+        let actualResult = flattenDictionary(dict: details)
+
+        let expectedResult: [String: Any] = [
+            "name": "\(EdgeConstants.JsonValues.ImplementationDetails.BASE_NAMESPACE)",
+            "environment": "app",
+            "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
+        ]
+        assertEqual(expectedResult, actualResult)
+    }
+
+    func testFrom_withVersion_withWrapperFlutter() {
+        let hubSharedState: [String: Any] = [
+            "version": "3.3.1",
+            "wrapper": ["type": "F"] // Flutter not supported yet, expect None type
+        ]
+
+        let details = ImplementationDetails.from(hubSharedState)
+
+        let actualResult = flattenDictionary(dict: details)
+
+        let expectedResult: [String: Any] = [
+            "name": "\(EdgeConstants.JsonValues.ImplementationDetails.BASE_NAMESPACE)",
+            "environment": "app",
+            "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
+        ]
+        assertEqual(expectedResult, actualResult)
+    }
+
+    func testFrom_withVersion_withNoWrapperType() {
+        let hubSharedState: [String: Any] = [
+            "version": "3.3.1",
+            "wrapper": ["invalid": "R"]
+        ]
+
+        let details = ImplementationDetails.from(hubSharedState)
+
+        let actualResult = flattenDictionary(dict: details)
+
+        let expectedResult: [String: Any] = [
+            "name": "\(EdgeConstants.JsonValues.ImplementationDetails.BASE_NAMESPACE)",
+            "environment": "app",
+            "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
+        ]
+        assertEqual(expectedResult, actualResult)
+    }
+
+    func testFrom_withVersion_withWrongWrapperType() {
+        let hubSharedState: [String: Any] = [
+            "version": "3.3.1",
+            "wrapper": "not map type" // wrong type, expected [String: Any]
+        ]
+
+        let details = ImplementationDetails.from(hubSharedState)
+
+        let actualResult = flattenDictionary(dict: details)
+
+        let expectedResult: [String: Any] = [
+            "name": "\(EdgeConstants.JsonValues.ImplementationDetails.BASE_NAMESPACE)",
+            "environment": "app",
+            "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
+        ]
+        assertEqual(expectedResult, actualResult)
+    }
+
+    func testFrom_withVersion_withNoWrapper() {
+        let hubSharedState: [String: Any] = [
+            "version": "3.3.1"
+        ]
+
+        let details = ImplementationDetails.from(hubSharedState)
+
+        let actualResult = flattenDictionary(dict: details)
+
+        let expectedResult: [String: Any] = [
+            "name": "\(EdgeConstants.JsonValues.ImplementationDetails.BASE_NAMESPACE)",
+            "environment": "app",
+            "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
+        ]
+        assertEqual(expectedResult, actualResult)
+    }
+
+    func testFrom_withWrongVersionType_withNoWrapper() {
+        let hubSharedState: [String: Any] = [
+            "version": ["not string type": "3.3.1"] // wrong type, expected String
+        ]
+
+        let details = ImplementationDetails.from(hubSharedState)
+
+        let actualResult = flattenDictionary(dict: details)
+
+        let expectedResult: [String: Any] = [
+            "name": "\(EdgeConstants.JsonValues.ImplementationDetails.BASE_NAMESPACE)",
+            "environment": "app",
+            "version": "+\(EdgeConstants.EXTENSION_VERSION)"
+        ]
+        assertEqual(expectedResult, actualResult)
+    }
+
+    func testFrom_withNoVersion_withWrapperReact() {
+        let hubSharedState: [String: Any] = [
+            "wrapper": ["type": "R"]
+        ]
+
+        let details = ImplementationDetails.from(hubSharedState)
+
+        let actualResult = flattenDictionary(dict: details)
+
+        let expectedResult: [String: Any] = [
+            "name": "\(EdgeConstants.JsonValues.ImplementationDetails.BASE_NAMESPACE)/\(EdgeConstants.JsonValues.ImplementationDetails.WRAPPER_REACT_NATIVE)",
+            "environment": "app",
+            "version": "+\(EdgeConstants.EXTENSION_VERSION)"
+        ]
+        assertEqual(expectedResult, actualResult)
+    }
+
+    func testFrom_withEmptyHubState() {
+        let hubSharedState: [String: Any] = [:]
+
+        let details = ImplementationDetails.from(hubSharedState)
+
+        let actualResult = flattenDictionary(dict: details)
+
+        let expectedResult: [String: Any] = [
+            "name": "\(EdgeConstants.JsonValues.ImplementationDetails.BASE_NAMESPACE)",
+            "environment": "app",
+            "version": "+\(EdgeConstants.EXTENSION_VERSION)"
+        ]
+        assertEqual(expectedResult, actualResult)
+    }
+
+    func testFrom_withNilHubState() {
+        let details = ImplementationDetails.from(nil)
+
+        let actualResult = flattenDictionary(dict: details)
+
+        let expectedResult: [String: Any] = [
+            "name": "\(EdgeConstants.JsonValues.ImplementationDetails.BASE_NAMESPACE)",
+            "environment": "app",
+            "version": "+\(EdgeConstants.EXTENSION_VERSION)"
+        ]
+        assertEqual(expectedResult, actualResult)
+    }
+}

--- a/Tests/UnitTests/ImplementationDetailsTests.swift
+++ b/Tests/UnitTests/ImplementationDetailsTests.swift
@@ -14,6 +14,8 @@
 import XCTest
 
 class ImplementationDetailsTests: XCTestCase {
+    private let BASE_NAMESPACE = "https://ns.adobe.com/experience/mobilesdk/ios"
+    private let WRAPPER_REACT_NATIVE = "reactnative"
 
     override func setUp() {
         continueAfterFailure = false // fail so nil checks stop execution
@@ -32,7 +34,7 @@ class ImplementationDetailsTests: XCTestCase {
         let actualResult = flattenDictionary(dict: details)
 
         let expectedResult: [String: Any] = [
-            "name": "\(EdgeConstants.JsonValues.ImplementationDetails.BASE_NAMESPACE)/\(EdgeConstants.JsonValues.ImplementationDetails.WRAPPER_REACT_NATIVE)",
+            "name": "\(BASE_NAMESPACE)/\(WRAPPER_REACT_NATIVE)",
             "environment": "app",
             "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
         ]
@@ -50,7 +52,7 @@ class ImplementationDetailsTests: XCTestCase {
         let actualResult = flattenDictionary(dict: details)
 
         let expectedResult: [String: Any] = [
-            "name": "\(EdgeConstants.JsonValues.ImplementationDetails.BASE_NAMESPACE)",
+            "name": "\(BASE_NAMESPACE)",
             "environment": "app",
             "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
         ]
@@ -68,7 +70,7 @@ class ImplementationDetailsTests: XCTestCase {
         let actualResult = flattenDictionary(dict: details)
 
         let expectedResult: [String: Any] = [
-            "name": "\(EdgeConstants.JsonValues.ImplementationDetails.BASE_NAMESPACE)",
+            "name": "\(BASE_NAMESPACE)",
             "environment": "app",
             "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
         ]
@@ -86,7 +88,7 @@ class ImplementationDetailsTests: XCTestCase {
         let actualResult = flattenDictionary(dict: details)
 
         let expectedResult: [String: Any] = [
-            "name": "\(EdgeConstants.JsonValues.ImplementationDetails.BASE_NAMESPACE)",
+            "name": "\(BASE_NAMESPACE)",
             "environment": "app",
             "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
         ]
@@ -104,7 +106,7 @@ class ImplementationDetailsTests: XCTestCase {
         let actualResult = flattenDictionary(dict: details)
 
         let expectedResult: [String: Any] = [
-            "name": "\(EdgeConstants.JsonValues.ImplementationDetails.BASE_NAMESPACE)",
+            "name": "\(BASE_NAMESPACE)",
             "environment": "app",
             "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
         ]
@@ -121,7 +123,7 @@ class ImplementationDetailsTests: XCTestCase {
         let actualResult = flattenDictionary(dict: details)
 
         let expectedResult: [String: Any] = [
-            "name": "\(EdgeConstants.JsonValues.ImplementationDetails.BASE_NAMESPACE)",
+            "name": "\(BASE_NAMESPACE)",
             "environment": "app",
             "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
         ]
@@ -138,7 +140,7 @@ class ImplementationDetailsTests: XCTestCase {
         let actualResult = flattenDictionary(dict: details)
 
         let expectedResult: [String: Any] = [
-            "name": "\(EdgeConstants.JsonValues.ImplementationDetails.BASE_NAMESPACE)",
+            "name": "\(BASE_NAMESPACE)",
             "environment": "app",
             "version": "+\(EdgeConstants.EXTENSION_VERSION)"
         ]
@@ -155,7 +157,7 @@ class ImplementationDetailsTests: XCTestCase {
         let actualResult = flattenDictionary(dict: details)
 
         let expectedResult: [String: Any] = [
-            "name": "\(EdgeConstants.JsonValues.ImplementationDetails.BASE_NAMESPACE)/\(EdgeConstants.JsonValues.ImplementationDetails.WRAPPER_REACT_NATIVE)",
+            "name": "\(BASE_NAMESPACE)/\(WRAPPER_REACT_NATIVE)",
             "environment": "app",
             "version": "+\(EdgeConstants.EXTENSION_VERSION)"
         ]
@@ -170,7 +172,7 @@ class ImplementationDetailsTests: XCTestCase {
         let actualResult = flattenDictionary(dict: details)
 
         let expectedResult: [String: Any] = [
-            "name": "\(EdgeConstants.JsonValues.ImplementationDetails.BASE_NAMESPACE)",
+            "name": "\(BASE_NAMESPACE)",
             "environment": "app",
             "version": "+\(EdgeConstants.EXTENSION_VERSION)"
         ]
@@ -183,7 +185,7 @@ class ImplementationDetailsTests: XCTestCase {
         let actualResult = flattenDictionary(dict: details)
 
         let expectedResult: [String: Any] = [
-            "name": "\(EdgeConstants.JsonValues.ImplementationDetails.BASE_NAMESPACE)",
+            "name": "\(BASE_NAMESPACE)",
             "environment": "app",
             "version": "+\(EdgeConstants.EXTENSION_VERSION)"
         ]

--- a/Tests/UnitTests/ImplementationDetailsTests.swift
+++ b/Tests/UnitTests/ImplementationDetailsTests.swift
@@ -29,7 +29,10 @@ class ImplementationDetailsTests: XCTestCase {
             "wrapper": ["type": "R"]
         ]
 
-        let details = ImplementationDetails.from(hubSharedState)
+        guard let details = ImplementationDetails.from(hubSharedState) else {
+            XCTFail("ImplementationDetails returned nil when not expected.")
+            return
+        }
 
         let actualResult = flattenDictionary(dict: details)
 
@@ -47,7 +50,10 @@ class ImplementationDetailsTests: XCTestCase {
             "wrapper": ["type": "N"]
         ]
 
-        let details = ImplementationDetails.from(hubSharedState)
+        guard let details = ImplementationDetails.from(hubSharedState) else {
+            XCTFail("ImplementationDetails returned nil when not expected.")
+            return
+        }
 
         let actualResult = flattenDictionary(dict: details)
 
@@ -65,7 +71,10 @@ class ImplementationDetailsTests: XCTestCase {
             "wrapper": ["type": "F"] // Flutter not supported yet, expect None type
         ]
 
-        let details = ImplementationDetails.from(hubSharedState)
+        guard let details = ImplementationDetails.from(hubSharedState) else {
+            XCTFail("ImplementationDetails returned nil when not expected.")
+            return
+        }
 
         let actualResult = flattenDictionary(dict: details)
 
@@ -83,12 +92,15 @@ class ImplementationDetailsTests: XCTestCase {
             "wrapper": ["invalid": "R"]
         ]
 
-        let details = ImplementationDetails.from(hubSharedState)
+        guard let details = ImplementationDetails.from(hubSharedState) else {
+            XCTFail("ImplementationDetails returned nil when not expected.")
+            return
+        }
 
         let actualResult = flattenDictionary(dict: details)
 
         let expectedResult: [String: Any] = [
-            "name": "\(BASE_NAMESPACE)",
+            "name": "\(BASE_NAMESPACE)/unknown",
             "environment": "app",
             "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
         ]
@@ -101,12 +113,15 @@ class ImplementationDetailsTests: XCTestCase {
             "wrapper": "not map type" // wrong type, expected [String: Any]
         ]
 
-        let details = ImplementationDetails.from(hubSharedState)
+        guard let details = ImplementationDetails.from(hubSharedState) else {
+            XCTFail("ImplementationDetails returned nil when not expected.")
+            return
+        }
 
         let actualResult = flattenDictionary(dict: details)
 
         let expectedResult: [String: Any] = [
-            "name": "\(BASE_NAMESPACE)",
+            "name": "\(BASE_NAMESPACE)/unknown",
             "environment": "app",
             "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
         ]
@@ -118,7 +133,10 @@ class ImplementationDetailsTests: XCTestCase {
             "version": "3.3.1"
         ]
 
-        let details = ImplementationDetails.from(hubSharedState)
+        guard let details = ImplementationDetails.from(hubSharedState) else {
+            XCTFail("ImplementationDetails returned nil when not expected.")
+            return
+        }
 
         let actualResult = flattenDictionary(dict: details)
 
@@ -135,14 +153,17 @@ class ImplementationDetailsTests: XCTestCase {
             "version": ["not string type": "3.3.1"] // wrong type, expected String
         ]
 
-        let details = ImplementationDetails.from(hubSharedState)
+        guard let details = ImplementationDetails.from(hubSharedState) else {
+            XCTFail("ImplementationDetails returned nil when not expected.")
+            return
+        }
 
         let actualResult = flattenDictionary(dict: details)
 
         let expectedResult: [String: Any] = [
             "name": "\(BASE_NAMESPACE)",
             "environment": "app",
-            "version": "+\(EdgeConstants.EXTENSION_VERSION)"
+            "version": "unknown+\(EdgeConstants.EXTENSION_VERSION)"
         ]
         assertEqual(expectedResult, actualResult)
     }
@@ -152,14 +173,17 @@ class ImplementationDetailsTests: XCTestCase {
             "wrapper": ["type": "R"]
         ]
 
-        let details = ImplementationDetails.from(hubSharedState)
+        guard let details = ImplementationDetails.from(hubSharedState) else {
+            XCTFail("ImplementationDetails returned nil when not expected.")
+            return
+        }
 
         let actualResult = flattenDictionary(dict: details)
 
         let expectedResult: [String: Any] = [
             "name": "\(BASE_NAMESPACE)/\(WRAPPER_REACT_NATIVE)",
             "environment": "app",
-            "version": "+\(EdgeConstants.EXTENSION_VERSION)"
+            "version": "unknown+\(EdgeConstants.EXTENSION_VERSION)"
         ]
         assertEqual(expectedResult, actualResult)
     }
@@ -167,28 +191,10 @@ class ImplementationDetailsTests: XCTestCase {
     func testFrom_withEmptyHubState() {
         let hubSharedState: [String: Any] = [:]
 
-        let details = ImplementationDetails.from(hubSharedState)
-
-        let actualResult = flattenDictionary(dict: details)
-
-        let expectedResult: [String: Any] = [
-            "name": "\(BASE_NAMESPACE)",
-            "environment": "app",
-            "version": "+\(EdgeConstants.EXTENSION_VERSION)"
-        ]
-        assertEqual(expectedResult, actualResult)
+        XCTAssertNil(ImplementationDetails.from(hubSharedState))
     }
 
     func testFrom_withNilHubState() {
-        let details = ImplementationDetails.from(nil)
-
-        let actualResult = flattenDictionary(dict: details)
-
-        let expectedResult: [String: Any] = [
-            "name": "\(BASE_NAMESPACE)",
-            "environment": "app",
-            "version": "+\(EdgeConstants.EXTENSION_VERSION)"
-        ]
-        assertEqual(expectedResult, actualResult)
+        XCTAssertNil(ImplementationDetails.from(nil))
     }
 }

--- a/Tests/UnitTests/ImplementationDetailsTests.swift
+++ b/Tests/UnitTests/ImplementationDetailsTests.swift
@@ -16,33 +16,16 @@ import XCTest
 class ImplementationDetailsTests: XCTestCase {
     private let BASE_NAMESPACE = "https://ns.adobe.com/experience/mobilesdk/ios"
     private let WRAPPER_REACT_NATIVE = "reactnative"
+    private let WRAPPER_CORDOVA = "cordova"
+    private let WRAPPER_FLUTTER = "flutter"
+    private let WRAPPER_UNITY = "unity"
+    private let WRAPPER_XAMARIN = "xamarin"
 
     override func setUp() {
         continueAfterFailure = false // fail so nil checks stop execution
     }
 
     // MARK: from tests
-
-    func testFrom_withVersion_withWrapperReact() {
-        let hubSharedState: [String: Any] = [
-            "version": "3.3.1",
-            "wrapper": ["type": "R"]
-        ]
-
-        guard let details = ImplementationDetails.from(hubSharedState) else {
-            XCTFail("ImplementationDetails returned nil when not expected.")
-            return
-        }
-
-        let actualResult = flattenDictionary(dict: details)
-
-        let expectedResult: [String: Any] = [
-            "name": "\(BASE_NAMESPACE)/\(WRAPPER_REACT_NATIVE)",
-            "environment": "app",
-            "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
-        ]
-        assertEqual(expectedResult, actualResult)
-    }
 
     func testFrom_withVersion_withWrapperNone() {
         let hubSharedState: [String: Any] = [
@@ -65,10 +48,10 @@ class ImplementationDetailsTests: XCTestCase {
         assertEqual(expectedResult, actualResult)
     }
 
-    func testFrom_withVersion_withWrapperFlutter() {
+    func testFrom_withVersion_withWrapperReact() {
         let hubSharedState: [String: Any] = [
             "version": "3.3.1",
-            "wrapper": ["type": "F"] // Flutter not supported yet, expect None type
+            "wrapper": ["type": "R"]
         ]
 
         guard let details = ImplementationDetails.from(hubSharedState) else {
@@ -78,6 +61,112 @@ class ImplementationDetailsTests: XCTestCase {
 
         let actualResult = flattenDictionary(dict: details)
 
+        let expectedResult: [String: Any] = [
+            "name": "\(BASE_NAMESPACE)/\(WRAPPER_REACT_NATIVE)",
+            "environment": "app",
+            "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
+        ]
+        assertEqual(expectedResult, actualResult)
+    }
+
+    func testFrom_withVersion_withWrapperFlutter() {
+        let hubSharedState: [String: Any] = [
+            "version": "3.3.1",
+            "wrapper": ["type": "F"]
+        ]
+
+        guard let details = ImplementationDetails.from(hubSharedState) else {
+            XCTFail("ImplementationDetails returned nil when not expected.")
+            return
+        }
+
+        let actualResult = flattenDictionary(dict: details)
+
+        let expectedResult: [String: Any] = [
+            "name": "\(BASE_NAMESPACE)/\(WRAPPER_FLUTTER)",
+            "environment": "app",
+            "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
+        ]
+        assertEqual(expectedResult, actualResult)
+    }
+
+    func testFrom_withVersion_withWrapperCordova() {
+        let hubSharedState: [String: Any] = [
+            "version": "3.3.1",
+            "wrapper": ["type": "C"]
+        ]
+
+        guard let details = ImplementationDetails.from(hubSharedState) else {
+            XCTFail("ImplementationDetails returned nil when not expected.")
+            return
+        }
+
+        let actualResult = flattenDictionary(dict: details)
+
+        let expectedResult: [String: Any] = [
+            "name": "\(BASE_NAMESPACE)/\(WRAPPER_CORDOVA)",
+            "environment": "app",
+            "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
+        ]
+        assertEqual(expectedResult, actualResult)
+    }
+
+    func testFrom_withVersion_withWrapperUnity() {
+        let hubSharedState: [String: Any] = [
+            "version": "3.3.1",
+            "wrapper": ["type": "U"]
+        ]
+
+        guard let details = ImplementationDetails.from(hubSharedState) else {
+            XCTFail("ImplementationDetails returned nil when not expected.")
+            return
+        }
+
+        let actualResult = flattenDictionary(dict: details)
+
+        let expectedResult: [String: Any] = [
+            "name": "\(BASE_NAMESPACE)/\(WRAPPER_UNITY)",
+            "environment": "app",
+            "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
+        ]
+        assertEqual(expectedResult, actualResult)
+    }
+
+    func testFrom_withVersion_withWrapperXamarin() {
+        let hubSharedState: [String: Any] = [
+            "version": "3.3.1",
+            "wrapper": ["type": "X"]
+        ]
+
+        guard let details = ImplementationDetails.from(hubSharedState) else {
+            XCTFail("ImplementationDetails returned nil when not expected.")
+            return
+        }
+
+        let actualResult = flattenDictionary(dict: details)
+
+        let expectedResult: [String: Any] = [
+            "name": "\(BASE_NAMESPACE)/\(WRAPPER_XAMARIN)",
+            "environment": "app",
+            "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
+        ]
+        assertEqual(expectedResult, actualResult)
+    }
+
+    func testFrom_withVersion_withWrapperUnknown() {
+        let hubSharedState: [String: Any] = [
+            "version": "3.3.1",
+            "wrapper": ["type": "A"] // unknown type
+        ]
+
+        guard let details = ImplementationDetails.from(hubSharedState) else {
+            XCTFail("ImplementationDetails returned nil when not expected.")
+            return
+        }
+
+        let actualResult = flattenDictionary(dict: details)
+
+        // WrapperType enum will default to .none for unknown values
         let expectedResult: [String: Any] = [
             "name": "\(BASE_NAMESPACE)",
             "environment": "app",
@@ -89,7 +178,7 @@ class ImplementationDetailsTests: XCTestCase {
     func testFrom_withVersion_withNoWrapperType() {
         let hubSharedState: [String: Any] = [
             "version": "3.3.1",
-            "wrapper": ["invalid": "R"]
+            "wrapper": ["invalid": "R"] // no "type" element
         ]
 
         guard let details = ImplementationDetails.from(hubSharedState) else {
@@ -140,6 +229,7 @@ class ImplementationDetailsTests: XCTestCase {
 
         let actualResult = flattenDictionary(dict: details)
 
+        // No "wrapper" object defaults to None
         let expectedResult: [String: Any] = [
             "name": "\(BASE_NAMESPACE)",
             "environment": "app",

--- a/Tests/UnitTests/ImplementationDetailsTests.swift
+++ b/Tests/UnitTests/ImplementationDetailsTests.swift
@@ -28,151 +28,32 @@ class ImplementationDetailsTests: XCTestCase {
     // MARK: from tests
 
     func testFrom_withVersion_withWrapperNone() {
-        let hubSharedState: [String: Any] = [
-            "version": "3.3.1",
-            "wrapper": ["type": "N"]
-        ]
-
-        guard let details = ImplementationDetails.from(hubSharedState) else {
-            XCTFail("ImplementationDetails returned nil when not expected.")
-            return
-        }
-
-        let actualResult = flattenDictionary(dict: details)
-
-        let expectedResult: [String: Any] = [
-            "name": "\(BASE_NAMESPACE)",
-            "environment": "app",
-            "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
-        ]
-        assertEqual(expectedResult, actualResult)
+        assertWrapper(inputType: "N", outputNamespace: BASE_NAMESPACE)
     }
 
     func testFrom_withVersion_withWrapperReact() {
-        let hubSharedState: [String: Any] = [
-            "version": "3.3.1",
-            "wrapper": ["type": "R"]
-        ]
-
-        guard let details = ImplementationDetails.from(hubSharedState) else {
-            XCTFail("ImplementationDetails returned nil when not expected.")
-            return
-        }
-
-        let actualResult = flattenDictionary(dict: details)
-
-        let expectedResult: [String: Any] = [
-            "name": "\(BASE_NAMESPACE)/\(WRAPPER_REACT_NATIVE)",
-            "environment": "app",
-            "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
-        ]
-        assertEqual(expectedResult, actualResult)
+        assertWrapper(inputType: "R", outputNamespace: "\(BASE_NAMESPACE)/\(WRAPPER_REACT_NATIVE)")
     }
 
     func testFrom_withVersion_withWrapperFlutter() {
-        let hubSharedState: [String: Any] = [
-            "version": "3.3.1",
-            "wrapper": ["type": "F"]
-        ]
-
-        guard let details = ImplementationDetails.from(hubSharedState) else {
-            XCTFail("ImplementationDetails returned nil when not expected.")
-            return
-        }
-
-        let actualResult = flattenDictionary(dict: details)
-
-        let expectedResult: [String: Any] = [
-            "name": "\(BASE_NAMESPACE)/\(WRAPPER_FLUTTER)",
-            "environment": "app",
-            "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
-        ]
-        assertEqual(expectedResult, actualResult)
+        assertWrapper(inputType: "F", outputNamespace: "\(BASE_NAMESPACE)/\(WRAPPER_FLUTTER)")
     }
 
     func testFrom_withVersion_withWrapperCordova() {
-        let hubSharedState: [String: Any] = [
-            "version": "3.3.1",
-            "wrapper": ["type": "C"]
-        ]
-
-        guard let details = ImplementationDetails.from(hubSharedState) else {
-            XCTFail("ImplementationDetails returned nil when not expected.")
-            return
-        }
-
-        let actualResult = flattenDictionary(dict: details)
-
-        let expectedResult: [String: Any] = [
-            "name": "\(BASE_NAMESPACE)/\(WRAPPER_CORDOVA)",
-            "environment": "app",
-            "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
-        ]
-        assertEqual(expectedResult, actualResult)
+        assertWrapper(inputType: "C", outputNamespace: "\(BASE_NAMESPACE)/\(WRAPPER_CORDOVA)")
     }
 
     func testFrom_withVersion_withWrapperUnity() {
-        let hubSharedState: [String: Any] = [
-            "version": "3.3.1",
-            "wrapper": ["type": "U"]
-        ]
-
-        guard let details = ImplementationDetails.from(hubSharedState) else {
-            XCTFail("ImplementationDetails returned nil when not expected.")
-            return
-        }
-
-        let actualResult = flattenDictionary(dict: details)
-
-        let expectedResult: [String: Any] = [
-            "name": "\(BASE_NAMESPACE)/\(WRAPPER_UNITY)",
-            "environment": "app",
-            "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
-        ]
-        assertEqual(expectedResult, actualResult)
+        assertWrapper(inputType: "U", outputNamespace: "\(BASE_NAMESPACE)/\(WRAPPER_UNITY)")
     }
 
     func testFrom_withVersion_withWrapperXamarin() {
-        let hubSharedState: [String: Any] = [
-            "version": "3.3.1",
-            "wrapper": ["type": "X"]
-        ]
-
-        guard let details = ImplementationDetails.from(hubSharedState) else {
-            XCTFail("ImplementationDetails returned nil when not expected.")
-            return
-        }
-
-        let actualResult = flattenDictionary(dict: details)
-
-        let expectedResult: [String: Any] = [
-            "name": "\(BASE_NAMESPACE)/\(WRAPPER_XAMARIN)",
-            "environment": "app",
-            "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
-        ]
-        assertEqual(expectedResult, actualResult)
+        assertWrapper(inputType: "X", outputNamespace: "\(BASE_NAMESPACE)/\(WRAPPER_XAMARIN)")
     }
 
     func testFrom_withVersion_withWrapperUnknown() {
-        let hubSharedState: [String: Any] = [
-            "version": "3.3.1",
-            "wrapper": ["type": "A"] // unknown type
-        ]
-
-        guard let details = ImplementationDetails.from(hubSharedState) else {
-            XCTFail("ImplementationDetails returned nil when not expected.")
-            return
-        }
-
-        let actualResult = flattenDictionary(dict: details)
-
-        // WrapperType enum will default to .none for unknown values
-        let expectedResult: [String: Any] = [
-            "name": "\(BASE_NAMESPACE)",
-            "environment": "app",
-            "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
-        ]
-        assertEqual(expectedResult, actualResult)
+        // An unknown type defaults to None
+        assertWrapper(inputType: "A", outputNamespace: BASE_NAMESPACE)
     }
 
     func testFrom_withVersion_withNoWrapperType() {
@@ -181,19 +62,9 @@ class ImplementationDetailsTests: XCTestCase {
             "wrapper": ["invalid": "R"] // no "type" element
         ]
 
-        guard let details = ImplementationDetails.from(hubSharedState) else {
-            XCTFail("ImplementationDetails returned nil when not expected.")
-            return
-        }
-
-        let actualResult = flattenDictionary(dict: details)
-
-        let expectedResult: [String: Any] = [
-            "name": "\(BASE_NAMESPACE)/unknown",
-            "environment": "app",
-            "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
-        ]
-        assertEqual(expectedResult, actualResult)
+        assertImplementationDetails(inputState: hubSharedState,
+                                    outputNamespace: "\(BASE_NAMESPACE)/unknown",
+                                    outputVersion: "3.3.1+\(EdgeConstants.EXTENSION_VERSION)")
     }
 
     func testFrom_withVersion_withWrongWrapperType() {
@@ -202,19 +73,9 @@ class ImplementationDetailsTests: XCTestCase {
             "wrapper": "not map type" // wrong type, expected [String: Any]
         ]
 
-        guard let details = ImplementationDetails.from(hubSharedState) else {
-            XCTFail("ImplementationDetails returned nil when not expected.")
-            return
-        }
-
-        let actualResult = flattenDictionary(dict: details)
-
-        let expectedResult: [String: Any] = [
-            "name": "\(BASE_NAMESPACE)/unknown",
-            "environment": "app",
-            "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
-        ]
-        assertEqual(expectedResult, actualResult)
+        assertImplementationDetails(inputState: hubSharedState,
+                                    outputNamespace: "\(BASE_NAMESPACE)/unknown",
+                                    outputVersion: "3.3.1+\(EdgeConstants.EXTENSION_VERSION)")
     }
 
     func testFrom_withVersion_withNoWrapper() {
@@ -222,20 +83,9 @@ class ImplementationDetailsTests: XCTestCase {
             "version": "3.3.1"
         ]
 
-        guard let details = ImplementationDetails.from(hubSharedState) else {
-            XCTFail("ImplementationDetails returned nil when not expected.")
-            return
-        }
-
-        let actualResult = flattenDictionary(dict: details)
-
-        // No "wrapper" object defaults to None
-        let expectedResult: [String: Any] = [
-            "name": "\(BASE_NAMESPACE)",
-            "environment": "app",
-            "version": "3.3.1+\(EdgeConstants.EXTENSION_VERSION)"
-        ]
-        assertEqual(expectedResult, actualResult)
+        assertImplementationDetails(inputState: hubSharedState,
+                                    outputNamespace: "\(BASE_NAMESPACE)",
+                                    outputVersion: "3.3.1+\(EdgeConstants.EXTENSION_VERSION)")
     }
 
     func testFrom_withWrongVersionType_withNoWrapper() {
@@ -243,19 +93,9 @@ class ImplementationDetailsTests: XCTestCase {
             "version": ["not string type": "3.3.1"] // wrong type, expected String
         ]
 
-        guard let details = ImplementationDetails.from(hubSharedState) else {
-            XCTFail("ImplementationDetails returned nil when not expected.")
-            return
-        }
-
-        let actualResult = flattenDictionary(dict: details)
-
-        let expectedResult: [String: Any] = [
-            "name": "\(BASE_NAMESPACE)",
-            "environment": "app",
-            "version": "unknown+\(EdgeConstants.EXTENSION_VERSION)"
-        ]
-        assertEqual(expectedResult, actualResult)
+        assertImplementationDetails(inputState: hubSharedState,
+                                    outputNamespace: "\(BASE_NAMESPACE)",
+                                    outputVersion: "unknown+\(EdgeConstants.EXTENSION_VERSION)")
     }
 
     func testFrom_withNoVersion_withWrapperReact() {
@@ -263,19 +103,9 @@ class ImplementationDetailsTests: XCTestCase {
             "wrapper": ["type": "R"]
         ]
 
-        guard let details = ImplementationDetails.from(hubSharedState) else {
-            XCTFail("ImplementationDetails returned nil when not expected.")
-            return
-        }
-
-        let actualResult = flattenDictionary(dict: details)
-
-        let expectedResult: [String: Any] = [
-            "name": "\(BASE_NAMESPACE)/\(WRAPPER_REACT_NATIVE)",
-            "environment": "app",
-            "version": "unknown+\(EdgeConstants.EXTENSION_VERSION)"
-        ]
-        assertEqual(expectedResult, actualResult)
+        assertImplementationDetails(inputState: hubSharedState,
+                                    outputNamespace: "\(BASE_NAMESPACE)/\(WRAPPER_REACT_NATIVE)",
+                                    outputVersion: "unknown+\(EdgeConstants.EXTENSION_VERSION)")
     }
 
     func testFrom_withEmptyHubState() {
@@ -286,5 +116,48 @@ class ImplementationDetailsTests: XCTestCase {
 
     func testFrom_withNilHubState() {
         XCTAssertNil(ImplementationDetails.from(nil))
+    }
+
+    /// Assert given wrapper type produces the expected Implementation Details namespace.
+    /// - Parameters:
+    ///   - inputType: the wrapper type tag
+    ///   - outputNamespace: the expected Implementation Details namespace URI
+    ///   - file: the file which called this method
+    ///   - line: the line in `file` which calls this method
+    private func assertWrapper(inputType: String, outputNamespace: String, file: StaticString = #file, line: UInt = #line) {
+        let hubSharedState: [String: Any] = [
+            "version": "3.3.1",
+            "wrapper": ["type": inputType]
+        ]
+
+        assertImplementationDetails(inputState: hubSharedState,
+                                    outputNamespace: outputNamespace,
+                                    outputVersion: "3.3.1+\(EdgeConstants.EXTENSION_VERSION)",
+                                    file: (file),
+                                    line: line)
+    }
+
+    /// Assert given shared state data produces the expected Implementation Details namespace and version.
+    /// - Parameters:
+    ///   - inputState: the input shared state
+    ///   - outputNamespace: the expected Implementation Details namespace URI
+    ///   - outputVersion: the expected Implementation Details version
+    ///   - file: the file which called this method
+    ///   - line: the line in `file` which calls this method
+    private func assertImplementationDetails(inputState: [String: Any], outputNamespace: String, outputVersion: String, file: StaticString = #file, line: UInt = #line) {
+
+        guard let details = ImplementationDetails.from(inputState) else {
+            XCTFail("ImplementationDetails returned nil when not expected for test.", file: (file), line: line)
+            return
+        }
+
+        let actualResult = flattenDictionary(dict: details)
+
+        let expectedResult: [String: Any] = [
+            "name": "\(outputNamespace)",
+            "environment": "app",
+            "version": "\(outputVersion)"
+        ]
+        assertEqual(expectedResult, actualResult, file: (file), line: line)
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Attaches ImplementationDetails to the XDM payload of each Experience Event.

See: [XDM ImplementationDetails schema](https://github.com/adobe/xdm/blob/014824a8b12d5828a6967781471f3a9765fcfbd1/components/datatypes/industry-verticals/implementationdetails.schema.json)
internal ticket: MOB-15365

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
