### PR TITLE
[DEV] Updates on EdgeEndpoint, renaming and clean up on unused fields

### DIFF
--- a/Sources/EdgeConstants.swift
+++ b/Sources/EdgeConstants.swift
@@ -138,10 +138,12 @@ enum EdgeConstants {
     }
 
     enum NetworkKeys {
+        static let HTTPS = "https"
         static let EDGE_DEFAULT_DOMAIN = "edge.adobedc.net"
-        static let EDGE_ENDPOINT_PATH = "/ee/v1"
-        static let EDGE_ENDPOINT_PRE_PRODUCTION_PATH = "/ee-pre-prd/v1"
-        static let EDGE_ENDPOINT_INTEGRATION = "https://edge-int.adobedc.net/ee/v1/"
+        static let EDGE_ENDPOINT_PATH = "/ee"
+        static let EDGE_ENDPOINT_PRE_PRODUCTION_PATH = "/ee-pre-prd"
+        static let EDGE_ENDPOINT_VERSION_PATH = "/v1"
+        static let EDGE_INTEGRATION_DOMAIN = "edge-int.adobedc.net"
         static let REQUEST_PARAM_CONFIG_ID = "configId"
         static let REQUEST_PARAM_REQUEST_ID = "requestId"
         static let DEFAULT_CONNECT_TIMEOUT: TimeInterval = 5

--- a/Sources/EdgeNetworkHandlers/ConsentEdgeHit.swift
+++ b/Sources/EdgeNetworkHandlers/ConsentEdgeHit.swift
@@ -21,8 +21,8 @@ struct ConsentEdgeHit: EdgeHit {
     /// The `EdgeConsentUpdate` for the corresponding hit
     let consents: EdgeConsentUpdate
 
-    func getType() -> ExperienceEdgeRequestType {
-        ExperienceEdgeRequestType.consent
+    func getType() -> EdgeRequestType {
+        EdgeRequestType.consent
     }
 
     func getPayload() -> String? {

--- a/Sources/EdgeNetworkHandlers/ConsentEdgeHit.swift
+++ b/Sources/EdgeNetworkHandlers/ConsentEdgeHit.swift
@@ -21,10 +21,6 @@ struct ConsentEdgeHit: EdgeHit {
     /// The `EdgeConsentUpdate` for the corresponding hit
     let consents: EdgeConsentUpdate
 
-    func getType() -> EdgeRequestType {
-        EdgeRequestType.consent
-    }
-
     func getPayload() -> String? {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted]

--- a/Sources/EdgeNetworkHandlers/ConsentEdgeHit.swift
+++ b/Sources/EdgeNetworkHandlers/ConsentEdgeHit.swift
@@ -14,7 +14,7 @@ import Foundation
 
 /// Implementation of `EdgeHit` for Consent update requests
 struct ConsentEdgeHit: EdgeHit {
-    let edgeEndpoint: EdgeEndpoint
+    let endpoint: EdgeEndpoint
     let configId: String
     let requestId: String = UUID().uuidString
 

--- a/Sources/EdgeNetworkHandlers/EdgeHit.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeHit.swift
@@ -25,8 +25,8 @@ protocol EdgeHit {
     /// Unique identifier for this hit
     var requestId: String { get }
 
-    /// The `ExperienceEdgeRequestType` to be used for this `EdgeHit`
-    func getType() -> ExperienceEdgeRequestType
+    /// The `EdgeRequestType` to be used for this `EdgeHit`
+    func getType() -> EdgeRequestType
 
     /// The network request payload for this `EdgeHit`
     func getPayload() -> String?

--- a/Sources/EdgeNetworkHandlers/EdgeHit.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeHit.swift
@@ -17,7 +17,7 @@ import Foundation
 protocol EdgeHit {
 
     /// The Edge endpoint
-    var edgeEndpoint: EdgeEndpoint { get }
+    var endpoint: EdgeEndpoint { get }
 
     /// The Edge configuration identifier
     var configId: String { get }

--- a/Sources/EdgeNetworkHandlers/EdgeHit.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeHit.swift
@@ -22,11 +22,8 @@ protocol EdgeHit {
     /// The Edge configuration identifier
     var configId: String { get }
 
-    /// Unique identifier for this hit
+    /// Unique identifier for the Edge request
     var requestId: String { get }
-
-    /// The `EdgeRequestType` to be used for this `EdgeHit`
-    func getType() -> EdgeRequestType
 
     /// The network request payload for this `EdgeHit`
     func getPayload() -> String?

--- a/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
@@ -98,7 +98,7 @@ class EdgeHitProcessor: HitProcessing {
             }
 
             let endpoint = buildEndpoint(config: edgeConfig, requestType: EdgeRequestType.interact)
-            let edgeHit = ExperienceEventsEdgeHit(edgeEndpoint: endpoint, configId: configId, request: requestPayload)
+            let edgeHit = ExperienceEventsEdgeHit(endpoint: endpoint, configId: configId, request: requestPayload)
             // NOTE: the order of these events needs to be maintained as they were sent in the network request
             // otherwise the response callback cannot be matched
             networkResponseHandler.addWaitingEvents(requestId: edgeHit.requestId,
@@ -120,7 +120,7 @@ class EdgeHitProcessor: HitProcessing {
             }
 
             let endpoint = buildEndpoint(config: edgeConfig, requestType: EdgeRequestType.consent)
-            let edgeHit = ConsentEdgeHit(edgeEndpoint: endpoint, configId: configId, consents: consentPayload)
+            let edgeHit = ConsentEdgeHit(endpoint: endpoint, configId: configId, consents: consentPayload)
             networkResponseHandler.addWaitingEvent(requestId: edgeHit.requestId, event: event)
             sendHit(entityId: entity.uniqueIdentifier, edgeHit: edgeHit, headers: getRequestHeaders(event), completion: completion)
         } else if event.isResetIdentitiesEvent {
@@ -160,7 +160,7 @@ class EdgeHitProcessor: HitProcessing {
     ///   - headers: headers for the request
     ///   - completion: completion handler for the hit processor
     private func sendHit(entityId: String, edgeHit: EdgeHit, headers: [String: String], completion: @escaping (Bool) -> Void) {
-        guard let url = networkService.buildUrl(endpoint: edgeHit.edgeEndpoint,
+        guard let url = networkService.buildUrl(endpoint: edgeHit.endpoint,
                                                 configId: edgeHit.configId,
                                                 requestId: edgeHit.requestId) else {
             Log.debug(label: EdgeConstants.LOG_TAG,

--- a/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
@@ -59,8 +59,8 @@ class EdgeHitProcessor: HitProcessing {
             return
         }
 
-        // fetch config shared state, this should be resolved based on readyForEvent check
-        guard let (configId, edgeEndpoint) = getEdgeConfig(event: event) else {
+        // fetch config keys for Edge extension
+        guard let edgeConfig = getEdgeConfig(event: event), let configId = edgeConfig[EdgeConstants.SharedState.Configuration.CONFIG_ID] else {
             completion(true)
             return // drop current event
         }
@@ -97,7 +97,8 @@ class EdgeHitProcessor: HitProcessing {
                 return
             }
 
-            let edgeHit = ExperienceEventsEdgeHit(edgeEndpoint: edgeEndpoint, configId: configId, request: requestPayload)
+            let endpoint = buildEndpoint(config: edgeConfig, requestType: EdgeRequestType.interact)
+            let edgeHit = ExperienceEventsEdgeHit(edgeEndpoint: endpoint, configId: configId, request: requestPayload)
             // NOTE: the order of these events needs to be maintained as they were sent in the network request
             // otherwise the response callback cannot be matched
             networkResponseHandler.addWaitingEvents(requestId: edgeHit.requestId,
@@ -118,7 +119,8 @@ class EdgeHitProcessor: HitProcessing {
                 return
             }
 
-            let edgeHit = ConsentEdgeHit(edgeEndpoint: edgeEndpoint, configId: configId, consents: consentPayload)
+            let endpoint = buildEndpoint(config: edgeConfig, requestType: EdgeRequestType.consent)
+            let edgeHit = ConsentEdgeHit(edgeEndpoint: endpoint, configId: configId, consents: consentPayload)
             networkResponseHandler.addWaitingEvent(requestId: edgeHit.requestId, event: event)
             sendHit(entityId: entity.uniqueIdentifier, edgeHit: edgeHit, headers: getRequestHeaders(event), completion: completion)
         } else if event.isResetIdentitiesEvent {
@@ -127,6 +129,17 @@ class EdgeHitProcessor: HitProcessing {
             storeResponsePayloadManager.deleteAllStorePayloads()
             completion(true)
         }
+    }
+
+    /// Builds the endpoint based on the provided config info and `EdgeRequestType`
+    /// - Parameters:
+    ///   - config: configuration data, used to extract the environment and the custom domain, if any
+    ///   - requestType: the `EdgeRequestType`
+    private func buildEndpoint(config: [String: String], requestType: EdgeRequestType) -> EdgeEndpoint {
+        return EdgeEndpoint(
+            requestType: requestType,
+            environmentType: EdgeEnvironmentType(optionalRawValue: config[EdgeConstants.SharedState.Configuration.EDGE_ENVIRONMENT]),
+            optionalDomain: config[EdgeConstants.SharedState.Configuration.EDGE_DOMAIN])
     }
 
     private func decode(dataEntity: DataEntity) -> EdgeDataEntity? {
@@ -147,10 +160,9 @@ class EdgeHitProcessor: HitProcessing {
     ///   - headers: headers for the request
     ///   - completion: completion handler for the hit processor
     private func sendHit(entityId: String, edgeHit: EdgeHit, headers: [String: String], completion: @escaping (Bool) -> Void) {
-        guard let url = networkService.buildUrl(requestType: edgeHit.getType(),
+        guard let url = networkService.buildUrl(endpoint: edgeHit.edgeEndpoint,
                                                 configId: edgeHit.configId,
-                                                requestId: edgeHit.requestId,
-                                                edgeEndpoint: edgeHit.edgeEndpoint) else {
+                                                requestId: edgeHit.requestId) else {
             Log.debug(label: EdgeConstants.LOG_TAG,
                       "\(SELF_TAG) - Failed to build the URL, dropping request with id '\(edgeHit.requestId)'.")
             completion(true)
@@ -169,10 +181,10 @@ class EdgeHitProcessor: HitProcessing {
         }
     }
 
-    /// Extracts the Edge Configuration identifier and Edge Configuration endpoint from the Configuration Shared State
+    /// Extracts all the Edge configuration keys from the Configuration shared state
     /// - Parameter event: current event for which the configuration is required
-    /// - Returns: the Edge Configuration Id if found and Edge Configuration endpoint, nil if Edge Configuration Id was not found
-    private func getEdgeConfig(event: Event) -> (String, EdgeEndpoint)? {
+    /// - Returns: the Edge configuration keys with values, nil if edge.configId was not found
+    private func getEdgeConfig(event: Event) -> [String: String]? {
         guard let configSharedState =
                 getSharedState(EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
                                event)?.value else {
@@ -180,10 +192,6 @@ class EdgeHitProcessor: HitProcessing {
                         "\(SELF_TAG) - Unable to process the event '\(event.id.uuidString)', Configuration is nil.")
             return nil
         }
-
-        let edgeEnvironmentStr = configSharedState[EdgeConstants.SharedState.Configuration.EDGE_ENVIRONMENT] as? String
-        let edgeDomainStr = configSharedState[EdgeConstants.SharedState.Configuration.EDGE_DOMAIN] as? String
-        let edgeEndpoint = EdgeEndpoint(type: EdgeEnvironmentType(optionalRawValue: edgeEnvironmentStr), optionalDomain: edgeDomainStr)
 
         guard let configId =
                 configSharedState[EdgeConstants.SharedState.Configuration.CONFIG_ID] as? String,
@@ -194,7 +202,12 @@ class EdgeHitProcessor: HitProcessing {
             return nil
         }
 
-        return (configId, edgeEndpoint)
+        var config: [String: String] = [:]
+        config[EdgeConstants.SharedState.Configuration.CONFIG_ID] = configId
+        config[EdgeConstants.SharedState.Configuration.EDGE_ENVIRONMENT] = configSharedState[EdgeConstants.SharedState.Configuration.EDGE_ENVIRONMENT] as? String
+        config[EdgeConstants.SharedState.Configuration.EDGE_DOMAIN] = configSharedState[EdgeConstants.SharedState.Configuration.EDGE_DOMAIN] as? String
+
+        return config
     }
 
     /// Computes the request headers for provided `event`, including the `Assurance` integration identifier when `Assurance` is enabled

--- a/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
@@ -97,7 +97,7 @@ class EdgeHitProcessor: HitProcessing {
                 return
             }
 
-            let endpoint = buildEndpoint(config: edgeConfig, requestType: EdgeRequestType.interact)
+            let endpoint = buildEdgeEndpoint(config: edgeConfig, requestType: EdgeRequestType.interact)
             let edgeHit = ExperienceEventsEdgeHit(endpoint: endpoint, configId: configId, request: requestPayload)
             // NOTE: the order of these events needs to be maintained as they were sent in the network request
             // otherwise the response callback cannot be matched
@@ -119,7 +119,7 @@ class EdgeHitProcessor: HitProcessing {
                 return
             }
 
-            let endpoint = buildEndpoint(config: edgeConfig, requestType: EdgeRequestType.consent)
+            let endpoint = buildEdgeEndpoint(config: edgeConfig, requestType: EdgeRequestType.consent)
             let edgeHit = ConsentEdgeHit(endpoint: endpoint, configId: configId, consents: consentPayload)
             networkResponseHandler.addWaitingEvent(requestId: edgeHit.requestId, event: event)
             sendHit(entityId: entity.uniqueIdentifier, edgeHit: edgeHit, headers: getRequestHeaders(event), completion: completion)
@@ -135,7 +135,7 @@ class EdgeHitProcessor: HitProcessing {
     /// - Parameters:
     ///   - config: configuration data, used to extract the environment and the custom domain, if any
     ///   - requestType: the `EdgeRequestType`
-    private func buildEndpoint(config: [String: String], requestType: EdgeRequestType) -> EdgeEndpoint {
+    private func buildEdgeEndpoint(config: [String: String], requestType: EdgeRequestType) -> EdgeEndpoint {
         return EdgeEndpoint(
             requestType: requestType,
             environmentType: EdgeEnvironmentType(optionalRawValue: config[EdgeConstants.SharedState.Configuration.EDGE_ENVIRONMENT]),

--- a/Sources/EdgeNetworkHandlers/EdgeNetworkService.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeNetworkService.swift
@@ -50,7 +50,7 @@ class EdgeNetworkService {
 
     /// Builds the URL required for connections to Experience Edge
     /// - Parameters:
-    ///   - edgeEndpoint: the endpoint for this URL
+    ///   - endpoint: the endpoint for this URL
     ///   - configId: Edge configuration identifier
     ///   - requestId: batch request identifier
     /// - Returns: built URL or nil on error

--- a/Sources/EdgeNetworkHandlers/EdgeNetworkService.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeNetworkService.swift
@@ -14,13 +14,11 @@ import AEPCore
 import AEPServices
 import Foundation
 
-/// ExperienceEdge Request Types:
+/// Edge Network request type:
 ///     - interact - makes request and expects a response
-///     - collect - makes request without expecting a response
 ///     - consent - sets user consent and expects a response
-enum ExperienceEdgeRequestType: String {
+enum EdgeRequestType: String {
     case interact
-    case collect
     case consent = "privacy/set-consent"
 }
 
@@ -50,20 +48,21 @@ class EdgeNetworkService {
     private var defaultHeaders = [EdgeConstants.NetworkKeys.HEADER_KEY_ACCEPT: EdgeConstants.NetworkKeys.HEADER_VALUE_APPLICATION_JSON,
                                   EdgeConstants.NetworkKeys.HEADER_KEY_CONTENT_TYPE: EdgeConstants.NetworkKeys.HEADER_VALUE_APPLICATION_JSON]
 
-    /// Builds the URL required for connections to Experience Edge with the provided `ExperienceEdgeRequestType`
+    /// Builds the URL required for connections to Experience Edge
     /// - Parameters:
-    ///   - requestType: see `ExperienceEdgeRequestType`
+    ///   - edgeEndpoint: the endpoint for this URL
     ///   - configId: Edge configuration identifier
     ///   - requestId: batch request identifier
-    ///   - edgeEndpoint: the endpoint for this URL to be based off of
     /// - Returns: built URL or nil on error
-    func buildUrl(requestType: ExperienceEdgeRequestType, configId: String, requestId: String, edgeEndpoint: EdgeEndpoint) -> URL? {
-        guard var url = URL(string: edgeEndpoint.endpointUrl) else { return nil }
-        url.appendPathComponent(requestType.rawValue)
-
+    func buildUrl(endpoint: EdgeEndpoint, configId: String, requestId: String) -> URL? {
+        guard let url = endpoint.url else { return nil }
         guard var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return nil }
-        urlComponents.queryItems = [URLQueryItem(name: EdgeConstants.NetworkKeys.REQUEST_PARAM_CONFIG_ID, value: configId),
-                                    URLQueryItem(name: EdgeConstants.NetworkKeys.REQUEST_PARAM_REQUEST_ID, value: requestId)]
+        urlComponents.queryItems = [
+            URLQueryItem(name: EdgeConstants.NetworkKeys.REQUEST_PARAM_CONFIG_ID,
+                         value: configId),
+            URLQueryItem(name: EdgeConstants.NetworkKeys.REQUEST_PARAM_REQUEST_ID,
+                         value: requestId)
+        ]
 
         return urlComponents.url
     }
@@ -183,20 +182,19 @@ class EdgeNetworkService {
 
         switch responseCode {
         case HttpResponseCodes.ok.rawValue:
-            Log.debug(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Interact connection to Experience Edge was successful.")
+            Log.debug(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Connection to Experience Edge was successful.")
             self.handleContent(connection: connection,
                                streaming: streaming,
                                responseCallback: responseCallback)
             responseCallback.onComplete()
             completion(true, nil) // successful request, return true
         case HttpResponseCodes.noContent.rawValue:
-            // Successful collect requests do not return content
-            Log.debug(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Collect connection to Experience Edge was successful.")
+            Log.debug(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Connection to Experience Edge was successful, no content returned.")
             responseCallback.onComplete()
             completion(true, nil) // successful request, return true
         case HttpResponseCodes.multiStatus.rawValue:
             Log.debug(label: EdgeConstants.LOG_TAG,
-                      "\(SELF_TAG) - Connection to Experience Edge was successful but encountered non-fatal errors/warnings. \(responseCode)")
+                      "\(SELF_TAG) - Connection to Experience Edge was successful, but encountered non-fatal errors/warnings. \(responseCode)")
             self.handleContent(connection: connection,
                                streaming: streaming,
                                responseCallback: responseCallback)

--- a/Sources/EdgeNetworkHandlers/ExperienceEventsEdgeHit.swift
+++ b/Sources/EdgeNetworkHandlers/ExperienceEventsEdgeHit.swift
@@ -21,8 +21,8 @@ struct ExperienceEventsEdgeHit: EdgeHit {
     /// The `EdgeRequest` for the corresponding hit
     let request: EdgeRequest
 
-    func getType() -> ExperienceEdgeRequestType {
-        ExperienceEdgeRequestType.interact
+    func getType() -> EdgeRequestType {
+        EdgeRequestType.interact
     }
 
     func getPayload() -> String? {

--- a/Sources/EdgeNetworkHandlers/ExperienceEventsEdgeHit.swift
+++ b/Sources/EdgeNetworkHandlers/ExperienceEventsEdgeHit.swift
@@ -21,10 +21,6 @@ struct ExperienceEventsEdgeHit: EdgeHit {
     /// The `EdgeRequest` for the corresponding hit
     let request: EdgeRequest
 
-    func getType() -> EdgeRequestType {
-        EdgeRequestType.interact
-    }
-
     func getPayload() -> String? {
         guard let events = request.events, !events.isEmpty else {
             return nil

--- a/Sources/EdgeNetworkHandlers/ExperienceEventsEdgeHit.swift
+++ b/Sources/EdgeNetworkHandlers/ExperienceEventsEdgeHit.swift
@@ -14,7 +14,7 @@ import Foundation
 
 /// Implementation of `EdgeHit` for ExperienceEvents requests
 struct ExperienceEventsEdgeHit: EdgeHit {
-    let edgeEndpoint: EdgeEndpoint
+    let endpoint: EdgeEndpoint
     let configId: String
     let requestId: String = UUID().uuidString
 

--- a/Tests/UnitTests/EdgeEndpointTests.swift
+++ b/Tests/UnitTests/EdgeEndpointTests.swift
@@ -20,6 +20,7 @@ class EdgeEndpointTests: XCTestCase {
         continueAfterFailure = false
     }
 
+    // MARK: EdgeEnvironmentType tests
     func testEnvironmentTypeProduction() {
         XCTAssertEqual(.production, EdgeEnvironmentType(optionalRawValue: "prod"))
     }
@@ -56,49 +57,59 @@ class EdgeEndpointTests: XCTestCase {
         XCTAssertEqual(.production, EdgeEnvironmentType(optionalRawValue: "invalid"))
     }
 
-    func testDefaultProductionEndpoint() {
-        let endpoint = EdgeEndpoint(type: .production)
-        let expected = "https://\(EdgeConstants.NetworkKeys.EDGE_DEFAULT_DOMAIN)\(EdgeConstants.NetworkKeys.EDGE_ENDPOINT_PATH)"
-        XCTAssertEqual(expected, endpoint.endpointUrl)
+    // MARK: EdgeEndpoint tests
+    func testEdgeEndpoint_interact_defaultDomain() {
+        // cases defined as: ($0: input EnvironmentType, $1: expected output EdgeEndpoint URL, $2: Test case name)
+        let cases = [(EdgeEnvironmentType.production, "https://edge.adobedc.net/ee/v1/interact", "DefaultProductionEndpoint"),
+                     (.preProduction, "https://edge.adobedc.net/ee-pre-prd/v1/interact", "DefaultPreProductionEndpoint"),
+                     (.integration, "https://edge-int.adobedc.net/ee/v1/interact", "DefaultIntegrationEndpoint")]
+
+        cases.forEach {
+            let endpoint = EdgeEndpoint(requestType: EdgeRequestType.interact, environmentType: $0)
+            XCTAssertEqual($1, endpoint.url?.absoluteString, "\($2) test case failed.")
+        }
     }
 
-    func testDefaultPreProductionEndpoint() {
-        let endpoint = EdgeEndpoint(type: .preProduction)
-        let expected = "https://\(EdgeConstants.NetworkKeys.EDGE_DEFAULT_DOMAIN)\(EdgeConstants.NetworkKeys.EDGE_ENDPOINT_PRE_PRODUCTION_PATH)"
-        XCTAssertEqual(expected, endpoint.endpointUrl)
+    func testEdgeEndpoint_interact_customDomain() {
+        let domain1 = "my.awesome.site"
+        let domain2 = ""
+        // cases defined as: ($0: input EnvironmentType, $1: input custom domain, $2: expected output EdgeEndpoint URL, $3: Test case name)
+        let cases = [(EdgeEnvironmentType.production, domain1, "https://\(domain1)/ee/v1/interact", "CustomProductionEndpoint"),
+                     (.preProduction, domain1, "https://\(domain1)/ee-pre-prd/v1/interact", "CustomPreProductionEndpoint"),
+                     (.integration, domain1, "https://edge-int.adobedc.net/ee/v1/interact", "CustomIntegrationEndpoint"),
+                     (.production, domain2, "https://edge.adobedc.net/ee/v1/interact", "CustomEmptyDomainUsesDefault")]
+
+        cases.forEach {
+            let endpoint = EdgeEndpoint(requestType: EdgeRequestType.interact, environmentType: $0, optionalDomain: $1)
+            XCTAssertEqual($2, endpoint.url?.absoluteString, "\($3) test case failed.")
+        }
     }
 
-    func testDefaultIntegrationEndpoint() {
-        let endpoint = EdgeEndpoint(type: .integration)
-        let expected = EdgeConstants.NetworkKeys.EDGE_ENDPOINT_INTEGRATION
-        XCTAssertEqual(expected, endpoint.endpointUrl)
+    func testEdgeEndpoint_consent_defaultDomain() {
+        // cases defined as: ($0: input EnvironmentType, $1: expected output EdgeEndpoint URL, $2: Test case name)
+        let cases = [(EdgeEnvironmentType.production, "https://edge.adobedc.net/ee/v1/privacy/set-consent", "DefaultProductionEndpoint"),
+                     (.preProduction, "https://edge.adobedc.net/ee-pre-prd/v1/privacy/set-consent", "DefaultProductionEndpoint"),
+                     (.integration, "https://edge-int.adobedc.net/ee/v1/privacy/set-consent", "DefaultIntegrationEndpoint")]
+
+        cases.forEach {
+            let endpoint = EdgeEndpoint(requestType: EdgeRequestType.consent, environmentType: $0)
+            XCTAssertEqual($1, endpoint.url?.absoluteString, "\($2) test case failed.")
+        }
     }
 
-    func testCustomProductionEndpoint() {
-        let domain = "my.awesome.site"
-        let endpoint = EdgeEndpoint(type: .production, optionalDomain: domain)
-        let expected = "https://\(domain)\(EdgeConstants.NetworkKeys.EDGE_ENDPOINT_PATH)"
-        XCTAssertEqual(expected, endpoint.endpointUrl)
+    func testEdgeEndpoint_consent_customDomain() {
+        let domain1 = "my.awesome.site"
+        let domain2 = ""
+        // cases defined as: ($0: input EnvironmentType, $1: input custom domain, $2: expected output EdgeEndpoint URL, $3: Test case name)
+        let cases = [(EdgeEnvironmentType.production, domain1, "https://\(domain1)/ee/v1/privacy/set-consent", "CustomProductionEndpoint"),
+                     (.preProduction, domain1, "https://\(domain1)/ee-pre-prd/v1/privacy/set-consent", "CustomPreProductionEndpoint"),
+                     (.integration, domain1, "https://edge-int.adobedc.net/ee/v1/privacy/set-consent", "CustomIntegrationEndpoint"),
+                     (.production, domain2, "https://edge.adobedc.net/ee/v1/privacy/set-consent", "CustomEmptyDomainUsesDefault")]
+
+        cases.forEach {
+            let endpoint = EdgeEndpoint(requestType: EdgeRequestType.consent, environmentType: $0, optionalDomain: $1)
+            XCTAssertEqual($2, endpoint.url?.absoluteString, "\($3) test case failed.")
+        }
     }
 
-    func testCustomPreProductionEndpoint() {
-        let domain = "my.awesome.site"
-        let endpoint = EdgeEndpoint(type: .preProduction, optionalDomain: domain)
-        let expected = "https://\(domain)\(EdgeConstants.NetworkKeys.EDGE_ENDPOINT_PRE_PRODUCTION_PATH)"
-        XCTAssertEqual(expected, endpoint.endpointUrl)
-    }
-
-    func testCustomIntegrationEndpoint() {
-        let domain = "my.awesome.site"
-        let endpoint = EdgeEndpoint(type: .integration, optionalDomain: domain)
-        let expected = EdgeConstants.NetworkKeys.EDGE_ENDPOINT_INTEGRATION
-        XCTAssertEqual(expected, endpoint.endpointUrl)
-    }
-
-    func testCustomEmptyDomainUsesDefault() {
-        let domain = ""
-        let endpoint = EdgeEndpoint(type: .production, optionalDomain: domain)
-        let expected = "https://\(EdgeConstants.NetworkKeys.EDGE_DEFAULT_DOMAIN)\(EdgeConstants.NetworkKeys.EDGE_ENDPOINT_PATH)"
-        XCTAssertEqual(expected, endpoint.endpointUrl)
-    }
 }

--- a/Tests/UnitTests/EdgeEndpointTests.swift
+++ b/Tests/UnitTests/EdgeEndpointTests.swift
@@ -17,7 +17,8 @@ import XCTest
 class EdgeEndpointTests: XCTestCase {
 
     override func setUp() {
-        continueAfterFailure = false
+        // continueAfterFailure set to true to continue running all test cases
+        continueAfterFailure = true
     }
 
     // MARK: EdgeEnvironmentType tests

--- a/Tests/UnitTests/EdgeHitTests.swift
+++ b/Tests/UnitTests/EdgeHitTests.swift
@@ -28,19 +28,23 @@ class EdgeHitTests: XCTestCase {
     // MARK: ExperienceEventsEdgeHit tests
 
     func testExperienceEventsEdgeHit() {
-        let edgeHit = ExperienceEventsEdgeHit(edgeEndpoint: INTERACT_ENDPOINT_PROD, configId: CONFIG_ID, request: EDGE_REQUEST)
-        XCTAssertEqual(INTERACT_ENDPOINT_PROD.url, edgeHit.edgeEndpoint.url)
+        let edgeHit = ExperienceEventsEdgeHit(endpoint: INTERACT_ENDPOINT_PROD,
+                                              configId: CONFIG_ID,
+                                              request: EDGE_REQUEST)
+        XCTAssertEqual(INTERACT_ENDPOINT_PROD.url, edgeHit.endpoint.url)
         XCTAssertEqual(CONFIG_ID, edgeHit.configId)
         XCTAssertNotNil(edgeHit.requestId)
         XCTAssertEqual(EDGE_REQUEST.events, edgeHit.request.events)
     }
 
     func testExperienceEventsEdgeHit_streamingSettings() {
-        let edgeHit1 = ExperienceEventsEdgeHit(edgeEndpoint: INTERACT_ENDPOINT_PROD, configId: CONFIG_ID, request: EdgeRequest(meta: nil, xdm: nil, events: [["test": "data"]]))
+        let edgeHit1 = ExperienceEventsEdgeHit(endpoint: INTERACT_ENDPOINT_PROD,
+                                               configId: CONFIG_ID,
+                                               request: EdgeRequest(meta: nil, xdm: nil, events: [["test": "data"]]))
         XCTAssertNil(edgeHit1.getStreamingSettings())
 
         let streamingSettings = Streaming(recordSeparator: "A", lineFeed: "B")
-        let edgeHit2 = ExperienceEventsEdgeHit(edgeEndpoint: INTERACT_ENDPOINT_PROD,
+        let edgeHit2 = ExperienceEventsEdgeHit(endpoint: INTERACT_ENDPOINT_PROD,
                                                configId: CONFIG_ID,
                                                request: EdgeRequest(meta: RequestMetadata(konductorConfig: KonductorConfig(streaming: streamingSettings), state: nil),
                                                                     xdm: nil, events: [["test": "data"]]))
@@ -55,7 +59,9 @@ class EdgeHitTests: XCTestCase {
                     """.data(using: .utf8)! // swiftlint:disable:this force_unwrapping
 
         let expectedPayload = try! JSONSerialization.jsonObject(with: json, options: []) as! [String: Any]
-        let edgeHit = ExperienceEventsEdgeHit(edgeEndpoint: INTERACT_ENDPOINT_PROD, configId: CONFIG_ID, request: EdgeRequest(meta: nil, xdm: nil, events: [["test": "data"]]))
+        let edgeHit = ExperienceEventsEdgeHit(endpoint: INTERACT_ENDPOINT_PROD,
+                                              configId: CONFIG_ID,
+                                              request: EdgeRequest(meta: nil, xdm: nil, events: [["test": "data"]]))
 
         XCTAssertTrue(expectedPayload == payloadToDict(payload: edgeHit.getPayload()))
     }
@@ -72,7 +78,7 @@ class EdgeHitTests: XCTestCase {
                 """.data(using: .utf8)! // swiftlint:disable:this force_unwrapping
         let expectedPayload = try! JSONSerialization.jsonObject(with: json, options: []) as! [String: Any]
         let streamingSettings = Streaming(recordSeparator: "A", lineFeed: "B")
-        let edgeHit = ExperienceEventsEdgeHit(edgeEndpoint: INTERACT_ENDPOINT_PROD,
+        let edgeHit = ExperienceEventsEdgeHit(endpoint: INTERACT_ENDPOINT_PROD,
                                               configId: CONFIG_ID,
                                               request: EdgeRequest(meta: RequestMetadata(konductorConfig: KonductorConfig(streaming: streamingSettings), state: nil), xdm: nil, events: [["test": "data"]]))
 
@@ -97,7 +103,7 @@ class EdgeHitTests: XCTestCase {
             }
             """.data(using: .utf8)! // swiftlint:disable:this force_unwrapping
         let expectedPayload = try! JSONSerialization.jsonObject(with: json, options: []) as! [String: Any]
-        let edgeHit = ConsentEdgeHit(edgeEndpoint: CONSENT_ENDPOINT_PROD, configId: CONFIG_ID, consents: CONSENT_UPDATE_REQUEST)
+        let edgeHit = ConsentEdgeHit(endpoint: CONSENT_ENDPOINT_PROD, configId: CONFIG_ID, consents: CONSENT_UPDATE_REQUEST)
 
         XCTAssertTrue(expectedPayload == payloadToDict(payload: edgeHit.getPayload()))
     }
@@ -128,13 +134,13 @@ class EdgeHitTests: XCTestCase {
         let consentUpdate = EdgeConsentUpdate(meta: RequestMetadata(konductorConfig: KonductorConfig(streaming: streamingSettings), state: nil),
                                               identityMap: nil,
                                               consent: [EdgeConsentPayload(standard: "Adobe", version: "2.0", value: ["consent": ["collect": "y"]])])
-        let edgeHit = ConsentEdgeHit(edgeEndpoint: CONSENT_ENDPOINT_PROD, configId: CONFIG_ID, consents: consentUpdate)
+        let edgeHit = ConsentEdgeHit(endpoint: CONSENT_ENDPOINT_PROD, configId: CONFIG_ID, consents: consentUpdate)
 
         XCTAssertTrue(expectedPayload == payloadToDict(payload: edgeHit.getPayload()))
     }
 
     func testConsentEdgeHit_getStreamingSettings_streamingNotEnabled() {
-        let edgeHit = ConsentEdgeHit(edgeEndpoint: CONSENT_ENDPOINT_PROD, configId: CONFIG_ID, consents: CONSENT_UPDATE_REQUEST)
+        let edgeHit = ConsentEdgeHit(endpoint: CONSENT_ENDPOINT_PROD, configId: CONFIG_ID, consents: CONSENT_UPDATE_REQUEST)
         XCTAssertNil(edgeHit.getStreamingSettings())
     }
 
@@ -143,7 +149,7 @@ class EdgeHitTests: XCTestCase {
         let consentUpdate = EdgeConsentUpdate(meta: RequestMetadata(konductorConfig: KonductorConfig(streaming: streamingSettings), state: nil),
                                               identityMap: nil,
                                               consent: [EdgeConsentPayload(standard: "Adobe", version: "2.0", value: ["consent": ["collect": "y"]])])
-        let edgeHit = ConsentEdgeHit(edgeEndpoint: CONSENT_ENDPOINT_PROD, configId: CONFIG_ID, consents: consentUpdate)
+        let edgeHit = ConsentEdgeHit(endpoint: CONSENT_ENDPOINT_PROD, configId: CONFIG_ID, consents: consentUpdate)
         XCTAssertNotNil(edgeHit.getStreamingSettings())
     }
 

--- a/Tests/UnitTests/EdgeHitTests.swift
+++ b/Tests/UnitTests/EdgeHitTests.swift
@@ -17,8 +17,10 @@ import XCTest
 class EdgeHitTests: XCTestCase {
     private let CONFIG_ID = "testConfigId"
     private let EDGE_REQUEST = EdgeRequest(meta: nil, xdm: nil, events: [["test": "data"]])
+    private let INTERACT_ENDPOINT_PROD = EdgeEndpoint(requestType: .interact, environmentType: .production)
     private let CONSENT_UPDATE_REQUEST = EdgeConsentUpdate(meta: nil, identityMap: nil, consent: [EdgeConsentPayload(standard: "Adobe", version: "2.0", value: ["consent": ["collect": "y"]])])
-    private let ENDPOINT_PROD = EdgeEndpoint(type: .production)
+    private let CONSENT_ENDPOINT_PROD = EdgeEndpoint(requestType: .consent, environmentType: .production)
+
     override func setUp() {
         continueAfterFailure = false
     }
@@ -26,19 +28,19 @@ class EdgeHitTests: XCTestCase {
     // MARK: ExperienceEventsEdgeHit tests
 
     func testExperienceEventsEdgeHit() {
-        let edgeHit = ExperienceEventsEdgeHit(edgeEndpoint: ENDPOINT_PROD, configId: CONFIG_ID, request: EDGE_REQUEST)
-        XCTAssertEqual(ENDPOINT_PROD.endpointUrl, edgeHit.edgeEndpoint.endpointUrl)
+        let edgeHit = ExperienceEventsEdgeHit(edgeEndpoint: INTERACT_ENDPOINT_PROD, configId: CONFIG_ID, request: EDGE_REQUEST)
+        XCTAssertEqual(INTERACT_ENDPOINT_PROD.url, edgeHit.edgeEndpoint.url)
         XCTAssertEqual(CONFIG_ID, edgeHit.configId)
         XCTAssertNotNil(edgeHit.requestId)
         XCTAssertEqual(EDGE_REQUEST.events, edgeHit.request.events)
     }
 
     func testExperienceEventsEdgeHit_streamingSettings() {
-        let edgeHit1 = ExperienceEventsEdgeHit(edgeEndpoint: ENDPOINT_PROD, configId: CONFIG_ID, request: EdgeRequest(meta: nil, xdm: nil, events: [["test": "data"]]))
+        let edgeHit1 = ExperienceEventsEdgeHit(edgeEndpoint: INTERACT_ENDPOINT_PROD, configId: CONFIG_ID, request: EdgeRequest(meta: nil, xdm: nil, events: [["test": "data"]]))
         XCTAssertNil(edgeHit1.getStreamingSettings())
 
         let streamingSettings = Streaming(recordSeparator: "A", lineFeed: "B")
-        let edgeHit2 = ExperienceEventsEdgeHit(edgeEndpoint: ENDPOINT_PROD,
+        let edgeHit2 = ExperienceEventsEdgeHit(edgeEndpoint: INTERACT_ENDPOINT_PROD,
                                                configId: CONFIG_ID,
                                                request: EdgeRequest(meta: RequestMetadata(konductorConfig: KonductorConfig(streaming: streamingSettings), state: nil),
                                                                     xdm: nil, events: [["test": "data"]]))
@@ -53,7 +55,7 @@ class EdgeHitTests: XCTestCase {
                     """.data(using: .utf8)! // swiftlint:disable:this force_unwrapping
 
         let expectedPayload = try! JSONSerialization.jsonObject(with: json, options: []) as! [String: Any]
-        let edgeHit = ExperienceEventsEdgeHit(edgeEndpoint: ENDPOINT_PROD, configId: CONFIG_ID, request: EdgeRequest(meta: nil, xdm: nil, events: [["test": "data"]]))
+        let edgeHit = ExperienceEventsEdgeHit(edgeEndpoint: INTERACT_ENDPOINT_PROD, configId: CONFIG_ID, request: EdgeRequest(meta: nil, xdm: nil, events: [["test": "data"]]))
 
         XCTAssertTrue(expectedPayload == payloadToDict(payload: edgeHit.getPayload()))
     }
@@ -70,7 +72,7 @@ class EdgeHitTests: XCTestCase {
                 """.data(using: .utf8)! // swiftlint:disable:this force_unwrapping
         let expectedPayload = try! JSONSerialization.jsonObject(with: json, options: []) as! [String: Any]
         let streamingSettings = Streaming(recordSeparator: "A", lineFeed: "B")
-        let edgeHit = ExperienceEventsEdgeHit(edgeEndpoint: ENDPOINT_PROD,
+        let edgeHit = ExperienceEventsEdgeHit(edgeEndpoint: INTERACT_ENDPOINT_PROD,
                                               configId: CONFIG_ID,
                                               request: EdgeRequest(meta: RequestMetadata(konductorConfig: KonductorConfig(streaming: streamingSettings), state: nil), xdm: nil, events: [["test": "data"]]))
 
@@ -78,8 +80,8 @@ class EdgeHitTests: XCTestCase {
     }
 
     func testExperienceEventsEdgeHit_getType() {
-        let edgeHit = ExperienceEventsEdgeHit(edgeEndpoint: ENDPOINT_PROD, configId: CONFIG_ID, request: EDGE_REQUEST)
-        XCTAssertEqual(ExperienceEdgeRequestType.interact, edgeHit.getType())
+        let edgeHit = ExperienceEventsEdgeHit(edgeEndpoint: INTERACT_ENDPOINT_PROD, configId: CONFIG_ID, request: EDGE_REQUEST)
+        XCTAssertEqual(EdgeRequestType.interact, edgeHit.getType())
     }
 
     // MARK: ConsentEgeHit tests
@@ -100,7 +102,7 @@ class EdgeHitTests: XCTestCase {
             }
             """.data(using: .utf8)! // swiftlint:disable:this force_unwrapping
         let expectedPayload = try! JSONSerialization.jsonObject(with: json, options: []) as! [String: Any]
-        let edgeHit = ConsentEdgeHit(edgeEndpoint: ENDPOINT_PROD, configId: CONFIG_ID, consents: CONSENT_UPDATE_REQUEST)
+        let edgeHit = ConsentEdgeHit(edgeEndpoint: CONSENT_ENDPOINT_PROD, configId: CONFIG_ID, consents: CONSENT_UPDATE_REQUEST)
 
         XCTAssertTrue(expectedPayload == payloadToDict(payload: edgeHit.getPayload()))
     }
@@ -131,18 +133,18 @@ class EdgeHitTests: XCTestCase {
         let consentUpdate = EdgeConsentUpdate(meta: RequestMetadata(konductorConfig: KonductorConfig(streaming: streamingSettings), state: nil),
                                               identityMap: nil,
                                               consent: [EdgeConsentPayload(standard: "Adobe", version: "2.0", value: ["consent": ["collect": "y"]])])
-        let edgeHit = ConsentEdgeHit(edgeEndpoint: ENDPOINT_PROD, configId: CONFIG_ID, consents: consentUpdate)
+        let edgeHit = ConsentEdgeHit(edgeEndpoint: CONSENT_ENDPOINT_PROD, configId: CONFIG_ID, consents: consentUpdate)
 
         XCTAssertTrue(expectedPayload == payloadToDict(payload: edgeHit.getPayload()))
     }
 
     func testConsentEdgeHit_getType() {
-        let edgeHit = ConsentEdgeHit(edgeEndpoint: ENDPOINT_PROD, configId: CONFIG_ID, consents: CONSENT_UPDATE_REQUEST)
-        XCTAssertEqual(ExperienceEdgeRequestType.consent, edgeHit.getType())
+        let edgeHit = ConsentEdgeHit(edgeEndpoint: CONSENT_ENDPOINT_PROD, configId: CONFIG_ID, consents: CONSENT_UPDATE_REQUEST)
+        XCTAssertEqual(EdgeRequestType.consent, edgeHit.getType())
     }
 
     func testConsentEdgeHit_getStreamingSettings_streamingNotEnabled() {
-        let edgeHit = ConsentEdgeHit(edgeEndpoint: ENDPOINT_PROD, configId: CONFIG_ID, consents: CONSENT_UPDATE_REQUEST)
+        let edgeHit = ConsentEdgeHit(edgeEndpoint: CONSENT_ENDPOINT_PROD, configId: CONFIG_ID, consents: CONSENT_UPDATE_REQUEST)
         XCTAssertNil(edgeHit.getStreamingSettings())
     }
 
@@ -151,7 +153,7 @@ class EdgeHitTests: XCTestCase {
         let consentUpdate = EdgeConsentUpdate(meta: RequestMetadata(konductorConfig: KonductorConfig(streaming: streamingSettings), state: nil),
                                               identityMap: nil,
                                               consent: [EdgeConsentPayload(standard: "Adobe", version: "2.0", value: ["consent": ["collect": "y"]])])
-        let edgeHit = ConsentEdgeHit(edgeEndpoint: ENDPOINT_PROD, configId: CONFIG_ID, consents: consentUpdate)
+        let edgeHit = ConsentEdgeHit(edgeEndpoint: CONSENT_ENDPOINT_PROD, configId: CONFIG_ID, consents: consentUpdate)
         XCTAssertNotNil(edgeHit.getStreamingSettings())
     }
 

--- a/Tests/UnitTests/EdgeHitTests.swift
+++ b/Tests/UnitTests/EdgeHitTests.swift
@@ -79,11 +79,6 @@ class EdgeHitTests: XCTestCase {
         XCTAssertTrue(expectedPayload == payloadToDict(payload: edgeHit.getPayload()))
     }
 
-    func testExperienceEventsEdgeHit_getType() {
-        let edgeHit = ExperienceEventsEdgeHit(edgeEndpoint: INTERACT_ENDPOINT_PROD, configId: CONFIG_ID, request: EDGE_REQUEST)
-        XCTAssertEqual(EdgeRequestType.interact, edgeHit.getType())
-    }
-
     // MARK: ConsentEgeHit tests
 
     func testConsentEdgeHit_getPayload() {
@@ -136,11 +131,6 @@ class EdgeHitTests: XCTestCase {
         let edgeHit = ConsentEdgeHit(edgeEndpoint: CONSENT_ENDPOINT_PROD, configId: CONFIG_ID, consents: consentUpdate)
 
         XCTAssertTrue(expectedPayload == payloadToDict(payload: edgeHit.getPayload()))
-    }
-
-    func testConsentEdgeHit_getType() {
-        let edgeHit = ConsentEdgeHit(edgeEndpoint: CONSENT_ENDPOINT_PROD, configId: CONFIG_ID, consents: CONSENT_UPDATE_REQUEST)
-        XCTAssertEqual(EdgeRequestType.consent, edgeHit.getType())
     }
 
     func testConsentEdgeHit_getStreamingSettings_streamingNotEnabled() {

--- a/Tests/UnitTests/EdgeNetworkServiceTests.swift
+++ b/Tests/UnitTests/EdgeNetworkServiceTests.swift
@@ -20,8 +20,8 @@ class EdgeNetworkServiceTests: XCTestCase {
     private var mockNetworking = MockNetworking()
     private var mockResponseCallback = MockResponseCallback()
     private var networkService = EdgeNetworkService()
-    private let edgeHitPayload = ExperienceEventsEdgeHit(edgeEndpoint: EdgeEndpoint(requestType: EdgeRequestType.interact,
-                                                                                    environmentType: .production),
+    private let edgeHitPayload = ExperienceEventsEdgeHit(endpoint: EdgeEndpoint(requestType: EdgeRequestType.interact,
+                                                                                environmentType: .production),
                                                          configId: "configIdExample",
                                                          request: EdgeRequest(meta: nil, xdm: nil, events: [["test": "data"]])).getPayload()
     private let url = URL(string: "https://test.com")! // swiftlint:disable:this force_unwrapping

--- a/Tests/UnitTests/EdgeNetworkServiceTests.swift
+++ b/Tests/UnitTests/EdgeNetworkServiceTests.swift
@@ -20,7 +20,10 @@ class EdgeNetworkServiceTests: XCTestCase {
     private var mockNetworking = MockNetworking()
     private var mockResponseCallback = MockResponseCallback()
     private var networkService = EdgeNetworkService()
-    private let edgeHitPayload = ExperienceEventsEdgeHit(edgeEndpoint: EdgeEndpoint(type: .production), configId: "configIdExample", request: EdgeRequest(meta: nil, xdm: nil, events: [["test": "data"]])).getPayload()
+    private let edgeHitPayload = ExperienceEventsEdgeHit(edgeEndpoint: EdgeEndpoint(requestType: EdgeRequestType.interact,
+                                                                                    environmentType: .production),
+                                                         configId: "configIdExample",
+                                                         request: EdgeRequest(meta: nil, xdm: nil, events: [["test": "data"]])).getPayload()
     private let url = URL(string: "https://test.com")! // swiftlint:disable:this force_unwrapping
     private let defaultNetworkingHeaders: [String] = ["User-Agent", "Accept-Language"]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- Updates how EdgeEndpoint is calculated using URLComponents and requires EdgeRequestType
- Renames ExperienceEdgeRequestType -> EdgeRequestType
- Removes unused EdgeRequestType.collect, can be re-added in the future if needed
- Group test cases by area to reduce lines of code in EdgeEndpoint tests, adds test for consent endpoints

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Changes made in preparation for path overwrite

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
