### PR TITLE
[MOB-15894] Format Experience Event timestamps in UTC with millisecond precision

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -10,36 +10,36 @@ project 'AEPEdge.xcodeproj'
 pod 'SwiftLint', '0.44.0'
 
 target 'AEPEdge' do
-  pod 'AEPCore'
+  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
 end
 
 target 'UnitTests' do
-  pod 'AEPCore'
+  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
 end
 
 target 'FunctionalTests' do
-  pod 'AEPCore'
+  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
   pod 'AEPEdgeIdentity'
   pod 'AEPEdgeConsent'
 end
 
 target 'AEPDemoAppSwiftUI' do
-  pod 'AEPCore'
-  pod 'AEPServices'
-  pod 'AEPLifecycle'
-  pod 'AEPIdentity'
-  pod 'AEPSignal'
+  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
+  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
+  pod 'AEPLifecycle', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
+  pod 'AEPIdentity', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
+  pod 'AEPSignal', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
   pod 'AEPEdgeIdentity'
   pod 'AEPEdgeConsent'
   pod 'AEPAssurance'
 end
 
 target 'AEPCommerceDemoApp' do
-  pod 'AEPCore'
-  pod 'AEPServices'
-  pod 'AEPLifecycle'
-  pod 'AEPIdentity'
-  pod 'AEPSignal'
+  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
+  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
+  pod 'AEPLifecycle', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
+  pod 'AEPIdentity', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
+  pod 'AEPSignal', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
   pod 'AEPEdgeIdentity'
   pod 'AEPAssurance'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,59 +2,88 @@ PODS:
   - AEPAssurance (3.0.0):
     - AEPCore (>= 3.1.0)
     - AEPServices (>= 3.1.0)
-  - AEPCore (3.3.2):
-    - AEPRulesEngine (= 1.0.1)
-    - AEPServices (= 3.3.2)
+  - AEPCore (3.4.2):
+    - AEPRulesEngine (>= 1.1.0)
+    - AEPServices (>= 3.4.2)
   - AEPEdgeConsent (1.0.0):
     - AEPCore (>= 3.1.0)
   - AEPEdgeIdentity (1.0.0):
     - AEPCore (>= 3.1.1)
-  - AEPIdentity (3.3.2):
-    - AEPCore (= 3.3.2)
-  - AEPLifecycle (3.3.2):
-    - AEPCore (= 3.3.2)
-  - AEPRulesEngine (1.0.1)
-  - AEPServices (3.3.2)
-  - AEPSignal (3.3.2):
-    - AEPCore (= 3.3.2)
+  - AEPIdentity (3.4.2):
+    - AEPCore (>= 3.4.2)
+  - AEPLifecycle (3.4.2):
+    - AEPCore (>= 3.4.2)
+  - AEPRulesEngine (1.1.0)
+  - AEPServices (3.4.2)
+  - AEPSignal (3.4.2):
+    - AEPCore (>= 3.4.2)
   - SwiftLint (0.44.0)
 
 DEPENDENCIES:
   - AEPAssurance
-  - AEPCore
+  - AEPCore (from `https://github.com/adobe/aepsdk-core-ios`, branch `dev-v3.4.3`)
   - AEPEdgeConsent
   - AEPEdgeIdentity
-  - AEPIdentity
-  - AEPLifecycle
-  - AEPServices
-  - AEPSignal
+  - AEPIdentity (from `https://github.com/adobe/aepsdk-core-ios`, branch `dev-v3.4.3`)
+  - AEPLifecycle (from `https://github.com/adobe/aepsdk-core-ios`, branch `dev-v3.4.3`)
+  - AEPServices (from `https://github.com/adobe/aepsdk-core-ios`, branch `dev-v3.4.3`)
+  - AEPSignal (from `https://github.com/adobe/aepsdk-core-ios`, branch `dev-v3.4.3`)
   - SwiftLint (= 0.44.0)
 
 SPEC REPOS:
   trunk:
     - AEPAssurance
-    - AEPCore
     - AEPEdgeConsent
     - AEPEdgeIdentity
-    - AEPIdentity
-    - AEPLifecycle
     - AEPRulesEngine
-    - AEPServices
-    - AEPSignal
     - SwiftLint
