### PR TITLE
Use edge.domain directly if set, without 'cleaning'

### DIFF
--- a/Sources/EdgeNetworkHandlers/EdgeEndpoint.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeEndpoint.swift
@@ -40,7 +40,12 @@ struct EdgeEndpoint {
     ///   - type: the `EdgeEnvironmentType` for the `EdgeEndpoint`
     ///   - optionalDomain: an optional custom domain for the `EdgeEndpoint`. If not set the default domain is used.
     init(type: EdgeEnvironmentType, optionalDomain: String? = nil) {
-        let domain = EdgeEndpoint.cleanDomain(optionalDomain)
+        let domain: String
+        if let unwrappedDomain = optionalDomain, !unwrappedDomain.isEmpty {
+            domain = unwrappedDomain
+        } else {
+            domain = EdgeConstants.NetworkKeys.EDGE_DEFAULT_DOMAIN
+        }
 
         switch type {
         case .production:
@@ -51,28 +56,5 @@ struct EdgeEndpoint {
             // Edge Integration endpoint does not support custom domains, so there is just the one URL
             endpointUrl = EdgeConstants.NetworkKeys.EDGE_ENDPOINT_INTEGRATION
         }
-    }
-
-    /// Clean the given `domain` name by removing any HTTP scheme prefix and lowercasing the name.
-    /// - Parameter domain: a URI domain name
-    /// - Returns: the given `domain` lowercased and with any HTTP scheme removed
-    private static func cleanDomain(_ domain: String?) -> String {
-        guard let domain = domain, !domain.isEmpty else {
-            return EdgeConstants.NetworkKeys.EDGE_DEFAULT_DOMAIN
-        }
-        return domain.lowercased().deletePrefix("https://").deletePrefix("http://")
-    }
-}
-
-extension String {
-
-    /// Remove the given `prefix` from the current string.
-    /// - Parameter prefix: the prefix to remove from the current string
-    /// - Returns: the current string with the given `prefix` removed
-    func deletePrefix(_ prefix: String) -> String {
-        guard self.hasPrefix(prefix.lowercased()) else {
-            return self
-        }
-        return String(self.dropFirst(prefix.count))
     }
 }

--- a/Tests/UnitTests/EdgeEndpointTests.swift
+++ b/Tests/UnitTests/EdgeEndpointTests.swift
@@ -95,31 +95,10 @@ class EdgeEndpointTests: XCTestCase {
         XCTAssertEqual(expected, endpoint.endpointUrl)
     }
 
-    func testCustomDomainRemovesHttpsPrefix() {
-        let domain = "https://my.awesome.site"
-        let endpoint = EdgeEndpoint(type: .production, optionalDomain: domain)
-        let expected = "https://my.awesome.site\(EdgeConstants.NetworkKeys.EDGE_ENDPOINT_PATH)"
-        XCTAssertEqual(expected, endpoint.endpointUrl)
-    }
-
-    func testCustomDomainRemovesHttpPrefix() {
-        let domain = "http://my.awesome.site"
-        let endpoint = EdgeEndpoint(type: .production, optionalDomain: domain)
-        let expected = "https://my.awesome.site\(EdgeConstants.NetworkKeys.EDGE_ENDPOINT_PATH)"
-        XCTAssertEqual(expected, endpoint.endpointUrl)
-    }
-
     func testCustomEmptyDomainUsesDefault() {
         let domain = ""
         let endpoint = EdgeEndpoint(type: .production, optionalDomain: domain)
         let expected = "https://\(EdgeConstants.NetworkKeys.EDGE_DEFAULT_DOMAIN)\(EdgeConstants.NetworkKeys.EDGE_ENDPOINT_PATH)"
-        XCTAssertEqual(expected, endpoint.endpointUrl)
-    }
-
-    func testCustomDomainIsLowercase() {
-        let domain = "MY.LOUD.SITE"
-        let endpoint = EdgeEndpoint(type: .production, optionalDomain: domain)
-        let expected = "https://my.loud.site\(EdgeConstants.NetworkKeys.EDGE_ENDPOINT_PATH)"
         XCTAssertEqual(expected, endpoint.endpointUrl)
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use 'edge.domain' configuration as set by user, if available. Do not attempt to "clean" domain string.

internal ticket: part of MOB-14959

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
