### PR TITLE
Remove forward slash suffix if found in edge.domain

### DIFF
--- a/Sources/EdgeNetworkHandlers/EdgeEndpoint.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeEndpoint.swift
@@ -60,7 +60,7 @@ struct EdgeEndpoint {
         guard let domain = domain, !domain.isEmpty else {
             return EdgeConstants.NetworkKeys.EDGE_DEFAULT_DOMAIN
         }
-        return domain.lowercased().deletePrefix("https://").deletePrefix("http://")
+        return domain.lowercased().deletePrefix("https://").deletePrefix("http://").deleteSuffix("/")
     }
 }
 
@@ -70,9 +70,19 @@ extension String {
     /// - Parameter prefix: the prefix to remove from the current string
     /// - Returns: the current string with the given `prefix` removed
     func deletePrefix(_ prefix: String) -> String {
-        guard self.hasPrefix(prefix.lowercased()) else {
+        guard self.hasPrefix(prefix) else {
             return self
         }
         return String(self.dropFirst(prefix.count))
+    }
+
+    /// Remove the given `suffix` from the current string.
+    /// - Parameter suffix: the suffix to remove from the current string
+    /// - Returns: the current string with the given `suffix` removed if found
+    func deleteSuffix(_ suffix: String) -> String {
+        guard self.hasSuffix(suffix) else {
+            return self
+        }
+        return String(self.dropLast(suffix.count))
     }
 }

--- a/Tests/UnitTests/EdgeEndpointTests.swift
+++ b/Tests/UnitTests/EdgeEndpointTests.swift
@@ -109,6 +109,13 @@ class EdgeEndpointTests: XCTestCase {
         XCTAssertEqual(expected, endpoint.endpointUrl)
     }
 
+    func testCustomDomainRemovesSlashSuffix() {
+        let domain = "my.awesome.site/"
+        let endpoint = EdgeEndpoint(type: .production, optionalDomain: domain)
+        let expected = "https://my.awesome.site\(EdgeConstants.NetworkKeys.EDGE_ENDPOINT_PATH)"
+        XCTAssertEqual(expected, endpoint.endpointUrl)
+    }
+
     func testCustomEmptyDomainUsesDefault() {
         let domain = ""
         let endpoint = EdgeEndpoint(type: .production, optionalDomain: domain)
@@ -118,6 +125,13 @@ class EdgeEndpointTests: XCTestCase {
 
     func testCustomDomainIsLowercase() {
         let domain = "MY.LOUD.SITE"
+        let endpoint = EdgeEndpoint(type: .production, optionalDomain: domain)
+        let expected = "https://my.loud.site\(EdgeConstants.NetworkKeys.EDGE_ENDPOINT_PATH)"
+        XCTAssertEqual(expected, endpoint.endpointUrl)
+    }
+
+    func testCustomDomainIsLowercaseAndPrefixRemoved() {
+        let domain = "HTTP://MY.LOUD.SITE"
         let endpoint = EdgeEndpoint(type: .production, optionalDomain: domain)
         let expected = "https://my.loud.site\(EdgeConstants.NetworkKeys.EDGE_ENDPOINT_PATH)"
         XCTAssertEqual(expected, endpoint.endpointUrl)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove any trailing forward slash from custom edge.domain before building the request URL.

Internal ticket: Addendum to MOB-14959.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