+
+EXTERNAL SOURCES:
+  AEPCore:
+    :branch: dev-v3.4.3
+    :git: https://github.com/adobe/aepsdk-core-ios
+  AEPIdentity:
+    :branch: dev-v3.4.3
+    :git: https://github.com/adobe/aepsdk-core-ios
+  AEPLifecycle:
+    :branch: dev-v3.4.3
+    :git: https://github.com/adobe/aepsdk-core-ios
+  AEPServices:
+    :branch: dev-v3.4.3
+    :git: https://github.com/adobe/aepsdk-core-ios
+  AEPSignal:
+    :branch: dev-v3.4.3
+    :git: https://github.com/adobe/aepsdk-core-ios
+
+CHECKOUT OPTIONS:
+  AEPCore:
+    :commit: b0987c04c2cffdaa6391d703b1be79ed9a798999
+    :git: https://github.com/adobe/aepsdk-core-ios
+  AEPIdentity:
+    :commit: b0987c04c2cffdaa6391d703b1be79ed9a798999
+    :git: https://github.com/adobe/aepsdk-core-ios
+  AEPLifecycle:
+    :commit: b0987c04c2cffdaa6391d703b1be79ed9a798999
+    :git: https://github.com/adobe/aepsdk-core-ios
+  AEPServices:
+    :commit: b0987c04c2cffdaa6391d703b1be79ed9a798999
+    :git: https://github.com/adobe/aepsdk-core-ios
+  AEPSignal:
+    :commit: b0987c04c2cffdaa6391d703b1be79ed9a798999
+    :git: https://github.com/adobe/aepsdk-core-ios
 
 SPEC CHECKSUMS:
   AEPAssurance: 18068627111e366a851dc2166239f22b665101bd
-  AEPCore: 922aa0eac3fa4f0bc3fbdd3f1b9f7cb7b65e440d
+  AEPCore: b01856bf24972e4720cb0511a358d1e68067252a
   AEPEdgeConsent: dd46002b0c4bf55443f5441990e799248975713e
   AEPEdgeIdentity: 40d312b4434b710a46c1738ab2a221dda4cfd67e
-  AEPIdentity: 5f7af2b937713ff82aa0788a6ee0b7e0d8fcd86e
-  AEPLifecycle: 8200df6d8f4579d4ee1eb924d6c46247b1fe102b
-  AEPRulesEngine: 5075ed294026a12e37bd26fe260f74604d205354
-  AEPServices: 7ac2a251b71a422ddaee316eac39f7a66a0d3a90
-  AEPSignal: f80b7d568388ac9b6119e8396c5126ff7284dd1a
+  AEPIdentity: fbf755560afcbb0acd66cd5b6a1c147530fca5f6
+  AEPLifecycle: 1e0e843465fb143f8d8949dcf06de169d5c26f62
+  AEPRulesEngine: bb2927ed5501ddf9754c66e97f8d2b1cf8e33b19
+  AEPServices: 3214311f239c8cdc6267d757200b05ec0ab05878
+  AEPSignal: be3a4789b492f4d5a5aef7408f30ff8e866d1d79
   SwiftLint: e96c0a8c770c7ebbc4d36c55baf9096bb65c4584
 
-PODFILE CHECKSUM: c64278d65566dda2b081faf2a99804d3f89fbee6
+PODFILE CHECKSUM: f2763b0e9275cc9712829783d327d216fbc965ec
 
 COCOAPODS: 1.11.2

--- a/SampleApps/AEPCommerceDemoApp/xdmlib/MobileSDKCommerceSchema.swift
+++ b/SampleApps/AEPCommerceDemoApp/xdmlib/MobileSDKCommerceSchema.swift
@@ -54,6 +54,6 @@ extension MobileSDKCommerceSchema {
 		if let unwrapped = eventType { try container.encode(unwrapped, forKey: .eventType) }
 		if let unwrapped = identityMap { try container.encode(unwrapped, forKey: .identityMap) }
 		if let unwrapped = productListItems { try container.encode(unwrapped, forKey: .productListItems) }
-		if let unwrapped = XDMFormatters.dateToISO8601String(from: timestamp) { try container.encode(unwrapped, forKey: .timestamp) }
+        if let unwrapped = timestamp?.getISO8601UTCDateWithMilliseconds() { try container.encode(unwrapped, forKey: .timestamp) }
 	}
 }

