### PR TITLE
Bump version to 1.4.0

### DIFF
--- a/AEPEdge.podspec
+++ b/AEPEdge.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AEPEdge"
-  s.version          = "1.3.0"
+  s.version          = "1.3.1"
   s.summary          = "Experience Platform Edge extension for Adobe Experience Platform Mobile SDK. Written and maintained by Adobe."
 
   s.description      = <<-DESC
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.swift_version = '5.1'
 
   s.pod_target_xcconfig = { 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }
-  s.dependency 'AEPCore', '>= 3.3.2'
+  s.dependency 'AEPCore', '>= 3.5.0'
   s.dependency 'AEPEdgeIdentity'
 
   s.source_files = 'Sources/**/*.swift'

--- a/AEPEdge.podspec
+++ b/AEPEdge.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AEPEdge"
-  s.version          = "1.3.1"
+  s.version          = "1.4.0"
   s.summary          = "Experience Platform Edge extension for Adobe Experience Platform Mobile SDK. Written and maintained by Adobe."
 
   s.description      = <<-DESC

--- a/AEPEdge.xcodeproj/project.pbxproj
+++ b/AEPEdge.xcodeproj/project.pbxproj
@@ -1642,7 +1642,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.edge;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1676,7 +1676,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.0;
+				MARKETING_VERSION = 1.3.1;
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.edge;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/AEPEdge.xcodeproj/project.pbxproj
+++ b/AEPEdge.xcodeproj/project.pbxproj
@@ -1642,7 +1642,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.4.0;
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.edge;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1676,7 +1676,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.4.0;
 				OTHER_LDFLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.edge;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .library(name: "AEPEdge", targets: ["AEPEdge"])
     ],
     dependencies: [
-        .package(url: "https://github.com/adobe/aepsdk-core-ios.git", .upToNextMajor(from: "3.3.2"))
+        .package(url: "https://github.com/adobe/aepsdk-core-ios.git", .upToNextMajor(from: "3.5.0"))
     ],
     targets: [
         .target(name: "AEPEdge",

--- a/Podfile
+++ b/Podfile
@@ -10,36 +10,36 @@ project 'AEPEdge.xcodeproj'
 pod 'SwiftLint', '0.44.0'
 
 target 'AEPEdge' do
-  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
+  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
 end
 
 target 'UnitTests' do
-  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
+  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
 end
 
 target 'FunctionalTests' do
-  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
+  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
   pod 'AEPEdgeIdentity'
   pod 'AEPEdgeConsent'
 end
 
 target 'AEPDemoAppSwiftUI' do
-  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
-  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
-  pod 'AEPLifecycle', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
-  pod 'AEPIdentity', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
-  pod 'AEPSignal', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
+  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
+  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
+  pod 'AEPLifecycle', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
+  pod 'AEPIdentity', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
+  pod 'AEPSignal', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
   pod 'AEPEdgeIdentity'
   pod 'AEPEdgeConsent'
   pod 'AEPAssurance'
 end
 
 target 'AEPCommerceDemoApp' do
-  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
-  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
-  pod 'AEPLifecycle', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
-  pod 'AEPIdentity', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
-  pod 'AEPSignal', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'dev-v3.4.3'
+  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
+  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
+  pod 'AEPLifecycle', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
+  pod 'AEPIdentity', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
+  pod 'AEPSignal', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
   pod 'AEPEdgeIdentity'
   pod 'AEPAssurance'
 end

--- a/Podfile
+++ b/Podfile
@@ -26,9 +26,6 @@ end
 target 'AEPDemoAppSwiftUI' do
   pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
   pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
-  pod 'AEPLifecycle', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
-  pod 'AEPIdentity', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
-  pod 'AEPSignal', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
   pod 'AEPEdgeIdentity'
   pod 'AEPEdgeConsent'
   pod 'AEPAssurance'
@@ -37,9 +34,6 @@ end
 target 'AEPCommerceDemoApp' do
   pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
   pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
-  pod 'AEPLifecycle', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
-  pod 'AEPIdentity', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
-  pod 'AEPSignal', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
   pod 'AEPEdgeIdentity'
   pod 'AEPAssurance'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,33 +1,33 @@
 PODS:
-  - AEPAssurance (3.0.0):
+  - AEPAssurance (3.0.1):
     - AEPCore (>= 3.1.0)
     - AEPServices (>= 3.1.0)
-  - AEPCore (3.4.2):
+  - AEPCore (3.5.0):
     - AEPRulesEngine (>= 1.1.0)
-    - AEPServices (>= 3.4.2)
+    - AEPServices (>= 3.5.0)
   - AEPEdgeConsent (1.0.0):
     - AEPCore (>= 3.1.0)
   - AEPEdgeIdentity (1.0.0):
     - AEPCore (>= 3.1.1)
-  - AEPIdentity (3.4.2):
-    - AEPCore (>= 3.4.2)
-  - AEPLifecycle (3.4.2):
-    - AEPCore (>= 3.4.2)
+  - AEPIdentity (3.5.0):
+    - AEPCore (>= 3.5.0)
+  - AEPLifecycle (3.5.0):
+    - AEPCore (>= 3.5.0)
   - AEPRulesEngine (1.1.0)
-  - AEPServices (3.4.2)
-  - AEPSignal (3.4.2):
-    - AEPCore (>= 3.4.2)
+  - AEPServices (3.5.0)
+  - AEPSignal (3.5.0):
+    - AEPCore (>= 3.5.0)
   - SwiftLint (0.44.0)
 
 DEPENDENCIES:
   - AEPAssurance
-  - AEPCore (from `https://github.com/adobe/aepsdk-core-ios`, branch `dev-v3.4.3`)
+  - AEPCore (from `https://github.com/adobe/aepsdk-core-ios`, branch `staging`)
   - AEPEdgeConsent
   - AEPEdgeIdentity
-  - AEPIdentity (from `https://github.com/adobe/aepsdk-core-ios`, branch `dev-v3.4.3`)
-  - AEPLifecycle (from `https://github.com/adobe/aepsdk-core-ios`, branch `dev-v3.4.3`)
-  - AEPServices (from `https://github.com/adobe/aepsdk-core-ios`, branch `dev-v3.4.3`)
-  - AEPSignal (from `https://github.com/adobe/aepsdk-core-ios`, branch `dev-v3.4.3`)
+  - AEPIdentity (from `https://github.com/adobe/aepsdk-core-ios`, branch `staging`)
+  - AEPLifecycle (from `https://github.com/adobe/aepsdk-core-ios`, branch `staging`)
+  - AEPServices (from `https://github.com/adobe/aepsdk-core-ios`, branch `staging`)
+  - AEPSignal (from `https://github.com/adobe/aepsdk-core-ios`, branch `staging`)
   - SwiftLint (= 0.44.0)
 
 SPEC REPOS:
@@ -40,50 +40,50 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   AEPCore:
-    :branch: dev-v3.4.3
+    :branch: staging
     :git: https://github.com/adobe/aepsdk-core-ios
   AEPIdentity:
-    :branch: dev-v3.4.3
+    :branch: staging
     :git: https://github.com/adobe/aepsdk-core-ios
   AEPLifecycle:
-    :branch: dev-v3.4.3
+    :branch: staging
     :git: https://github.com/adobe/aepsdk-core-ios
   AEPServices:
-    :branch: dev-v3.4.3
+    :branch: staging
     :git: https://github.com/adobe/aepsdk-core-ios
   AEPSignal:
-    :branch: dev-v3.4.3
+    :branch: staging
     :git: https://github.com/adobe/aepsdk-core-ios
 
 CHECKOUT OPTIONS:
   AEPCore:
-    :commit: b0987c04c2cffdaa6391d703b1be79ed9a798999
+    :commit: bbbb9748e04d28b28411dc104adab6f785877959
     :git: https://github.com/adobe/aepsdk-core-ios
   AEPIdentity:
-    :commit: b0987c04c2cffdaa6391d703b1be79ed9a798999
+    :commit: bbbb9748e04d28b28411dc104adab6f785877959
     :git: https://github.com/adobe/aepsdk-core-ios
   AEPLifecycle:
-    :commit: b0987c04c2cffdaa6391d703b1be79ed9a798999
+    :commit: bbbb9748e04d28b28411dc104adab6f785877959
     :git: https://github.com/adobe/aepsdk-core-ios
   AEPServices:
-    :commit: b0987c04c2cffdaa6391d703b1be79ed9a798999
+    :commit: bbbb9748e04d28b28411dc104adab6f785877959
     :git: https://github.com/adobe/aepsdk-core-ios
   AEPSignal:
-    :commit: b0987c04c2cffdaa6391d703b1be79ed9a798999
+    :commit: bbbb9748e04d28b28411dc104adab6f785877959
     :git: https://github.com/adobe/aepsdk-core-ios
 
 SPEC CHECKSUMS:
-  AEPAssurance: 18068627111e366a851dc2166239f22b665101bd
-  AEPCore: b01856bf24972e4720cb0511a358d1e68067252a
+  AEPAssurance: b25880cd4b14f22c61a1dce19807bd0ca0fe9b17
+  AEPCore: a3b4159038df33b63ebdab227342cd57d8ded1b0
   AEPEdgeConsent: dd46002b0c4bf55443f5441990e799248975713e
   AEPEdgeIdentity: 40d312b4434b710a46c1738ab2a221dda4cfd67e
-  AEPIdentity: fbf755560afcbb0acd66cd5b6a1c147530fca5f6
-  AEPLifecycle: 1e0e843465fb143f8d8949dcf06de169d5c26f62
+  AEPIdentity: d7745fc4df403b7281b18fa7df917e68f061c9b2
+  AEPLifecycle: d3ff90c661c4452fb1c619e7f02dad8ba49a8fd2
   AEPRulesEngine: bb2927ed5501ddf9754c66e97f8d2b1cf8e33b19
-  AEPServices: 3214311f239c8cdc6267d757200b05ec0ab05878
-  AEPSignal: be3a4789b492f4d5a5aef7408f30ff8e866d1d79
+  AEPServices: 2e869a387b67c04ab5f3f647026412ff410efbb0
+  AEPSignal: 636e615dd02d670aa0fe6c2b9dcebee6c95e1f4f
   SwiftLint: e96c0a8c770c7ebbc4d36c55baf9096bb65c4584
 
-PODFILE CHECKSUM: f2763b0e9275cc9712829783d327d216fbc965ec
+PODFILE CHECKSUM: 5cb7ac7723656b6d8dc005b187fca1e6ff5a5b4a
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,14 +9,8 @@ PODS:
     - AEPCore (>= 3.1.0)
   - AEPEdgeIdentity (1.0.0):
     - AEPCore (>= 3.1.1)
-  - AEPIdentity (3.5.0):
-    - AEPCore (>= 3.5.0)
-  - AEPLifecycle (3.5.0):
-    - AEPCore (>= 3.5.0)
   - AEPRulesEngine (1.1.0)
   - AEPServices (3.5.0)
-  - AEPSignal (3.5.0):
-    - AEPCore (>= 3.5.0)
   - SwiftLint (0.44.0)
 
 DEPENDENCIES:
@@ -24,10 +18,7 @@ DEPENDENCIES:
   - AEPCore (from `https://github.com/adobe/aepsdk-core-ios`, branch `staging`)
   - AEPEdgeConsent
   - AEPEdgeIdentity
-  - AEPIdentity (from `https://github.com/adobe/aepsdk-core-ios`, branch `staging`)
-  - AEPLifecycle (from `https://github.com/adobe/aepsdk-core-ios`, branch `staging`)
   - AEPServices (from `https://github.com/adobe/aepsdk-core-ios`, branch `staging`)
-  - AEPSignal (from `https://github.com/adobe/aepsdk-core-ios`, branch `staging`)
   - SwiftLint (= 0.44.0)
 
 SPEC REPOS:
@@ -42,16 +33,7 @@ EXTERNAL SOURCES:
   AEPCore:
     :branch: staging
     :git: https://github.com/adobe/aepsdk-core-ios
-  AEPIdentity:
-    :branch: staging
-    :git: https://github.com/adobe/aepsdk-core-ios
-  AEPLifecycle:
-    :branch: staging
-    :git: https://github.com/adobe/aepsdk-core-ios
   AEPServices:
-    :branch: staging
-    :git: https://github.com/adobe/aepsdk-core-ios
-  AEPSignal:
     :branch: staging
     :git: https://github.com/adobe/aepsdk-core-ios
 
@@ -59,16 +41,7 @@ CHECKOUT OPTIONS:
   AEPCore:
     :commit: bbbb9748e04d28b28411dc104adab6f785877959
     :git: https://github.com/adobe/aepsdk-core-ios
-  AEPIdentity:
-    :commit: bbbb9748e04d28b28411dc104adab6f785877959
-    :git: https://github.com/adobe/aepsdk-core-ios
-  AEPLifecycle:
-    :commit: bbbb9748e04d28b28411dc104adab6f785877959
-    :git: https://github.com/adobe/aepsdk-core-ios
   AEPServices:
-    :commit: bbbb9748e04d28b28411dc104adab6f785877959
-    :git: https://github.com/adobe/aepsdk-core-ios
-  AEPSignal:
     :commit: bbbb9748e04d28b28411dc104adab6f785877959
     :git: https://github.com/adobe/aepsdk-core-ios
 
@@ -77,13 +50,10 @@ SPEC CHECKSUMS:
   AEPCore: a3b4159038df33b63ebdab227342cd57d8ded1b0
   AEPEdgeConsent: dd46002b0c4bf55443f5441990e799248975713e
   AEPEdgeIdentity: 40d312b4434b710a46c1738ab2a221dda4cfd67e
-  AEPIdentity: d7745fc4df403b7281b18fa7df917e68f061c9b2
-  AEPLifecycle: d3ff90c661c4452fb1c619e7f02dad8ba49a8fd2
   AEPRulesEngine: bb2927ed5501ddf9754c66e97f8d2b1cf8e33b19
   AEPServices: 2e869a387b67c04ab5f3f647026412ff410efbb0
-  AEPSignal: 636e615dd02d670aa0fe6c2b9dcebee6c95e1f4f
   SwiftLint: e96c0a8c770c7ebbc4d36c55baf9096bb65c4584
 
-PODFILE CHECKSUM: 5cb7ac7723656b6d8dc005b187fca1e6ff5a5b4a
+PODFILE CHECKSUM: f4cf96f004aaad1e08d2edfef37b03a62ada966a
 
 COCOAPODS: 1.11.2

--- a/SampleApps/AEPCommerceDemoApp/Podfile
+++ b/SampleApps/AEPCommerceDemoApp/Podfile
@@ -8,11 +8,8 @@ target 'AEPCommerceDemoApp' do
   # Comment the next line if you don't want to use dynamic frameworks
   use_frameworks!
   pod 'AEPEdge', :path => '../../'
-  pod 'AEPCore'
-  pod 'AEPServices'
-  pod 'AEPLifecycle'
-  pod 'AEPIdentity'
-  pod 'AEPSignal'
+  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
+  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios', :branch => 'staging'
   pod 'AEPEdgeIdentity'
   pod 'AEPAssurance'
 

--- a/SampleApps/AEPCommerceDemoApp/Podfile.lock
+++ b/SampleApps/AEPCommerceDemoApp/Podfile.lock
@@ -1,60 +1,57 @@
 PODS:
-  - AEPAssurance (3.0.0):
+  - AEPAssurance (3.0.1):
     - AEPCore (>= 3.1.0)
     - AEPServices (>= 3.1.0)
-  - AEPCore (3.3.2):
-    - AEPRulesEngine (= 1.0.1)
-    - AEPServices (= 3.3.2)
-  - AEPEdge (1.3.0):
-    - AEPCore (>= 3.3.2)
+  - AEPCore (3.5.0):
+    - AEPRulesEngine (>= 1.1.0)
+    - AEPServices (>= 3.5.0)
+  - AEPEdge (1.3.1):
+    - AEPCore (>= 3.5.0)
     - AEPEdgeIdentity
   - AEPEdgeIdentity (1.0.0):
     - AEPCore (>= 3.1.1)
-  - AEPIdentity (3.3.2):
-    - AEPCore (= 3.3.2)
-  - AEPLifecycle (3.3.2):
-    - AEPCore (= 3.3.2)
-  - AEPRulesEngine (1.0.1)
-  - AEPServices (3.3.2)
-  - AEPSignal (3.3.2):
-    - AEPCore (= 3.3.2)
+  - AEPRulesEngine (1.1.0)
+  - AEPServices (3.5.0)
 
 DEPENDENCIES:
   - AEPAssurance
-  - AEPCore
+  - AEPCore (from `https://github.com/adobe/aepsdk-core-ios`, branch `staging`)
   - AEPEdge (from `../../`)
   - AEPEdgeIdentity
-  - AEPIdentity
-  - AEPLifecycle
-  - AEPServices
-  - AEPSignal
+  - AEPServices (from `https://github.com/adobe/aepsdk-core-ios`, branch `staging`)
 
 SPEC REPOS:
   trunk:
     - AEPAssurance
-    - AEPCore
     - AEPEdgeIdentity
-    - AEPIdentity
-    - AEPLifecycle
     - AEPRulesEngine
-    - AEPServices
-    - AEPSignal
 
 EXTERNAL SOURCES:
+  AEPCore:
+    :branch: staging
+    :git: https://github.com/adobe/aepsdk-core-ios
   AEPEdge:
     :path: "../../"
+  AEPServices:
+    :branch: staging
+    :git: https://github.com/adobe/aepsdk-core-ios
+
+CHECKOUT OPTIONS:
+  AEPCore:
+    :commit: bbbb9748e04d28b28411dc104adab6f785877959
+    :git: https://github.com/adobe/aepsdk-core-ios
+  AEPServices:
+    :commit: bbbb9748e04d28b28411dc104adab6f785877959
+    :git: https://github.com/adobe/aepsdk-core-ios
 
 SPEC CHECKSUMS:
-  AEPAssurance: 18068627111e366a851dc2166239f22b665101bd
-  AEPCore: 922aa0eac3fa4f0bc3fbdd3f1b9f7cb7b65e440d
-  AEPEdge: 500628aee1319ef2690dfaf5bd950badce6ec3f0
+  AEPAssurance: b25880cd4b14f22c61a1dce19807bd0ca0fe9b17
+  AEPCore: a3b4159038df33b63ebdab227342cd57d8ded1b0
+  AEPEdge: cb46ff57b812c52dc4d20ba4ba16091af0a82960
   AEPEdgeIdentity: 40d312b4434b710a46c1738ab2a221dda4cfd67e
-  AEPIdentity: 5f7af2b937713ff82aa0788a6ee0b7e0d8fcd86e
-  AEPLifecycle: 8200df6d8f4579d4ee1eb924d6c46247b1fe102b
-  AEPRulesEngine: 5075ed294026a12e37bd26fe260f74604d205354
-  AEPServices: 7ac2a251b71a422ddaee316eac39f7a66a0d3a90
-  AEPSignal: f80b7d568388ac9b6119e8396c5126ff7284dd1a
+  AEPRulesEngine: bb2927ed5501ddf9754c66e97f8d2b1cf8e33b19
+  AEPServices: 2e869a387b67c04ab5f3f647026412ff410efbb0
 
-PODFILE CHECKSUM: 050b2e4d2a867cf8cf6ccae97ea4e4ba1ce000c1
+PODFILE CHECKSUM: b0ceff739cb1f577ff41b9d73248c0ee0068408f
 
 COCOAPODS: 1.11.2

--- a/Sources/EdgeConstants.swift
+++ b/Sources/EdgeConstants.swift
@@ -15,7 +15,7 @@ import Foundation
 enum EdgeConstants {
 
     static let EXTENSION_NAME = "com.adobe.edge"
-    static let EXTENSION_VERSION = "1.3.0"
+    static let EXTENSION_VERSION = "1.3.1"
     static let FRIENDLY_NAME = "AEPEdge"
     static let LOG_TAG = FRIENDLY_NAME
 

--- a/Sources/EdgeConstants.swift
+++ b/Sources/EdgeConstants.swift
@@ -15,7 +15,7 @@ import Foundation
 enum EdgeConstants {
 
     static let EXTENSION_NAME = "com.adobe.edge"
-    static let EXTENSION_VERSION = "1.3.1"
+    static let EXTENSION_VERSION = "1.4.0"
     static let FRIENDLY_NAME = "AEPEdge"
     static let LOG_TAG = FRIENDLY_NAME
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Bump version to 1.4.0

- Sets AEPCore dependency to 3.5.0 in AEPEdge.podspec and Package.swift
- In Podfile, use AEPCore from staging branch since v3.5.0 is not released yet.
- Remove unnecessary pods from sample app targets in Podfiles

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