--- a/SampleApps/AEPCommerceDemoApp/xdmlib/MobileSDKLifecycleSchema.swift
+++ b/SampleApps/AEPCommerceDemoApp/xdmlib/MobileSDKLifecycleSchema.swift
@@ -60,6 +60,6 @@ extension MobileSDKLifecycleSchema {
 		if let unwrapped = eventType { try container.encode(unwrapped, forKey: .eventType) }
 		if let unwrapped = identityMap { try container.encode(unwrapped, forKey: .identityMap) }
 		if let unwrapped = placeContext { try container.encode(unwrapped, forKey: .placeContext) }
-		if let unwrapped = XDMFormatters.dateToISO8601String(from: timestamp) { try container.encode(unwrapped, forKey: .timestamp) }
+        if let unwrapped = timestamp?.getISO8601UTCDateWithMilliseconds() { try container.encode(unwrapped, forKey: .timestamp) }
 	}
 }

--- a/SampleApps/AEPCommerceDemoApp/xdmlib/PlaceContext.swift
+++ b/SampleApps/AEPCommerceDemoApp/xdmlib/PlaceContext.swift
@@ -38,7 +38,7 @@ extension PlaceContext:Encodable {
 	public func encode(to encoder: Encoder) throws {
 		var container = encoder.container(keyedBy: CodingKeys.self)
 		if let unwrapped = geo { try container.encode(unwrapped, forKey: .geo) }
-		if let unwrapped = XDMFormatters.dateToISO8601String(from: localTime) { try container.encode(unwrapped, forKey: .localTime) }
+        if let unwrapped = localTime?.getISO8601Date() { try container.encode(unwrapped, forKey: .localTime) }
 		if let unwrapped = localTimezoneOffset { try container.encode(unwrapped, forKey: .localTimezoneOffset) }
 	}
 }

--- a/Sources/EdgeNetworkHandlers/RequestBuilder.swift
+++ b/Sources/EdgeNetworkHandlers/RequestBuilder.swift
@@ -113,7 +113,7 @@ class RequestBuilder {
                 if xdm[EdgeConstants.JsonKeys.TIMESTAMP] == nil ||
                     (xdm[EdgeConstants.JsonKeys.TIMESTAMP] as? String)?.isEmpty ?? true {
                     // if no timestamp is provided in the xdm event payload, set the event timestamp
-                    xdm[EdgeConstants.JsonKeys.TIMESTAMP] = ISO8601DateFormatter().string(from: event.timestamp)
+                    xdm[EdgeConstants.JsonKeys.TIMESTAMP] = event.timestamp.getISO8601UTCDateWithMilliseconds()
                 }
 
                 xdm[EdgeConstants.JsonKeys.EVENT_ID] = event.id.uuidString

--- a/Sources/xdm/XDMFormatters.swift
+++ b/Sources/xdm/XDMFormatters.swift
@@ -22,6 +22,7 @@ public enum XDMFormatters {
     ///   - Date: A timestamp and it must not be null
     /// - Returns: The timestamp formatted to a string in the format of 'yyyy-MM-dd'T'HH:mm:ssXXX',
     ///            or an empty string if Date  is null
+    @available(*, deprecated, message: "Use function getISO8601UTCDateWithMilliseconds() in Date class extension from AEPServices module instead.")
     public static func dateToISO8601String(from: Date?) -> String? {
         if let unwrapped = from {
             return unwrapped.asISO8601String()
@@ -37,6 +38,7 @@ public enum XDMFormatters {
     ///   - Date:  A timestamp and it must not be null
     /// - Returns: The timestamp formatted to a string in the format of 'yyyy-MM-dd',
     ///            or an empty string if Date  is null
+    @available(*, deprecated, message: "Use function getISO8601FullDate() in Date class extension from AEPServices module instead.")
     public static func dateToFullDateString(from: Date?) -> String? {
         if let unwrapped = from {
             return unwrapped.asFullDate()

--- a/Tests/FunctionalTests/util/TestXDMSchema.swift
+++ b/Tests/FunctionalTests/util/TestXDMSchema.swift
@@ -51,6 +51,6 @@ extension TestXDMSchema: Encodable {
         if let unwrapped = intObject { try container.encode(unwrapped, forKey: .intObject) }
         if let unwrapped = boolObject { try container.encode(unwrapped, forKey: .boolObject) }
         if let unwrapped = doubleObject { try container.encode(unwrapped, forKey: .doubleObject) }
-        if let unwrapped = XDMFormatters.dateToISO8601String(from: timestamp) { try container.encode(unwrapped, forKey: .timestamp) }
+        if let unwrapped = timestamp?.getISO8601UTCDateWithMilliseconds() { try container.encode(unwrapped, forKey: .timestamp) }
     }
 }

--- a/Tests/TestUtils/TestUtils.swift
+++ b/Tests/TestUtils/TestUtils.swift
@@ -59,7 +59,11 @@ func flattenDictionary(dict: [String: Any]) -> [String: Any] {
 /// Convert an timestamp as Date to an iso 8601 formatted date string.
 /// - Parameter timestamp
 func timestampToISO8601(_ timestamp: Date) -> String {
-    return ISO8601DateFormatter().string(from: timestamp)
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+    return formatter.string(from: timestamp)
 }
 
 /// Attempts to convert provided data to [String: Any] using JSONSerialization.

--- a/Tests/TestUtils/TestableExtensionRuntime.swift
+++ b/Tests/TestUtils/TestableExtensionRuntime.swift
@@ -18,6 +18,11 @@ import Foundation
 /// Enable easy setup for the input and verification of the output of an extension
 /// See also AEPCore/Mocks
 public class TestableExtensionRuntime: ExtensionRuntime {
+
+    public func getHistoricalEvents(_ requests: [EventHistoryRequest], enforceOrder: Bool, handler: @escaping ([EventHistoryResult]) -> Void) {
+        handler([])
+    }
+
     public var listeners: [String: EventListener] = [:]
     public var dispatchedEvents: [Event] = []
     public var createdSharedStates: [[String: Any]?] = []

--- a/Tests/UnitTests/RequestBuilderTests.swift
+++ b/Tests/UnitTests/RequestBuilderTests.swift
@@ -273,7 +273,7 @@ class RequestBuilderTests: XCTestCase {
         XCTAssertNotNil(requestPayload)
         XCTAssertEqual(1, requestPayload?.events?.count)
         let flattenEvent = flattenDictionary(dict: requestPayload?.events?[0]["xdm"]?.dictionaryValue ?? [:])
-        XCTAssertEqual(XDMFormatters.dateToISO8601String(from: event.timestamp), flattenEvent["timestamp"] as? String)
+        XCTAssertEqual(timestampToISO8601(event.timestamp), flattenEvent["timestamp"] as? String)
     }
 
     func testGetPayloadWithExperienceEventsSetsEventTimestampWhenProvidedTimestampIsMissing() {
@@ -293,7 +293,7 @@ class RequestBuilderTests: XCTestCase {
         XCTAssertNotNil(requestPayload)
         XCTAssertEqual(1, requestPayload?.events?.count)
         let flattenEvent = flattenDictionary(dict: requestPayload?.events?[0]["xdm"]?.dictionaryValue ?? [:])
-        XCTAssertEqual(XDMFormatters.dateToISO8601String(from: event.timestamp), flattenEvent["timestamp"] as? String)
+        XCTAssertEqual(timestampToISO8601(event.timestamp), flattenEvent["timestamp"] as? String)
     }
 
     private func buildIdentityMap() -> [String: Any]? {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use AEPServices Date+Format to format Experience Event timestamps as ISO 8601 dates in UTC with millisecond precision.
Add deprecated warning to XDMFormatters functions with message to use Date+Format instead.

IMPORTANT: Changed AEPCore location in Podfile to use Git branch `dev-v3.4.3`. The Podfile will need to be updated once AEPCore production is released but before AEPEdge is released.

![Screen Shot 2022-03-21 at 1 18 51 PM](https://user-images.githubusercontent.com/40409666/159357610-8e5afab3-8ca1-4936-afad-0c3136d31494.png)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
