### PR TITLE
[MOB-16678] Handle edge network location hint response

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
 
   build-and-test:
     macos:
-      xcode: 12.0.1 # Specify the Xcode version to use
+      xcode: 13.4.0 # Specify the Xcode version to use
 
     steps:
       - checkout

--- a/AEPEdge.xcodeproj/project.pbxproj
+++ b/AEPEdge.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		BF0F92522756A57800378913 /* ImplementationDetailsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0F92502756A3EF00378913 /* ImplementationDetailsTests.swift */; };
 		BF4A717926DDAE4C00612434 /* AssuranceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4A717826DDAE4B00612434 /* AssuranceView.swift */; };
 		BF74550D28BB18CD00FF3AEC /* EdgeProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF74550C28BB18CD00FF3AEC /* EdgeProperties.swift */; };
+		BF74551128BC649A00FF3AEC /* EdgeStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF74551028BC649A00FF3AEC /* EdgeStateTests.swift */; };
 		BF7E5B3B2789189D00D5E0FF /* EdgeEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7E5B3A2789189D00D5E0FF /* EdgeEndpointTests.swift */; };
 		BF947F74243BA0E10057A6CC /* KonductorConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF947F73243BA0E10057A6CC /* KonductorConfigTests.swift */; };
 		BF947F7E243EA1300057A6CC /* RequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF947F7D243EA1300057A6CC /* RequestBuilderTests.swift */; };
@@ -224,6 +225,7 @@
 		BF0F92502756A3EF00378913 /* ImplementationDetailsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplementationDetailsTests.swift; sourceTree = "<group>"; };
 		BF4A717826DDAE4B00612434 /* AssuranceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssuranceView.swift; sourceTree = "<group>"; };
 		BF74550C28BB18CD00FF3AEC /* EdgeProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeProperties.swift; sourceTree = "<group>"; };
+		BF74551028BC649A00FF3AEC /* EdgeStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeStateTests.swift; sourceTree = "<group>"; };
 		BF7E5B3A2789189D00D5E0FF /* EdgeEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeEndpointTests.swift; sourceTree = "<group>"; };
 		BF947F62243565CC0057A6CC /* Edge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Edge.swift; sourceTree = "<group>"; };
 		BF947F63243565CC0057A6CC /* EdgeConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EdgeConstants.swift; sourceTree = "<group>"; };
@@ -520,6 +522,7 @@
 				D4145F3F25D1D3200019EA4C /* EdgeHitTests.swift */,
 				D4000F34245A53FB0052C536 /* EdgeNetworkServiceTests.swift */,
 				BF947F9F244569190057A6CC /* EdgeRequestTests.swift */,
+				BF74551028BC649A00FF3AEC /* EdgeStateTests.swift */,
 				1CCD27C82458CB8000E912B2 /* ExperienceEventTests.swift */,
 				BF0F92502756A3EF00378913 /* ImplementationDetailsTests.swift */,
 				BF947F73243BA0E10057A6CC /* KonductorConfigTests.swift */,
@@ -1066,6 +1069,7 @@
 				BF0F92522756A57800378913 /* ImplementationDetailsTests.swift in Sources */,
 				D49A628F250AE4F500B7C4A3 /* EventHub+Test.swift in Sources */,
 				BF947F74243BA0E10057A6CC /* KonductorConfigTests.swift in Sources */,
+				BF74551128BC649A00FF3AEC /* EdgeStateTests.swift in Sources */,
 				D45F2E7E25EE190A000AC350 /* MockHitProcessor.swift in Sources */,
 				D4F74FE92447A92800379258 /* MockURLSession.swift in Sources */,
 				D4145F4025D1D3200019EA4C /* EdgeHitTests.swift in Sources */,

--- a/AEPEdge.xcodeproj/project.pbxproj
+++ b/AEPEdge.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		BF0F924F27476E6C00378913 /* ImplementationDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0F924E27476E6C00378913 /* ImplementationDetails.swift */; };
 		BF0F92522756A57800378913 /* ImplementationDetailsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0F92502756A3EF00378913 /* ImplementationDetailsTests.swift */; };
 		BF4A717926DDAE4C00612434 /* AssuranceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF4A717826DDAE4B00612434 /* AssuranceView.swift */; };
+		BF74550D28BB18CD00FF3AEC /* EdgeProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF74550C28BB18CD00FF3AEC /* EdgeProperties.swift */; };
 		BF7E5B3B2789189D00D5E0FF /* EdgeEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF7E5B3A2789189D00D5E0FF /* EdgeEndpointTests.swift */; };
 		BF947F74243BA0E10057A6CC /* KonductorConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF947F73243BA0E10057A6CC /* KonductorConfigTests.swift */; };
 		BF947F7E243EA1300057A6CC /* RequestBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF947F7D243EA1300057A6CC /* RequestBuilderTests.swift */; };
@@ -222,6 +223,7 @@
 		BF0F924E27476E6C00378913 /* ImplementationDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplementationDetails.swift; sourceTree = "<group>"; };
 		BF0F92502756A3EF00378913 /* ImplementationDetailsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplementationDetailsTests.swift; sourceTree = "<group>"; };
 		BF4A717826DDAE4B00612434 /* AssuranceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssuranceView.swift; sourceTree = "<group>"; };
+		BF74550C28BB18CD00FF3AEC /* EdgeProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeProperties.swift; sourceTree = "<group>"; };
 		BF7E5B3A2789189D00D5E0FF /* EdgeEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeEndpointTests.swift; sourceTree = "<group>"; };
 		BF947F62243565CC0057A6CC /* Edge.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Edge.swift; sourceTree = "<group>"; };
 		BF947F63243565CC0057A6CC /* EdgeConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EdgeConstants.swift; sourceTree = "<group>"; };
@@ -494,6 +496,7 @@
 				BF947F63243565CC0057A6CC /* EdgeConstants.swift */,
 				BF947F62243565CC0057A6CC /* Edge.swift */,
 				D4EC0D9625E6CEA00026EBAA /* EdgeHitQueueing+Consent.swift */,
+				BF74550C28BB18CD00FF3AEC /* EdgeProperties.swift */,
 				D4EC0DBA25E73FF10026EBAA /* EdgeState.swift */,
 				D4145FB425D5D0430019EA4C /* Event+Edge.swift */,
 				BF0F924E27476E6C00378913 /* ImplementationDetails.swift */,
@@ -1012,6 +1015,7 @@
 				D4145FB525D5D0430019EA4C /* Event+Edge.swift in Sources */,
 				D4C6B43D251A76CB0038F4F9 /* EdgeEventHandle.swift in Sources */,
 				D4C6B43E251A76CB0038F4F9 /* EdgeRequest.swift in Sources */,
+				BF74550D28BB18CD00FF3AEC /* EdgeProperties.swift in Sources */,
 				D43BAB0325BB758400B08CC0 /* EdgeConsentStatus.swift in Sources */,
 				D4C6B43F251A76CB0038F4F9 /* EdgeResponse.swift in Sources */,
 				D4C6B440251A76CB0038F4F9 /* EdgeNetworkService.swift in Sources */,

--- a/AEPEdge.xcodeproj/xcshareddata/xcschemes/AEPEdge.xcscheme
+++ b/AEPEdge.xcodeproj/xcshareddata/xcschemes/AEPEdge.xcscheme
@@ -54,7 +54,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D444995E2519506B0093B364"
+            BuildableName = "AEPEdge.framework"
+            BlueprintName = "AEPEdge"
+            ReferencedContainer = "container:AEPEdge.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Sources/Edge.swift
+++ b/Sources/Edge.swift
@@ -241,6 +241,7 @@ public class Edge: NSObject, Extension {
 
     /// Set the location hint for the Edge Network. The new location hint and expiry date (calculated from the ttlSeconds) are updated in memory and in
     /// persistent storage. If the new location hint is different from the previous, then a shared state is also created with the new hint.
+    /// A nil `hint` value will clear the location hint in memory, persistent storage, and create a new shared state if a previous location hint was set.
     /// - Parameters:
     ///   - hint: the new EdgeNetwork location hint to set
     ///   - ttlSeconds: the time-to-live for the location hint
@@ -248,6 +249,8 @@ public class Edge: NSObject, Extension {
         guard let state = state else { return }
         if let hint = hint, let ttlSeconds = ttlSeconds {
             state.setLocationHint(hint: hint, ttlSeconds: ttlSeconds, createSharedState: createSharedState(data:event:))
+        } else if hint == nil {
+            state.clearLocationHint(createSharedState: createSharedState(data:event:))
         }
     }
 

--- a/Sources/Edge.swift
+++ b/Sources/Edge.swift
@@ -35,7 +35,7 @@ public class Edge: NSObject, Extension {
         // set default on init for register/unregister use-case
         networkResponseHandler = NetworkResponseHandler(updateLocationHint: setLocationHint)
         if let hitQueue = setupHitQueue() {
-            state = EdgeState(hitQueue: hitQueue)
+            state = EdgeState(hitQueue: hitQueue, edgeProperties: EdgeProperties())
         }
     }
 
@@ -195,7 +195,9 @@ public class Edge: NSObject, Extension {
     /// - Returns: true if events can be processed at the moment, false otherwise
     private func canProcessEvents(event: Event) -> Bool {
         guard let state = state else { return false }
-        state.bootupIfNeeded(event: event, getSharedState: getSharedState(extensionName:event:barrier:))
+        state.bootupIfNeeded(event: event,
+                             getSharedState: getSharedState(extensionName:event:barrier:),
+                             createSharedState: createSharedState(data:event:))
         return true
     }
 

--- a/Sources/Edge.swift
+++ b/Sources/Edge.swift
@@ -33,7 +33,7 @@ public class Edge: NSObject, Extension {
         super.init()
 
         // set default on init for register/unregister use-case
-        networkResponseHandler = NetworkResponseHandler()
+        networkResponseHandler = NetworkResponseHandler(updateLocationHint: setLocationHint)
         if let hitQueue = setupHitQueue() {
             state = EdgeState(hitQueue: hitQueue)
         }
@@ -216,7 +216,8 @@ public class Edge: NSObject, Extension {
                                             getSharedState: getSharedState(extensionName:event:),
                                             getXDMSharedState: getXDMSharedState(extensionName:event:barrier:),
                                             readyForEvent: readyForEvent(_:),
-                                            getImplementationDetails: getImplementationDetails)
+                                            getImplementationDetails: getImplementationDetails,
+                                            getLocationHint: getLocationHint)
         return PersistentHitQueue(dataQueue: dataQueue, processor: hitProcessor)
     }
 
@@ -236,6 +237,17 @@ public class Edge: NSObject, Extension {
     /// - Returns: the `ImplementationDetails` for this session or nil if not yet set
     private func getImplementationDetails() -> [String: Any]? {
         return state?.implementationDetails
+    }
+
+    private func setLocationHint(hint: String?, ttlSeconds: TimeInterval?) {
+        guard let state = state else { return }
+        if let hint = hint, let ttlSeconds = ttlSeconds {
+            state.setLocationHint(hint: hint, ttlSeconds: ttlSeconds)
+        }
+    }
+
+    private func getLocationHint() -> String? {
+        return state?.getLocationHint()
     }
 
 }

--- a/Sources/Edge.swift
+++ b/Sources/Edge.swift
@@ -239,13 +239,20 @@ public class Edge: NSObject, Extension {
         return state?.implementationDetails
     }
 
+    /// Set the location hint for the Edge Network. The new location hint and expiry date (calculated from the ttlSeconds) are updated in memory and in
+    /// persistent storage. If the new location hint is different from the previous, then a shared state is also created with the new hint.
+    /// - Parameters:
+    ///   - hint: the new EdgeNetwork location hint to set
+    ///   - ttlSeconds: the time-to-live for the location hint
     private func setLocationHint(hint: String?, ttlSeconds: TimeInterval?) {
         guard let state = state else { return }
         if let hint = hint, let ttlSeconds = ttlSeconds {
-            state.setLocationHint(hint: hint, ttlSeconds: ttlSeconds)
+            state.setLocationHint(hint: hint, ttlSeconds: ttlSeconds, createSharedState: createSharedState(data:event:))
         }
     }
 
+    /// Get the Edge Network location hint.
+    /// - Returns: the Edge Network location hint or nil if no location hint is set or the location hint expired.
     private func getLocationHint() -> String? {
         return state?.getLocationHint()
     }

--- a/Sources/EdgeConstants.swift
+++ b/Sources/EdgeConstants.swift
@@ -48,8 +48,7 @@ enum EdgeConstants {
         static let STORE_NAME = "AEPEdge"
         static let STORE_PAYLOADS = "storePayloads"
         static let RESET_IDENTITIES_DATE = "reset.identities.date"
-        static let LOCATION_HINT = "edgeNetworkLocationHint"
-        static let LOCATION_HINT_EXPIRY_DATE = "edgeNetworkLocationHintExpiryDate"
+        static let EDGE_PROPERTIES = "edge.properties"
     }
 
     enum SharedState {

--- a/Sources/EdgeConstants.swift
+++ b/Sources/EdgeConstants.swift
@@ -121,8 +121,10 @@ enum EdgeConstants {
         }
 
         enum Response {
-            static let EVENT_HANDLE_TYPE_STORE = "state:store"
-            static let EVENT_HANDLE_TYPE_LOCATION_HINT = "locationHint:result"
+            enum EventHandleType {
+                static let STORE = "state:store"
+                static let LOCATION_HINT = "locationHint:result"
+            }
 
             enum Error {
                 static let MESSAGE = "message"

--- a/Sources/EdgeConstants.swift
+++ b/Sources/EdgeConstants.swift
@@ -55,6 +55,10 @@ enum EdgeConstants {
     enum SharedState {
         static let STATE_OWNER = "stateowner"
 
+        enum Edge {
+            static let LOCATION_HINT = "locationHint"
+        }
+
         enum Configuration {
             static let STATE_OWNER_NAME = "com.adobe.module.configuration"
             static let CONFIG_ID = "edge.configId"

--- a/Sources/EdgeConstants.swift
+++ b/Sources/EdgeConstants.swift
@@ -48,6 +48,8 @@ enum EdgeConstants {
         static let STORE_NAME = "AEPEdge"
         static let STORE_PAYLOADS = "storePayloads"
         static let RESET_IDENTITIES_DATE = "reset.identities.date"
+        static let LOCATION_HINT = "edgeNetworkLocationHint"
+        static let LOCATION_HINT_EXPIRY_DATE = "edgeNetworkLocationHintExpiryDate"
     }
 
     enum SharedState {
@@ -117,10 +119,17 @@ enum EdgeConstants {
 
         enum Response {
             static let EVENT_HANDLE_TYPE_STORE = "state:store"
+            static let EVENT_HANDLE_TYPE_LOCATION_HINT = "locationHint:result"
 
             enum Error {
                 static let MESSAGE = "message"
                 static let NAMESPACE = "namespace"
+            }
+
+            enum LocationHint {
+                static let SCOPE = "scope"
+                static let HINT = "hint"
+                static let TTL_SECONDS = "ttlSeconds"
             }
         }
     }

--- a/Sources/EdgeNetworkHandlers/EdgeEndpoint.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeEndpoint.swift
@@ -46,8 +46,7 @@ struct EdgeEndpoint {
          environmentType: EdgeEnvironmentType,
          optionalDomain: String? = nil,
          optionalPath: String? = nil,
-         locationHint: String? = nil)
-    {
+         locationHint: String? = nil) {
         let domain: String
         if let unwrappedDomain = optionalDomain, !unwrappedDomain.isEmpty {
             domain = unwrappedDomain

--- a/Sources/EdgeNetworkHandlers/EdgeEndpoint.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeEndpoint.swift
@@ -40,11 +40,11 @@ struct EdgeEndpoint {
     ///   - requestType: the `EdgeRequestType` to be used
     ///   - environmentType: the `EdgeEnvironmentType` for the `EdgeEndpoint`
     ///   - optionalDomain: an optional custom domain for the `EdgeEndpoint`. If not set the default domain is used.
-    ///   - regionId: an optional region ID for the `EdgeEndpoint` which hints at the Edge Network cluster to send requests.
+    ///   - locationHint: an optional location hint for the `EdgeEndpoint` which hints at the Edge Network cluster to send requests.
     init(requestType: EdgeRequestType,
          environmentType: EdgeEnvironmentType,
          optionalDomain: String? = nil,
-         regionId: String? = nil) {
+         locationHint: String? = nil) {
         let domain: String
         if let unwrappedDomain = optionalDomain, !unwrappedDomain.isEmpty {
             domain = unwrappedDomain
@@ -68,8 +68,8 @@ struct EdgeEndpoint {
             components.path = EdgeConstants.NetworkKeys.EDGE_ENDPOINT_PATH
         }
 
-        if let regionId = regionId, !regionId.isEmpty {
-            components.path.append("/\(regionId)")
+        if let locationHint = locationHint, !locationHint.isEmpty {
+            components.path.append("/\(locationHint)")
         }
 
         components.path.append(EdgeConstants.NetworkKeys.EDGE_ENDPOINT_VERSION_PATH)

--- a/Sources/EdgeNetworkHandlers/EdgeEndpoint.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeEndpoint.swift
@@ -40,9 +40,11 @@ struct EdgeEndpoint {
     ///   - requestType: the `EdgeRequestType` to be used
     ///   - environmentType: the `EdgeEnvironmentType` for the `EdgeEndpoint`
     ///   - optionalDomain: an optional custom domain for the `EdgeEndpoint`. If not set the default domain is used.
+    ///   - regionId: an optional region ID for the `EdgeEndpoint` which hints at the Edge Network cluster to send requests.
     init(requestType: EdgeRequestType,
          environmentType: EdgeEnvironmentType,
-         optionalDomain: String? = nil) {
+         optionalDomain: String? = nil,
+         regionId: String? = nil) {
         let domain: String
         if let unwrappedDomain = optionalDomain, !unwrappedDomain.isEmpty {
             domain = unwrappedDomain
@@ -64,6 +66,10 @@ struct EdgeEndpoint {
             // Edge Integration endpoint does not support custom domains, so there is just the one URL
             components.host = EdgeConstants.NetworkKeys.EDGE_INTEGRATION_DOMAIN
             components.path = EdgeConstants.NetworkKeys.EDGE_ENDPOINT_PATH
+        }
+
+        if let regionId = regionId, !regionId.isEmpty {
+            components.path.append("/\(regionId)")
         }
 
         components.path.append(EdgeConstants.NetworkKeys.EDGE_ENDPOINT_VERSION_PATH)

--- a/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
@@ -25,8 +25,6 @@ class EdgeHitProcessor: HitProcessing {
     private var getImplementationDetails: () -> [String: Any]?
     private var getLocationHint: () -> String?
     private var entityRetryIntervalMapping = ThreadSafeDictionary<String, TimeInterval>()
-    // Note, use same Data Store collection used to store Edge Network Region ID
-    private let dataStore = NamedCollectionDataStore(name: EdgeConstants.EXTENSION_NAME)
 
     init(networkService: EdgeNetworkService,
          networkResponseHandler: NetworkResponseHandler,
@@ -149,7 +147,7 @@ class EdgeHitProcessor: HitProcessing {
             requestType: requestType,
             environmentType: EdgeEnvironmentType(optionalRawValue: config[EdgeConstants.SharedState.Configuration.EDGE_ENVIRONMENT]),
             optionalDomain: config[EdgeConstants.SharedState.Configuration.EDGE_DOMAIN],
-            regionId: locationHint)
+            locationHint: locationHint)
     }
 
     private func decode(dataEntity: DataEntity) -> EdgeDataEntity? {

--- a/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
+++ b/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
@@ -155,9 +155,9 @@ class NetworkResponseHandler {
                 Log.debug(label: LOG_TAG, "Identities were reset recently, ignoring state:store payload for request with id: \(requestId)")
             } else {
                 if let type = eventHandle.type {
-                    if EdgeConstants.JsonKeys.Response.EVENT_HANDLE_TYPE_STORE == type.lowercased() {
+                    if EdgeConstants.JsonKeys.Response.EventHandleType.STORE == type.lowercased() {
                         handleStoreEventHandle(handle: eventHandle)
-                    } else if EdgeConstants.JsonKeys.Response.EVENT_HANDLE_TYPE_LOCATION_HINT == type {
+                    } else if EdgeConstants.JsonKeys.Response.EventHandleType.LOCATION_HINT == type {
                         handleLocationHintHandle(handle: eventHandle)
                     }
                 }
@@ -304,7 +304,7 @@ class NetworkResponseHandler {
     private func handleStoreEventHandle(handle: EdgeEventHandle) {
         let storeResponsePayloadManager = StoreResponsePayloadManager(EdgeConstants.DataStoreKeys.STORE_NAME)
 
-        guard let type = handle.type, EdgeConstants.JsonKeys.Response.EVENT_HANDLE_TYPE_STORE == type.lowercased() else { return }
+        guard let type = handle.type, EdgeConstants.JsonKeys.Response.EventHandleType.STORE == type.lowercased() else { return }
         guard let payload: [[String: Any]] = handle.payload else { return }
 
         var storeResponsePayloads: [StoreResponsePayload] = []
@@ -328,7 +328,7 @@ class NetworkResponseHandler {
     /// If handle is of type "locationHint:result", persist it to the data store
     /// - Parameter handle: current `EventHandle` to process
     private func handleLocationHintHandle(handle: EdgeEventHandle) {
-        guard let type = handle.type, EdgeConstants.JsonKeys.Response.EVENT_HANDLE_TYPE_LOCATION_HINT == type else { return }
+        guard let type = handle.type, EdgeConstants.JsonKeys.Response.EventHandleType.LOCATION_HINT == type else { return }
         guard let payload: [[String: Any]] = handle.payload else { return }
 
         for locationHint in payload {

--- a/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
+++ b/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
@@ -333,10 +333,11 @@ class NetworkResponseHandler {
 
         for locationHint in payload {
             if let scope = locationHint[EdgeConstants.JsonKeys.Response.LocationHint.SCOPE] as? String, scope == "EdgeNetwork" {
-                guard let hint = locationHint[EdgeConstants.JsonKeys.Response.LocationHint.HINT] as? String, !hint.isEmpty else { continue }
-                guard let ttlSeconds = locationHint[EdgeConstants.JsonKeys.Response.LocationHint.TTL_SECONDS] as? Int else { continue }
+                if let hint = locationHint[EdgeConstants.JsonKeys.Response.LocationHint.HINT] as? String, !hint.isEmpty,
+                   let ttlSeconds = locationHint[EdgeConstants.JsonKeys.Response.LocationHint.TTL_SECONDS] as? Int {
+                    updateLocationHint(hint, TimeInterval(ttlSeconds))
+                }
 
-                updateLocationHint(hint, TimeInterval(ttlSeconds))
                 break
             }
         }

--- a/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
+++ b/Sources/EdgeNetworkHandlers/NetworkResponseHandler.swift
@@ -337,6 +337,7 @@ class NetworkResponseHandler {
                 guard let ttlSeconds = locationHint[EdgeConstants.JsonKeys.Response.LocationHint.TTL_SECONDS] as? Int else { continue }
 
                 updateLocationHint(hint, TimeInterval(ttlSeconds))
+                break
             }
         }
     }

--- a/Sources/EdgeProperties.swift
+++ b/Sources/EdgeProperties.swift
@@ -36,7 +36,10 @@ struct EdgeProperties: Codable {
     ///   - ttlSeconds: the time-to-live in seconds for the given location hint
     ///   - Returns: true if the location hint value changed
     mutating func setLocationHint(hint: String, ttlSeconds: TimeInterval) -> Bool {
-        let hasHintChanged = locationHint != hint // Note using "locationHint" not "_locationHint" so expiry date is checked
+        // Determine if hint changed. Use "locationHint" here so expiry date is checked
+        // As this check can determine if a shared state is created, need to check expiry date to determine if hint
+        // changed in cases where state is not shared if hint expired, such as boot up case
+        let hasHintChanged = locationHint != hint
         let newExpiryDate = Date() + ttlSeconds
 
         _locationHint = hint
@@ -48,7 +51,10 @@ struct EdgeProperties: Codable {
     /// Clears the Edge Network location hint from memory and persistent storage. If the previous location hint was set, then returns true.
     /// - Returns: true if a non-nil location hint value was cleared
     mutating func clearLocationHint() -> Bool {
-        let hasHintChanged = locationHint != nil // Note using "locationHint" not "_locationHint" so expiry date is checked
+        // Determine if hint changed. Use "_locationHint" here so expiry date is not checked.
+        // As this check can determine if a shared state is created, need to check hint regardless of expiry date
+        // to create shared state with cleared hint as the shared state doesn't include the ttl or expiry date.
+        let hasHintChanged = _locationHint != nil
         _locationHint = nil
         locationHintExpiryDate = nil
 

--- a/Sources/EdgeProperties.swift
+++ b/Sources/EdgeProperties.swift
@@ -22,12 +22,10 @@ struct EdgeProperties: Codable {
 
     /// Retrieves the Edge Network location hint. Returns nil if location hit expired or is not set.
     var locationHint: String? {
-        get {
-            if let expiryDate = self.locationHintExpiryDate, expiryDate > Date() {
-                return self._locationHint
-            }
-            return nil
+        if let expiryDate = self.locationHintExpiryDate, expiryDate > Date() {
+            return self._locationHint
         }
+        return nil
     }
 
     /// Update the Edge Network location hint and persist the new hint to the data store. If the new location hint is different from the previous, then returns true.

--- a/Sources/EdgeProperties.swift
+++ b/Sources/EdgeProperties.swift
@@ -43,6 +43,8 @@ struct EdgeProperties: Codable {
         _locationHint = hint
         locationHintExpiryDate = newExpiryDate
 
+        saveToPersistence()
+
         return hasHintChanged
     }
 
@@ -55,6 +57,8 @@ struct EdgeProperties: Codable {
         let hasHintChanged = _locationHint != nil
         _locationHint = nil
         locationHintExpiryDate = nil
+
+        saveToPersistence()
 
         return hasHintChanged
     }

--- a/Sources/EdgeProperties.swift
+++ b/Sources/EdgeProperties.swift
@@ -1,0 +1,88 @@
+//
+// Copyright 2022 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+import AEPServices
+import Foundation
+
+/// Structure to manage properties used by the Edge extension.
+struct EdgeProperties: Codable {
+
+    // Edge Network location hint and expiration date. Location hint is invalid after expiry date.
+    private var _locationHint: String?
+    private(set) var locationHintExpiryDate: Date?
+
+    /// Retrieves the Edge Network location hint. Returns nil if location hit expired or is not set.
+    var locationHint: String? {
+        get {
+            if let expiryDate = self.locationHintExpiryDate, expiryDate > Date() {
+                return self._locationHint
+            }
+            return nil
+        }
+    }
+
+    /// Update the Edge Network location hint and persist the new hint to the data store. If the new location hint is different from the previous, then returns true.
+    /// - Parameters:
+    ///   - hint: the Edge Network location hint to set
+    ///   - ttlSeconds: the time-to-live in seconds for the given location hint
+    ///   - Returns: true if the location hint value changed
+    mutating func setLocationHint(hint: String, ttlSeconds: TimeInterval) -> Bool {
+        let hasHintChanged = locationHint != hint // Note using "locationHint" not "_locationHint" so expiry date is checked
+        let newExpiryDate = Date() + ttlSeconds
+
+        _locationHint = hint
+        locationHintExpiryDate = newExpiryDate
+
+        return hasHintChanged
+    }
+
+    /// Clears the Edge Network location hint from memory and persistent storage. If the previous location hint was set, then returns true.
+    /// - Returns: true if a non-nil location hint value was cleared
+    mutating func clearLocationHint() -> Bool {
+        let hasHintChanged = locationHint != nil // Note using "locationHint" not "_locationHint" so expiry date is checked
+        _locationHint = nil
+        locationHintExpiryDate = nil
+
+        return hasHintChanged
+    }
+
+    /// Loads the fields of this `EdgeProperties` with the values stored in the Edge extension's data store.
+    mutating func loadFromPersistence() {
+        let dataStore = NamedCollectionDataStore(name: EdgeConstants.EXTENSION_NAME)
+        let savedProperties: EdgeProperties? = dataStore.getObject(key: EdgeConstants.DataStoreKeys.EDGE_PROPERTIES)
+
+        if let savedProperties = savedProperties {
+            self = savedProperties
+        }
+    }
+
+    /// Saves this instance of `EdgeProperties` to the Edge extension's data store.
+    func saveToPersistence() {
+        let dataStore = NamedCollectionDataStore(name: EdgeConstants.EXTENSION_NAME)
+        dataStore.setObject(key: EdgeConstants.DataStoreKeys.EDGE_PROPERTIES, value: self)
+    }
+
+    /// Returns a dictionary of the fields stored in this `EdgeProperties`.  Fields which have nil values are not included in the resultant dictionary.
+    /// The returned dictionary is suitable for sharing in the `EventHub` as a shared state.
+    /// - Returns: a dictionary of this `EdgeProperties`
+    func toEventData() -> [String: Any] {
+        var map: [String: Any] = [:]
+
+        // Use "locationHint", not "_locationHint" so expiry date is checked
+        if let hint = locationHint {
+            map[EdgeConstants.SharedState.Edge.LOCATION_HINT] = hint
+        }
+
+        return map
+    }
+
+}

--- a/Sources/EdgeState.swift
+++ b/Sources/EdgeState.swift
@@ -111,7 +111,6 @@ class EdgeState {
     func setLocationHint(hint: String, ttlSeconds: TimeInterval, createSharedState: @escaping (_ data: [String: Any], _ event: Event?) -> Void) {
         queue.async {
             let needsStateUpdate = self.edgeProperties.setLocationHint(hint: hint, ttlSeconds: ttlSeconds)
-            self.edgeProperties.saveToPersistence()
 
             if needsStateUpdate {
                 // Create shared state if location hint changed
@@ -132,7 +131,6 @@ class EdgeState {
     func clearLocationHint(createSharedState: @escaping (_ data: [String: Any], _ event: Event?) -> Void) {
         queue.async {
             let needsStateUpdate = self.edgeProperties.clearLocationHint()
-            self.edgeProperties.saveToPersistence()
 
             if needsStateUpdate {
                 // Create shared state if location hint changed

--- a/Sources/EdgeState.swift
+++ b/Sources/EdgeState.swift
@@ -75,7 +75,10 @@ class EdgeState {
         }
         // else keep consent pending until the consent preferences update event is received
 
-        // TODO - Always set state or only when properties are not empty ???
+        // Important - Using nil Event here which creates a shared state at the next available Event number.
+        //             An extension should NOT mix creating shared states using nil and using received events
+        //             as it can cause shared state generation to fail due to received events having potentially
+        //             lower event numbers than states using nil.
         createSharedState(edgeProperties.toEventData(), nil)
 
         hasBooted = true

--- a/Sources/EdgeState.swift
+++ b/Sources/EdgeState.swift
@@ -19,6 +19,8 @@ class EdgeState {
     private let SELF_TAG = "EdgeState"
     private let queue: DispatchQueue
     private var _implementationDetails: [String: Any]?
+    private var locationHint: String?
+    private var locationHintExpiryDate: Date?
     private(set) var hitQueue: HitQueuing
     private(set) var hasBooted = false
     private(set) var currentCollectConsent: ConsentStatus
@@ -26,6 +28,7 @@ class EdgeState {
         get { queue.sync { self._implementationDetails } }
         set { queue.async { self._implementationDetails = newValue } }
     }
+    private let dataStore = NamedCollectionDataStore(name: EdgeConstants.EXTENSION_NAME)
 
     /// Creates a new `EdgeState` and initializes the required properties and sets the initial collect consent
     init(hitQueue: HitQueuing) {
@@ -33,6 +36,9 @@ class EdgeState {
         self.hitQueue = hitQueue
         self.currentCollectConsent = EdgeConstants.Defaults.COLLECT_CONSENT_PENDING
         hitQueue.handleCollectConsentChange(status: currentCollectConsent)
+
+        // Assigns locationHint and locationHintExpiryDate variables from DataStore
+        loadLocationHintFromPersistence()
     }
 
     /// Completes init for the `Edge` extension and the collect consent is set based on either Consent shared state
@@ -73,5 +79,48 @@ class EdgeState {
     func updateCurrentConsent(status: ConsentStatus) {
         currentCollectConsent = status
         hitQueue.handleCollectConsentChange(status: status)
+    }
+
+    /// Get the current Edge Network location hint. May return `nil` if the hint has expired or is not set.
+    /// - Returns: the Edge Network location hint or nil if expired or not set
+    func getLocationHint() -> String? {
+        queue.sync {
+            if let expiryDate = self.locationHintExpiryDate, expiryDate > Date() {
+                return self.locationHint
+            }
+            return nil
+        }
+    }
+
+    /// Update the Edge Network location hint and persist the new hint to the data store.
+    /// - Parameters:
+    ///   - hint: the Edge Network location hint to set
+    ///   - ttlSeconds: the time-to-live in seconds for the given location hint
+    func setLocationHint(hint: String, ttlSeconds: TimeInterval) {
+        let newExpiryDate = Date() + ttlSeconds
+        queue.async {
+            self.locationHint = hint
+            self.locationHintExpiryDate = newExpiryDate
+        }
+
+        persistLocationHint(hint: hint, expiryDate: newExpiryDate)
+    }
+
+    /// Store a location hint to local persistent storage.
+    /// Note, operation is not atomic and is not thread-safe. It is expected that no other thread is accessing the location hint and expiry date when this function is called.
+    /// - Parameters:
+    ///   - hint: the Edge Network location hint to persist
+    ///   - expiryDate: the expiry `Date` for the location hint to persist
+    private func persistLocationHint(hint: String, expiryDate: Date) {
+        self.dataStore.setObject(key: EdgeConstants.DataStoreKeys.LOCATION_HINT_EXPIRY_DATE, value: expiryDate)
+        self.dataStore.set(key: EdgeConstants.DataStoreKeys.LOCATION_HINT, value: hint)
+    }
+
+    /// Load the Edge Network location hint from persistence and assign to local instance variables.
+    private func loadLocationHintFromPersistence() {
+        queue.async {
+            self.locationHint = self.dataStore.getString(key: EdgeConstants.DataStoreKeys.LOCATION_HINT)
+            self.locationHintExpiryDate = self.dataStore.getObject(key: EdgeConstants.DataStoreKeys.LOCATION_HINT_EXPIRY_DATE, fallback: nil)
+        }
     }
 }

--- a/Sources/EdgeState.swift
+++ b/Sources/EdgeState.swift
@@ -19,8 +19,6 @@ class EdgeState {
     private let SELF_TAG = "EdgeState"
     private let queue: DispatchQueue
     private var _implementationDetails: [String: Any]?
-    private var locationHint: String?
-    private var locationHintExpiryDate: Date?
     private(set) var hitQueue: HitQueuing
     private(set) var hasBooted = false
     private(set) var currentCollectConsent: ConsentStatus
@@ -28,27 +26,36 @@ class EdgeState {
         get { queue.sync { self._implementationDetails } }
         set { queue.async { self._implementationDetails = newValue } }
     }
-    private let dataStore = NamedCollectionDataStore(name: EdgeConstants.EXTENSION_NAME)
+
+    #if DEBUG
+    var edgeProperties: EdgeProperties
+    #else
+    private(set) var edgeProperties: EdgeProperties
+    #endif
 
     /// Creates a new `EdgeState` and initializes the required properties and sets the initial collect consent
-    init(hitQueue: HitQueuing) {
+    init(hitQueue: HitQueuing, edgeProperties: EdgeProperties) {
+        self.edgeProperties = edgeProperties
         self.queue = DispatchQueue(label: "com.adobe.edgestate.queue")
         self.hitQueue = hitQueue
         self.currentCollectConsent = EdgeConstants.Defaults.COLLECT_CONSENT_PENDING
         hitQueue.handleCollectConsentChange(status: currentCollectConsent)
-
-        // Assigns locationHint and locationHintExpiryDate variables from DataStore
-        loadLocationHintFromPersistence()
     }
 
-    /// Completes init for the `Edge` extension and the collect consent is set based on either Consent shared state
-    /// or the default value if this extension is not registered
-    ///
+    /// Completes init for the `Edge` extension.
+    /// The collect consent is set based on either Consent shared state or the default value if this extension is not registered.
+    /// Loads any persisted Edge properties and creates an initial shared state.
     /// - Parameters:
     ///   - event: The `Event` triggering the bootup
     ///   - getSharedState: used to fetch the `Event Hub` shared state
-    func bootupIfNeeded(event: Event, getSharedState: @escaping (_ name: String, _ event: Event?, _ barrier: Bool) -> SharedStateResult?) {
+    ///   - createSharedState: function to create a shared state with the `EventHub`
+    func bootupIfNeeded(event: Event,
+                        getSharedState: @escaping (_ name: String, _ event: Event?, _ barrier: Bool) -> SharedStateResult?,
+                        createSharedState: @escaping (_ data: [String: Any], _ event: Event?) -> Void) {
         guard !hasBooted else { return }
+
+        // load data from local storage
+        edgeProperties.loadFromPersistence()
 
         // Important: set implementationDetails before starting the hit queue so it is available to the EdgeHitProcessor
         let hubSharedState = getSharedState(EdgeConstants.SharedState.Hub.SHARED_OWNER_NAME, event, false)
@@ -68,6 +75,9 @@ class EdgeState {
         }
         // else keep consent pending until the consent preferences update event is received
 
+        // TODO - Always set state or only when properties are not empty ???
+        createSharedState(edgeProperties.toEventData(), nil)
+
         hasBooted = true
         Log.debug(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Edge has successfully booted up")
     }
@@ -85,10 +95,7 @@ class EdgeState {
     /// - Returns: the Edge Network location hint or nil if expired or not set
     func getLocationHint() -> String? {
         queue.sync {
-            if let expiryDate = self.locationHintExpiryDate, expiryDate > Date() {
-                return self.locationHint
-            }
-            return nil
+            return edgeProperties.locationHint
         }
     }
 
@@ -100,13 +107,8 @@ class EdgeState {
     ///   - createSharedState: function which creates a shared state with the Event Hub
     func setLocationHint(hint: String, ttlSeconds: TimeInterval, createSharedState: @escaping (_ data: [String: Any], _ event: Event?) -> Void) {
         queue.async {
-            let needsStateUpdate = self.locationHint != hint
-            let newExpiryDate = Date() + ttlSeconds
-
-            self.locationHint = hint
-            self.locationHintExpiryDate = newExpiryDate
-
-            self.persistLocationHint(hint: hint, expiryDate: newExpiryDate)
+            let needsStateUpdate = self.edgeProperties.setLocationHint(hint: hint, ttlSeconds: ttlSeconds)
+            self.edgeProperties.saveToPersistence()
 
             if needsStateUpdate {
                 // Create shared state if location hint changed
@@ -116,7 +118,7 @@ class EdgeState {
                 //             lower event numbers than states using nil. If this extension later needs to create shared
                 //             states from received events, then this code must be refactored to also use received
                 //             events as the state version.
-                createSharedState([EdgeConstants.SharedState.Edge.LOCATION_HINT: hint], nil)
+                createSharedState(self.edgeProperties.toEventData(), nil)
             }
         }
     }
@@ -126,38 +128,19 @@ class EdgeState {
     /// - Parameter createSharedState: function which creates a shared state with the Event Hub
     func clearLocationHint(createSharedState: @escaping (_ data: [String: Any], _ event: Event?) -> Void) {
         queue.async {
-            if self.locationHint != nil {
-                // Create empty shared state to "clear" location hint
-                createSharedState([:], nil)
+            let needsStateUpdate = self.edgeProperties.clearLocationHint()
+            self.edgeProperties.saveToPersistence()
+
+            if needsStateUpdate {
+                // Create shared state if location hint changed
+                // Important - Using nil Event here which creates a shared state at the next available Event number.
+                //             An extension should NOT mix creating shared states using nil and using received events
+                //             as it can cause shared state generation to fail due to received events having potentially
+                //             lower event numbers than states using nil. If this extension later needs to create shared
+                //             states from received events, then this code must be refactored to also use received
+                //             events as the state version.
+                createSharedState(self.edgeProperties.toEventData(), nil)
             }
-
-            self.locationHint = nil
-            self.locationHintExpiryDate = nil
-            self.persistLocationHint(hint: nil, expiryDate: nil)
-        }
-    }
-
-    /// Store a location hint to local persistent storage. Passing a nil `hint` will remove the location hint from persistent storage.
-    /// Passing a nil `expiryDate` while passing a non-nil `hint` will result in no changes to persistent storage (a no-op).
-    /// Note, operation is not atomic and is not thread-safe. It is expected that no other thread is accessing the location hint and expiry date when this function is called.
-    /// - Parameters:
-    ///   - hint: the Edge Network location hint to persist. A value of nil will remove the location hint from persistence.
-    ///   - expiryDate: the expiry `Date` for the location hint to persist.
-    private func persistLocationHint(hint: String?, expiryDate: Date?) {
-        if let hint = hint, let expiryDate = expiryDate {
-            self.dataStore.setObject(key: EdgeConstants.DataStoreKeys.LOCATION_HINT_EXPIRY_DATE, value: expiryDate)
-            self.dataStore.set(key: EdgeConstants.DataStoreKeys.LOCATION_HINT, value: hint)
-        } else if hint == nil {
-            self.dataStore.remove(key: EdgeConstants.DataStoreKeys.LOCATION_HINT_EXPIRY_DATE)
-            self.dataStore.remove(key: EdgeConstants.DataStoreKeys.LOCATION_HINT)
-        }
-    }
-
-    /// Load the Edge Network location hint from persistence and assign to local instance variables.
-    private func loadLocationHintFromPersistence() {
-        queue.async {
-            self.locationHint = self.dataStore.getString(key: EdgeConstants.DataStoreKeys.LOCATION_HINT)
-            self.locationHintExpiryDate = self.dataStore.getObject(key: EdgeConstants.DataStoreKeys.LOCATION_HINT_EXPIRY_DATE, fallback: nil)
         }
     }
 }

--- a/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
+++ b/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
@@ -17,6 +17,8 @@ import AEPServices
 import Foundation
 import XCTest
 
+// swiftlint:disable type_body_length
+
 /// End-to-end testing for the AEPEdge public APIs
 class AEPEdgeFunctionalTests: FunctionalTestBase {
     private let event1 = Event(name: "e1", type: "eventType", source: "eventSource", data: nil)
@@ -1064,7 +1066,6 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
     }
 
     func testSendEvent_edgeNetworkResponseContainsLocationHint_nextSendEventIncludesLocationHint() {
-        // swiftlint:disable:next line_length
         let hintResponseBody = "\u{0000}{\"requestId\": \"0000-4a4e-1111-bf5c-abcd\",\"handle\": [{\"payload\": [{\"scope\": \"EdgeNetwork\",\"hint\": \"or2\",\"ttlSeconds\": 1800}],\"type\": \"locationHint:result\"}]}\n"
         let responseConnection: HttpConnection = HttpConnection(data: hintResponseBody.data(using: .utf8),
                                                                 response: HTTPURLResponse(url: exEdgeInteractProdUrl,
@@ -1074,7 +1075,7 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
                                                                 error: nil)
         setNetworkResponseFor(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post, responseHttpConnection: responseConnection)
         setExpectationNetworkRequest(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post, expectedCount: 1)
-        setExpectationNetworkRequest(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR_OR2_LOCATION, httpMethod: HttpMethod.post, expectedCount: 1)
+        setExpectationNetworkRequest(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR_OR2_LOC, httpMethod: HttpMethod.post, expectedCount: 1)
 
         // Send two requests
         let experienceEvent = ExperienceEvent(xdm: ["testString": "xdm"])
@@ -1087,13 +1088,12 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
         XCTAssertEqual(1, resultNetworkRequests.count)
         XCTAssertTrue(resultNetworkRequests[0].url.absoluteURL.absoluteString.hasPrefix(FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR))
 
-        resultNetworkRequests = getNetworkRequestsWith(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR_OR2_LOCATION, httpMethod: HttpMethod.post)
+        resultNetworkRequests = getNetworkRequestsWith(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR_OR2_LOC, httpMethod: HttpMethod.post)
         XCTAssertEqual(1, resultNetworkRequests.count)
-        XCTAssertTrue(resultNetworkRequests[0].url.absoluteURL.absoluteString.hasPrefix(FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR_OR2_LOCATION))
+        XCTAssertTrue(resultNetworkRequests[0].url.absoluteURL.absoluteString.hasPrefix(FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR_OR2_LOC))
     }
 
     func testSendEvent_edgeNetworkResponseContainsLocationHint_sendEventDoesNotIncludeExpiredLocationHint() {
-        // swiftlint:disable:next line_length
         let hintResponseBody = "\u{0000}{\"requestId\": \"0000-4a4e-1111-bf5c-abcd\",\"handle\": [{\"payload\": [{\"scope\": \"EdgeNetwork\",\"hint\": \"or2\",\"ttlSeconds\": 1}],\"type\": \"locationHint:result\"}]}\n"
         let responseConnection: HttpConnection = HttpConnection(data: hintResponseBody.data(using: .utf8),
                                                                 response: HTTPURLResponse(url: exEdgeInteractProdUrl,
@@ -1112,7 +1112,7 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
 
         // verify
         assertNetworkRequestsCount()
-        var resultNetworkRequests = getNetworkRequestsWith(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post)
+        let resultNetworkRequests = getNetworkRequestsWith(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post)
         XCTAssertEqual(2, resultNetworkRequests.count)
         XCTAssertTrue(resultNetworkRequests[0].url.absoluteURL.absoluteString.hasPrefix(FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR))
         XCTAssertTrue(resultNetworkRequests[1].url.absoluteURL.absoluteString.hasPrefix(FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR))

--- a/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
+++ b/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
@@ -36,8 +36,8 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
         continueAfterFailure = false
         FileManager.default.clearCache()
 
-        // hub shared state update for 1 extension versions (InstrumentedExtension (registered in FunctionalTestBase), IdentityEdge, Edge) IdentityEdge XDM and Config shared state updates
-        setExpectationEvent(type: FunctionalTestConst.EventType.HUB, source: FunctionalTestConst.EventSource.SHARED_STATE, expectedCount: 3)
+        // hub shared state update for 1 extension versions (InstrumentedExtension (registered in FunctionalTestBase), IdentityEdge, Edge) IdentityEdge XDM, Config, and Edge shared state updates
+        setExpectationEvent(type: FunctionalTestConst.EventType.HUB, source: FunctionalTestConst.EventSource.SHARED_STATE, expectedCount: 4)
 
         // expectations for update config request&response events
         setExpectationEvent(type: FunctionalTestConst.EventType.CONFIGURATION, source: FunctionalTestConst.EventSource.REQUEST_CONTENT, expectedCount: 1)
@@ -1061,6 +1061,61 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
         XCTAssertTrue(requestUrl.absoluteURL.absoluteString.hasPrefix(FunctionalTestConst.EX_EDGE_INTERACT_INTEGRATION_URL_STR))
         XCTAssertEqual("12345-example", requestUrl.queryParam("configId"))
         XCTAssertNotNil(requestUrl.queryParam("requestId"))
+    }
+
+    func testSendEvent_edgeNetworkResponseContainsLocationHint_nextSendEventIncludesLocationHint() {
+        // swiftlint:disable:next line_length
+        let hintResponseBody = "\u{0000}{\"requestId\": \"0000-4a4e-1111-bf5c-abcd\",\"handle\": [{\"payload\": [{\"scope\": \"EdgeNetwork\",\"hint\": \"or2\",\"ttlSeconds\": 1800}],\"type\": \"locationHint:result\"}]}\n"
+        let responseConnection: HttpConnection = HttpConnection(data: hintResponseBody.data(using: .utf8),
+                                                                response: HTTPURLResponse(url: exEdgeInteractProdUrl,
+                                                                                          statusCode: 200,
+                                                                                          httpVersion: nil,
+                                                                                          headerFields: nil),
+                                                                error: nil)
+        setNetworkResponseFor(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post, responseHttpConnection: responseConnection)
+        setExpectationNetworkRequest(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post, expectedCount: 1)
+        setExpectationNetworkRequest(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR_OR2_LOCATION, httpMethod: HttpMethod.post, expectedCount: 1)
+
+        // Send two requests
+        let experienceEvent = ExperienceEvent(xdm: ["testString": "xdm"])
+        Edge.sendEvent(experienceEvent: experienceEvent)
+        Edge.sendEvent(experienceEvent: experienceEvent)
+
+        // verify
+        assertNetworkRequestsCount()
+        var resultNetworkRequests = getNetworkRequestsWith(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post)
+        XCTAssertEqual(1, resultNetworkRequests.count)
+        XCTAssertTrue(resultNetworkRequests[0].url.absoluteURL.absoluteString.hasPrefix(FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR))
+
+        resultNetworkRequests = getNetworkRequestsWith(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR_OR2_LOCATION, httpMethod: HttpMethod.post)
+        XCTAssertEqual(1, resultNetworkRequests.count)
+        XCTAssertTrue(resultNetworkRequests[0].url.absoluteURL.absoluteString.hasPrefix(FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR_OR2_LOCATION))
+    }
+
+    func testSendEvent_edgeNetworkResponseContainsLocationHint_sendEventDoesNotIncludeExpiredLocationHint() {
+        // swiftlint:disable:next line_length
+        let hintResponseBody = "\u{0000}{\"requestId\": \"0000-4a4e-1111-bf5c-abcd\",\"handle\": [{\"payload\": [{\"scope\": \"EdgeNetwork\",\"hint\": \"or2\",\"ttlSeconds\": 1}],\"type\": \"locationHint:result\"}]}\n"
+        let responseConnection: HttpConnection = HttpConnection(data: hintResponseBody.data(using: .utf8),
+                                                                response: HTTPURLResponse(url: exEdgeInteractProdUrl,
+                                                                                          statusCode: 200,
+                                                                                          httpVersion: nil,
+                                                                                          headerFields: nil),
+                                                                error: nil)
+        setNetworkResponseFor(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post, responseHttpConnection: responseConnection)
+        setExpectationNetworkRequest(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post, expectedCount: 2)
+
+        // Send two requests
+        let experienceEvent = ExperienceEvent(xdm: ["testString": "xdm"])
+        Edge.sendEvent(experienceEvent: experienceEvent)
+        sleep(2)
+        Edge.sendEvent(experienceEvent: experienceEvent)
+
+        // verify
+        assertNetworkRequestsCount()
+        var resultNetworkRequests = getNetworkRequestsWith(url: FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post)
+        XCTAssertEqual(2, resultNetworkRequests.count)
+        XCTAssertTrue(resultNetworkRequests[0].url.absoluteURL.absoluteString.hasPrefix(FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR))
+        XCTAssertTrue(resultNetworkRequests[1].url.absoluteURL.absoluteString.hasPrefix(FunctionalTestConst.EX_EDGE_INTERACT_PROD_URL_STR))
     }
 
     func getEdgeEventError(message: String, code: String) -> EdgeEventError {

--- a/Tests/FunctionalTests/Edge+ConsentTests.swift
+++ b/Tests/FunctionalTests/Edge+ConsentTests.swift
@@ -57,8 +57,8 @@ class EdgeConsentTests: FunctionalTestBase {
         continueAfterFailure = false
         FileManager.default.clearCache()
 
-        // hub shared state update for 4 extensions (InstrumentedExtension (registered in FunctionalTestBase), Configuration, Edge, Consent, Edge Identity)
-        setExpectationEvent(type: FunctionalTestConst.EventType.HUB, source: FunctionalTestConst.EventSource.SHARED_STATE, expectedCount: 4)
+        // hub shared state update for 5 extensions (InstrumentedExtension (registered in FunctionalTestBase), Configuration, Edge, Consent, Edge Identity)
+        setExpectationEvent(type: FunctionalTestConst.EventType.HUB, source: FunctionalTestConst.EventSource.SHARED_STATE, expectedCount: 5)
         setExpectationEvent(type: FunctionalTestConst.EventType.CONSENT, source: FunctionalTestConst.EventSource.RESPONSE_CONTENT, expectedCount: 1)
 
         // expectations for update config request&response events

--- a/Tests/FunctionalTests/IdentityStateFunctionalTests.swift
+++ b/Tests/FunctionalTests/IdentityStateFunctionalTests.swift
@@ -25,8 +25,8 @@ class IdentityStateFunctionalTests: FunctionalTestBase {
         continueAfterFailure = false // fail so nil checks stop execution
         FunctionalTestBase.debugEnabled = false
 
-        // config state and 1 event hub states (TestableEdgeInternal, FakeIdentityExtension and InstrumentedExtension registered in FunctionalTestBase)
-        setExpectationEvent(type: FunctionalTestConst.EventType.HUB, source: FunctionalTestConst.EventSource.SHARED_STATE, expectedCount: 2)
+        // config state and 2 event hub states (Edge, TestableEdgeInternal, FakeIdentityExtension and InstrumentedExtension registered in FunctionalTestBase)
+        setExpectationEvent(type: FunctionalTestConst.EventType.HUB, source: FunctionalTestConst.EventSource.SHARED_STATE, expectedCount: 3)
 
         // expectations for update config request&response events
         setExpectationEvent(type: FunctionalTestConst.EventType.CONFIGURATION, source: FunctionalTestConst.EventSource.REQUEST_CONTENT, expectedCount: 1)

--- a/Tests/FunctionalTests/NetworkResponseHandlerFunctionalTests.swift
+++ b/Tests/FunctionalTests/NetworkResponseHandlerFunctionalTests.swift
@@ -15,6 +15,7 @@ import AEPCore
 @testable import AEPServices
 import XCTest
 
+// swiftlint:disable type_body_length
 class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
     private let event1 = Event(name: "e1", type: "eventType", source: "eventSource", data: nil)
     private let event2 = Event(name: "e2", type: "eventType", source: "eventSource", data: nil)

--- a/Tests/FunctionalTests/NetworkResponseHandlerFunctionalTests.swift
+++ b/Tests/FunctionalTests/NetworkResponseHandlerFunctionalTests.swift
@@ -18,7 +18,7 @@ import XCTest
 class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
     private let event1 = Event(name: "e1", type: "eventType", source: "eventSource", data: nil)
     private let event2 = Event(name: "e2", type: "eventType", source: "eventSource", data: nil)
-    private var networkResponseHandler = NetworkResponseHandler()
+    private var networkResponseHandler = NetworkResponseHandler(updateLocationHint: { (_ :String?, _ :TimeInterval?) -> Void in  })
     private let dataStore = NamedCollectionDataStore(name: EdgeConstants.EXTENSION_NAME)
 
     override func setUp() {
@@ -322,7 +322,7 @@ class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
     /// Tests that when an event is processed after a persisted reset event that the store payloads are saved
     func testProcessResponseOnSuccess_afterPersistedResetEvent_savesStorePayloads() {
         dataStore.set(key: EdgeConstants.DataStoreKeys.RESET_IDENTITIES_DATE, value: Date().timeIntervalSince1970 - 10) // date is before `event.timestamp`
-        networkResponseHandler = NetworkResponseHandler() // loads reset time on init
+        networkResponseHandler = NetworkResponseHandler(updateLocationHint: { (_ :String?, _ :TimeInterval?) -> Void in  }) // loads reset time on init
 
         let event = Event(name: "test", type: "test-type", source: "test-source", data: nil)
 
@@ -357,7 +357,7 @@ class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
         let event = Event(name: "test", type: "test-type", source: "test-source", data: nil)
 
         dataStore.set(key: EdgeConstants.DataStoreKeys.RESET_IDENTITIES_DATE, value: Date().timeIntervalSince1970 + 10) // date is after `event.timestamp`
-        networkResponseHandler = NetworkResponseHandler() // loads reset time on init
+        networkResponseHandler = NetworkResponseHandler(updateLocationHint: { (_ :String?, _ :TimeInterval?) -> Void in  }) // loads reset time on init
         networkResponseHandler.addWaitingEvents(requestId: "d81c93e5-7558-4996-a93c-489d550748b8",
                                                 batchedEvents: [event])
 

--- a/Tests/FunctionalTests/NetworkResponseHandlerFunctionalTests.swift
+++ b/Tests/FunctionalTests/NetworkResponseHandlerFunctionalTests.swift
@@ -794,4 +794,427 @@ class NetworkResponseHandlerFunctionalTests: FunctionalTestBase {
         XCTAssertEqual(202, flattenReceivedData2["report.cause.code"] as? Int)
         XCTAssertEqual("123", flattenReceivedData2["requestId"] as? String)
     }
+
+    // MARK: locationHint:result
+
+    func testProcessResponseOnSuccess_WhenLocationHintResultEventHandle_dispatchesEvent() {
+        setExpectationEvent(type: FunctionalTestConst.EventType.EDGE, source: FunctionalTestConst.EventSource.RESPONSE_CONTENT, expectedCount: 1)
+        let jsonResponse = "{\n" +
+            "      \"requestId\": \"d81c93e5-7558-4996-a93c-489d550748b8\",\n" +
+            "      \"handle\": [" +
+            "           {\n" +
+            "            \"type\": \"locationHint:result\",\n" +
+            "            \"payload\": [\n" +
+            "                {\n" +
+            "                    \"scope\": \"EdgeNetwork\",\n" +
+            "                    \"hint\": \"or2\",\n" +
+            "                    \"ttlSeconds\": 1800\n" +
+            "                },\n" +
+            "                {\n" +
+            "                    \"scope\": \"Target\",\n" +
+            "                    \"hint\": \"edge34\",\n" +
+            "                    \"ttlSeconds\": 600\n" +
+            "                }\n" +
+            "            ]\n" +
+            "        }]\n" +
+            "    }"
+        networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: "123")
+
+        let dispatchEvents = getDispatchedEventsWith(type: FunctionalTestConst.EventType.EDGE, source: "locationHint:result")
+        XCTAssertEqual(1, dispatchEvents.count)
+        guard let receivedData = dispatchEvents[0].data else {
+            XCTFail("Invalid event data")
+            return
+        }
+
+        let flattenReceivedData: [String: Any] = flattenDictionary(dict: receivedData)
+        XCTAssertEqual(8, flattenReceivedData.count)
+        XCTAssertEqual("locationHint:result", flattenReceivedData["type"] as? String)
+        XCTAssertEqual("123", flattenReceivedData["requestId"] as? String)
+        XCTAssertEqual("EdgeNetwork", flattenReceivedData["payload[0].scope"] as? String)
+        XCTAssertEqual("or2", flattenReceivedData["payload[0].hint"] as? String)
+        XCTAssertEqual(1800, flattenReceivedData["payload[0].ttlSeconds"] as? Int)
+        XCTAssertEqual("Target", flattenReceivedData["payload[1].scope"] as? String)
+        XCTAssertEqual("edge34", flattenReceivedData["payload[1].hint"] as? String)
+        XCTAssertEqual(600, flattenReceivedData["payload[1].ttlSeconds"] as? Int)
+    }
+
+    /// Tests that when an event is processed after a reset event that the location hint is updated
+    func testProcessResponseOnSuccess_afterResetEvent_updatesLocationHint() {
+        var locationHintResultHint: String?
+        var locationHintResultTtlSeconds: TimeInterval?
+        networkResponseHandler = NetworkResponseHandler(updateLocationHint: { (hint: String?, ttlSeconds: TimeInterval?) -> Void in
+            locationHintResultHint = hint
+            locationHintResultTtlSeconds = ttlSeconds
+        })
+
+        networkResponseHandler.setLastReset(date: Date(timeIntervalSince1970: Date().timeIntervalSince1970 - 10)) // date is before `event.timestamp`
+        let event = Event(name: "test", type: "test-type", source: "test-source", data: nil)
+
+        networkResponseHandler.addWaitingEvents(requestId: "d81c93e5-7558-4996-a93c-489d550748b8",
+                                                batchedEvents: [event])
+
+        setExpectationEvent(type: FunctionalTestConst.EventType.EDGE, source: FunctionalTestConst.EventSource.RESPONSE_CONTENT, expectedCount: 1)
+        let jsonResponse = "{\n" +
+            "      \"requestId\": \"d81c93e5-7558-4996-a93c-489d550748b8\",\n" +
+            "      \"handle\": [" +
+            "           {\n" +
+            "            \"type\": \"locationHint:result\",\n" +
+            "            \"payload\": [\n" +
+            "                {\n" +
+            "                    \"scope\": \"EdgeNetwork\",\n" +
+            "                    \"hint\": \"or2\",\n" +
+            "                    \"ttlSeconds\": 1800\n" +
+            "                }\n" +
+            "            ]\n" +
+            "        }],\n" +
+            "      \"errors\": []\n" +
+            "    }"
+        networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: "d81c93e5-7558-4996-a93c-489d550748b8")
+
+        // verify saved location hint
+        XCTAssertEqual("or2", locationHintResultHint)
+        XCTAssertEqual(1800, locationHintResultTtlSeconds)
+    }
+
+    func testProcessResponseOnSuccess_beforeResetEvent_doesNotUpdateLocationHint() {
+        let event = Event(name: "test", type: "test-type", source: "test-source", data: nil)
+
+        var locationHintResultHint: String?
+        var locationHintResultTtlSeconds: TimeInterval?
+        networkResponseHandler = NetworkResponseHandler(updateLocationHint: { (hint: String?, ttlSeconds: TimeInterval?) -> Void in
+            locationHintResultHint = hint
+            locationHintResultTtlSeconds = ttlSeconds
+        })
+
+        networkResponseHandler.addWaitingEvents(requestId: "d81c93e5-7558-4996-a93c-489d550748b8",
+                                                batchedEvents: [event])
+
+        networkResponseHandler.setLastReset(date: Date(timeIntervalSince1970: Date().timeIntervalSince1970 + 10)) // date is after `event.timestamp` // date is after `event.timestamp`
+
+        setExpectationEvent(type: FunctionalTestConst.EventType.EDGE, source: FunctionalTestConst.EventSource.RESPONSE_CONTENT, expectedCount: 1)
+        let jsonResponse = "{\n" +
+            "      \"requestId\": \"d81c93e5-7558-4996-a93c-489d550748b8\",\n" +
+            "      \"handle\": [" +
+            "           {\n" +
+            "            \"type\": \"locationHint:result\",\n" +
+            "            \"payload\": [\n" +
+            "                {\n" +
+            "                    \"scope\": \"EdgeNetwork\",\n" +
+            "                    \"hint\": \"or2\",\n" +
+            "                    \"ttlSeconds\": 1800\n" +
+            "                }\n" +
+            "            ]\n" +
+            "        }],\n" +
+            "      \"errors\": []\n" +
+            "    }"
+        networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: "d81c93e5-7558-4996-a93c-489d550748b8")
+
+        // verify location hint not saved
+        XCTAssertNil(locationHintResultHint)
+        XCTAssertNil(locationHintResultTtlSeconds)
+    }
+
+    /// Tests that when an event is processed after a persisted reset event that the location hint is updated
+    func testProcessResponseOnSuccess_afterPersistedResetEvent_updatesLocationHint() {
+        dataStore.set(key: EdgeConstants.DataStoreKeys.RESET_IDENTITIES_DATE, value: Date().timeIntervalSince1970 - 10) // date is before `event.timestamp`
+
+        var locationHintResultHint: String?
+        var locationHintResultTtlSeconds: TimeInterval?
+        networkResponseHandler = NetworkResponseHandler(updateLocationHint: { (hint: String?, ttlSeconds: TimeInterval?) -> Void in
+            locationHintResultHint = hint
+            locationHintResultTtlSeconds = ttlSeconds
+        }) // loads reset time on init
+
+        let event = Event(name: "test", type: "test-type", source: "test-source", data: nil)
+
+        networkResponseHandler.addWaitingEvents(requestId: "d81c93e5-7558-4996-a93c-489d550748b8",
+                                                batchedEvents: [event])
+
+        setExpectationEvent(type: FunctionalTestConst.EventType.EDGE, source: FunctionalTestConst.EventSource.RESPONSE_CONTENT, expectedCount: 1)
+        let jsonResponse = "{\n" +
+            "      \"requestId\": \"d81c93e5-7558-4996-a93c-489d550748b8\",\n" +
+            "      \"handle\": [" +
+            "           {\n" +
+            "            \"type\": \"locationHint:result\",\n" +
+            "            \"payload\": [\n" +
+            "                {\n" +
+            "                    \"scope\": \"EdgeNetwork\",\n" +
+            "                    \"hint\": \"or2\",\n" +
+            "                    \"ttlSeconds\": 1800\n" +
+            "                }\n" +
+            "            ]\n" +
+            "        }],\n" +
+            "      \"errors\": []\n" +
+            "    }"
+        networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: "d81c93e5-7558-4996-a93c-489d550748b8")
+
+        // verify saved location hint
+        XCTAssertEqual("or2", locationHintResultHint)
+        XCTAssertEqual(1800, locationHintResultTtlSeconds)
+    }
+
+    /// Tests that when an event is processed before a persisted reset event that the location hint is not updated
+    func testProcessResponseOnSuccess_beforePersistedResetEvent_doesNotUpdateLocationHint() {
+        let event = Event(name: "test", type: "test-type", source: "test-source", data: nil)
+
+        dataStore.set(key: EdgeConstants.DataStoreKeys.RESET_IDENTITIES_DATE, value: Date().timeIntervalSince1970 + 10) // date is after `event.timestamp`
+
+        var locationHintResultHint: String?
+        var locationHintResultTtlSeconds: TimeInterval?
+        networkResponseHandler = NetworkResponseHandler(updateLocationHint: { (hint: String?, ttlSeconds: TimeInterval?) -> Void in
+            locationHintResultHint = hint
+            locationHintResultTtlSeconds = ttlSeconds
+        }) // loads reset time on init
+        networkResponseHandler.addWaitingEvents(requestId: "d81c93e5-7558-4996-a93c-489d550748b8",
+                                                batchedEvents: [event])
+
+        setExpectationEvent(type: FunctionalTestConst.EventType.EDGE, source: FunctionalTestConst.EventSource.RESPONSE_CONTENT, expectedCount: 1)
+        let jsonResponse = "{\n" +
+            "      \"requestId\": \"d81c93e5-7558-4996-a93c-489d550748b8\",\n" +
+            "      \"handle\": [" +
+            "           {\n" +
+            "            \"type\": \"locationHint:result\",\n" +
+            "            \"payload\": [\n" +
+            "                {\n" +
+            "                    \"scope\": \"EdgeNetwork\",\n" +
+            "                    \"hint\": \"or2\",\n" +
+            "                    \"ttlSeconds\": 1800\n" +
+            "                }\n" +
+            "            ]\n" +
+            "        }],\n" +
+            "      \"errors\": []\n" +
+            "    }"
+        networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: "d81c93e5-7558-4996-a93c-489d550748b8")
+
+        // verify location hint not saved
+        XCTAssertNil(locationHintResultHint)
+        XCTAssertNil(locationHintResultTtlSeconds)
+    }
+
+    func testProcessResponseOnSuccess_whenEdgeNetworkNotInScope_doesNotUpdateLocationHint() {
+        var locationHintResultHint: String?
+        var locationHintResultTtlSeconds: TimeInterval?
+        networkResponseHandler = NetworkResponseHandler(updateLocationHint: { (hint: String?, ttlSeconds: TimeInterval?) -> Void in
+            locationHintResultHint = hint
+            locationHintResultTtlSeconds = ttlSeconds
+        }) // loads reset time on init
+
+        let event = Event(name: "test", type: "test-type", source: "test-source", data: nil)
+
+        networkResponseHandler.addWaitingEvents(requestId: "d81c93e5-7558-4996-a93c-489d550748b8",
+                                                batchedEvents: [event])
+
+        setExpectationEvent(type: FunctionalTestConst.EventType.EDGE, source: FunctionalTestConst.EventSource.RESPONSE_CONTENT, expectedCount: 1)
+        let jsonResponse = "{\n" +
+            "      \"requestId\": \"d81c93e5-7558-4996-a93c-489d550748b8\",\n" +
+            "      \"handle\": [" +
+            "           {\n" +
+            "            \"type\": \"locationHint:result\",\n" +
+            "            \"payload\": [\n" +
+            "                {\n" +
+            "                    \"scope\": \"Target\",\n" +
+            "                    \"hint\": \"edge34\",\n" +
+            "                    \"ttlSeconds\": 1800\n" +
+            "                }\n" +
+            "            ]\n" +
+            "        }],\n" +
+            "      \"errors\": []\n" +
+            "    }"
+        networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: "d81c93e5-7558-4996-a93c-489d550748b8")
+
+        // verify location hint not saved
+        XCTAssertNil(locationHintResultHint)
+        XCTAssertNil(locationHintResultTtlSeconds)
+    }
+
+    func testProcessResponseOnSuccess_whenEventHandleHasBothStateStoreAndLocationHintResult_stateStoreSaved_locationHintUpdated() {
+        var locationHintResultHint: String?
+        var locationHintResultTtlSeconds: TimeInterval?
+        networkResponseHandler = NetworkResponseHandler(updateLocationHint: { (hint: String?, ttlSeconds: TimeInterval?) -> Void in
+            locationHintResultHint = hint
+            locationHintResultTtlSeconds = ttlSeconds
+        }) // loads reset time on init
+
+        let event = Event(name: "test", type: "test-type", source: "test-source", data: nil)
+
+        networkResponseHandler.addWaitingEvents(requestId: "d81c93e5-7558-4996-a93c-489d550748b8",
+                                                batchedEvents: [event])
+
+        setExpectationEvent(type: FunctionalTestConst.EventType.EDGE, source: FunctionalTestConst.EventSource.RESPONSE_CONTENT, expectedCount: 1)
+        let jsonResponse = "{\n" +
+            "      \"requestId\": \"d81c93e5-7558-4996-a93c-489d550748b8\",\n" +
+            "      \"handle\": [" +
+            "           {\n" +
+            "            \"type\": \"locationHint:result\",\n" +
+            "            \"payload\": [\n" +
+            "                {\n" +
+            "                    \"scope\": \"EdgeNetwork\",\n" +
+            "                    \"hint\": \"or2\",\n" +
+            "                    \"ttlSeconds\": 1800\n" +
+            "                }\n" +
+            "            ]},\n" +
+            "           {\n" +
+            "            \"type\": \"state:store\",\n" +
+            "            \"payload\": [\n" +
+            "                {\n" +
+            "                    \"key\": \"s_ecid\",\n" +
+            "                    \"value\": \"MCMID|29068398647607325310376254630528178721\",\n" +
+            "                    \"maxAge\": 15552000\n" +
+            "                }\n" +
+            "            ]\n" +
+            "        }],\n" +
+            "      \"errors\": []\n" +
+            "    }"
+        networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: "d81c93e5-7558-4996-a93c-489d550748b8")
+
+        // verify saved location hint
+        XCTAssertEqual("or2", locationHintResultHint)
+        XCTAssertEqual(1800, locationHintResultTtlSeconds)
+
+        // verify saved to store manager
+        let storeResponsePayloadManager = StoreResponsePayloadManager(EdgeConstants.DataStoreKeys.STORE_NAME)
+        XCTAssertFalse(storeResponsePayloadManager.getActivePayloadList().isEmpty)
+    }
+
+    func testProcessResponseOnSuccess_whenLocationHintHandleDoesNotHaveHint_thenLocationHintNotUpdated() {
+        var locationHintResultHint: String?
+        var locationHintResultTtlSeconds: TimeInterval?
+        networkResponseHandler = NetworkResponseHandler(updateLocationHint: { (hint: String?, ttlSeconds: TimeInterval?) -> Void in
+            locationHintResultHint = hint
+            locationHintResultTtlSeconds = ttlSeconds
+        })
+
+        let event = Event(name: "test", type: "test-type", source: "test-source", data: nil)
+
+        networkResponseHandler.addWaitingEvents(requestId: "d81c93e5-7558-4996-a93c-489d550748b8",
+                                                batchedEvents: [event])
+
+        setExpectationEvent(type: FunctionalTestConst.EventType.EDGE, source: FunctionalTestConst.EventSource.RESPONSE_CONTENT, expectedCount: 1)
+        let jsonResponse = "{\n" +
+            "      \"requestId\": \"d81c93e5-7558-4996-a93c-489d550748b8\",\n" +
+            "      \"handle\": [" +
+            "           {\n" +
+            "            \"type\": \"locationHint:result\",\n" +
+            "            \"payload\": [\n" +
+            "                {\n" +
+            "                    \"scope\": \"EdgeNetwork\",\n" +
+            "                    \"ttlSeconds\": 1800\n" +
+            "                }\n" +
+            "            ]\n" +
+            "        }],\n" +
+            "      \"errors\": []\n" +
+            "    }"
+        networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: "d81c93e5-7558-4996-a93c-489d550748b8")
+
+        // verify saved location hint
+        XCTAssertNil(locationHintResultHint)
+        XCTAssertNil(locationHintResultTtlSeconds)
+    }
+
+    func testProcessResponseOnSuccess_whenLocationHintHandleHasEmptyHint_thenLocationHintNotUpdated() {
+        var locationHintResultHint: String?
+        var locationHintResultTtlSeconds: TimeInterval?
+        networkResponseHandler = NetworkResponseHandler(updateLocationHint: { (hint: String?, ttlSeconds: TimeInterval?) -> Void in
+            locationHintResultHint = hint
+            locationHintResultTtlSeconds = ttlSeconds
+        })
+
+        let event = Event(name: "test", type: "test-type", source: "test-source", data: nil)
+
+        networkResponseHandler.addWaitingEvents(requestId: "d81c93e5-7558-4996-a93c-489d550748b8",
+                                                batchedEvents: [event])
+
+        setExpectationEvent(type: FunctionalTestConst.EventType.EDGE, source: FunctionalTestConst.EventSource.RESPONSE_CONTENT, expectedCount: 1)
+        let jsonResponse = "{\n" +
+            "      \"requestId\": \"d81c93e5-7558-4996-a93c-489d550748b8\",\n" +
+            "      \"handle\": [" +
+            "           {\n" +
+            "            \"type\": \"locationHint:result\",\n" +
+            "            \"payload\": [\n" +
+            "                {\n" +
+            "                    \"scope\": \"EdgeNetwork\",\n" +
+            "                    \"hint\": \"\",\n" +
+            "                    \"ttlSeconds\": 1800\n" +
+            "                }\n" +
+            "            ]\n" +
+            "        }],\n" +
+            "      \"errors\": []\n" +
+            "    }"
+        networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: "d81c93e5-7558-4996-a93c-489d550748b8")
+
+        // verify saved location hint
+        XCTAssertNil(locationHintResultHint)
+        XCTAssertNil(locationHintResultTtlSeconds)
+    }
+
+    func testProcessResponseOnSuccess_whenLocationHintHandleDoesNotHaveTtl_thenLocationHintNotUpdated() {
+        var locationHintResultHint: String?
+        var locationHintResultTtlSeconds: TimeInterval?
+        networkResponseHandler = NetworkResponseHandler(updateLocationHint: { (hint: String?, ttlSeconds: TimeInterval?) -> Void in
+            locationHintResultHint = hint
+            locationHintResultTtlSeconds = ttlSeconds
+        })
+
+        let event = Event(name: "test", type: "test-type", source: "test-source", data: nil)
+
+        networkResponseHandler.addWaitingEvents(requestId: "d81c93e5-7558-4996-a93c-489d550748b8",
+                                                batchedEvents: [event])
+
+        setExpectationEvent(type: FunctionalTestConst.EventType.EDGE, source: FunctionalTestConst.EventSource.RESPONSE_CONTENT, expectedCount: 1)
+        let jsonResponse = "{\n" +
+            "      \"requestId\": \"d81c93e5-7558-4996-a93c-489d550748b8\",\n" +
+            "      \"handle\": [" +
+            "           {\n" +
+            "            \"type\": \"locationHint:result\",\n" +
+            "            \"payload\": [\n" +
+            "                {\n" +
+            "                    \"scope\": \"EdgeNetwork\",\n" +
+            "                    \"hint\": \"or2\"\n" +
+            "                }\n" +
+            "            ]\n" +
+            "        }],\n" +
+            "      \"errors\": []\n" +
+            "    }"
+        networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: "d81c93e5-7558-4996-a93c-489d550748b8")
+
+        // verify saved location hint
+        XCTAssertNil(locationHintResultHint)
+        XCTAssertNil(locationHintResultTtlSeconds)
+    }
+
+    func testProcessResponseOnSuccess_whenLocationHintHandleHasIncorrectTtlType_thenLocationHintNotUpdated() {
+        var locationHintResultHint: String?
+        var locationHintResultTtlSeconds: TimeInterval?
+        networkResponseHandler = NetworkResponseHandler(updateLocationHint: { (hint: String?, ttlSeconds: TimeInterval?) -> Void in
+            locationHintResultHint = hint
+            locationHintResultTtlSeconds = ttlSeconds
+        })
+
+        let event = Event(name: "test", type: "test-type", source: "test-source", data: nil)
+
+        networkResponseHandler.addWaitingEvents(requestId: "d81c93e5-7558-4996-a93c-489d550748b8",
+                                                batchedEvents: [event])
+
+        setExpectationEvent(type: FunctionalTestConst.EventType.EDGE, source: FunctionalTestConst.EventSource.RESPONSE_CONTENT, expectedCount: 1)
+        let jsonResponse = "{\n" +
+            "      \"requestId\": \"d81c93e5-7558-4996-a93c-489d550748b8\",\n" +
+            "      \"handle\": [" +
+            "           {\n" +
+            "            \"type\": \"locationHint:result\",\n" +
+            "            \"payload\": [\n" +
+            "                {\n" +
+            "                    \"scope\": \"EdgeNetwork\",\n" +
+            "                    \"ttlSeconds\": \"1800\"\n" + // String but should be Int
+            "                }\n" +
+            "            ]\n" +
+            "        }],\n" +
+            "      \"errors\": []\n" +
+            "    }"
+        networkResponseHandler.processResponseOnSuccess(jsonResponse: jsonResponse, requestId: "d81c93e5-7558-4996-a93c-489d550748b8")
+
+        // verify saved location hint
+        XCTAssertNil(locationHintResultHint)
+        XCTAssertNil(locationHintResultTtlSeconds)
+    }
 }

--- a/Tests/FunctionalTests/NoConfigFunctionalTests.swift
+++ b/Tests/FunctionalTests/NoConfigFunctionalTests.swift
@@ -24,8 +24,8 @@ class NoConfigFunctionalTests: FunctionalTestBase {
         continueAfterFailure = false // fail so nil checks stop execution
         FunctionalTestBase.debugEnabled = false
 
-        // 1 event hub shared state for registered extensions (TestableEdge and InstrumentedExtension registered in FunctionalTestBase)
-        setExpectationEvent(type: FunctionalTestConst.EventType.HUB, source: FunctionalTestConst.EventSource.SHARED_STATE, expectedCount: 1)
+        // event hub shared state for registered extensions (Edge, TestableEdge and InstrumentedExtension registered in FunctionalTestBase)
+        setExpectationEvent(type: FunctionalTestConst.EventType.HUB, source: FunctionalTestConst.EventSource.SHARED_STATE, expectedCount: 2)
 
         MobileCore.registerExtensions([TestableEdge.self])
 

--- a/Tests/FunctionalTests/SampleFunctionalTests.swift
+++ b/Tests/FunctionalTests/SampleFunctionalTests.swift
@@ -34,8 +34,8 @@ class SampleFunctionalTests: FunctionalTestBase {
         super.setUp()
         continueAfterFailure = false
 
-        // hub shared state update for 1 extension versions (InstrumentedExtension (registered in FunctionalTestBase), IdentityEdge, Edge), IdentityEdge XDM shared state and Config shared state updates
-        setExpectationEvent(type: FunctionalTestConst.EventType.HUB, source: FunctionalTestConst.EventSource.SHARED_STATE, expectedCount: 3)
+        // hub shared state update for extension versions (InstrumentedExtension (registered in FunctionalTestBase), IdentityEdge, Edge), Edge extension, IdentityEdge XDM shared state and Config shared state updates
+        setExpectationEvent(type: FunctionalTestConst.EventType.HUB, source: FunctionalTestConst.EventSource.SHARED_STATE, expectedCount: 4)
 
         // expectations for update config request&response events
         setExpectationEvent(type: FunctionalTestConst.EventType.CONFIGURATION, source: FunctionalTestConst.EventSource.REQUEST_CONTENT, expectedCount: 1)

--- a/Tests/FunctionalTests/util/FunctionalTestConst.swift
+++ b/Tests/FunctionalTests/util/FunctionalTestConst.swift
@@ -65,5 +65,5 @@ enum FunctionalTestConst {
     static let EX_EDGE_CONSENT_PRE_PROD_URL_STR = "https://edge.adobedc.net/ee-pre-prd/v1/privacy/set-consent"
     static let EX_EDGE_CONSENT_INTEGRATION_URL_STR = "https://edge-int.adobedc.net/ee/v1/privacy/set-consent"
 
-    static let EX_EDGE_INTERACT_PROD_URL_STR_OR2_LOCATION = "https://edge.adobedc.net/ee/or2/v1/interact"
+    static let EX_EDGE_INTERACT_PROD_URL_STR_OR2_LOC = "https://edge.adobedc.net/ee/or2/v1/interact"
 }

--- a/Tests/FunctionalTests/util/FunctionalTestConst.swift
+++ b/Tests/FunctionalTests/util/FunctionalTestConst.swift
@@ -66,7 +66,7 @@ enum FunctionalTestConst {
     static let EX_EDGE_CONSENT_INTEGRATION_URL_STR = "https://edge-int.adobedc.net/ee/v1/privacy/set-consent"
 
     static let EX_EDGE_INTERACT_PROD_URL_STR_OR2_LOC = "https://edge.adobedc.net/ee/or2/v1/interact"
-    
+
     static let EX_EDGE_MEDIA_PROD_URL_STR = "https://edge.adobedc.net/ee/va/v1/sessionstart"
     static let EX_EDGE_MEDIA_PRE_PROD_URL_STR = "https://edge.adobedc.net/ee-pre-prd/va/v1/sessionstart"
     static let EX_EDGE_MEDIA_INTEGRATION_URL_STR = "https://edge-int.adobedc.net/ee/va/v1/sessionstart"

--- a/Tests/FunctionalTests/util/FunctionalTestConst.swift
+++ b/Tests/FunctionalTests/util/FunctionalTestConst.swift
@@ -64,4 +64,6 @@ enum FunctionalTestConst {
     static let EX_EDGE_CONSENT_PROD_URL_STR = "https://edge.adobedc.net/ee/v1/privacy/set-consent"
     static let EX_EDGE_CONSENT_PRE_PROD_URL_STR = "https://edge.adobedc.net/ee-pre-prd/v1/privacy/set-consent"
     static let EX_EDGE_CONSENT_INTEGRATION_URL_STR = "https://edge-int.adobedc.net/ee/v1/privacy/set-consent"
+
+    static let EX_EDGE_INTERACT_PROD_URL_STR_OR2_LOCATION = "https://edge.adobedc.net/ee/or2/v1/interact"
 }

--- a/Tests/UnitTests/EdgeEndpointTests.swift
+++ b/Tests/UnitTests/EdgeEndpointTests.swift
@@ -81,7 +81,7 @@ class EdgeEndpointTests: XCTestCase {
                      (.integration, "", "https://edge-int.adobedc.net/ee/v1/interact", "DefaultIntegrationEndpointWithRegionIdWithEmptyRegionId")]
 
         cases.forEach {
-            let endpoint = EdgeEndpoint(requestType: EdgeRequestType.interact, environmentType: $0, optionalDomain: nil, regionId: $1)
+            let endpoint = EdgeEndpoint(requestType: EdgeRequestType.interact, environmentType: $0, optionalDomain: nil, locationHint: $1)
             XCTAssertEqual($2, endpoint.url?.absoluteString, "\($3) test case failed.")
         }
     }
@@ -112,7 +112,7 @@ class EdgeEndpointTests: XCTestCase {
                      (.integration, domain1, "", "https://edge-int.adobedc.net/ee/v1/interact", "CustomIntegrationEndpointWithEmptyRegionId")]
 
         cases.forEach {
-            let endpoint = EdgeEndpoint(requestType: EdgeRequestType.interact, environmentType: $0, optionalDomain: $1, regionId: $2)
+            let endpoint = EdgeEndpoint(requestType: EdgeRequestType.interact, environmentType: $0, optionalDomain: $1, locationHint: $2)
             XCTAssertEqual($3, endpoint.url?.absoluteString, "\($4) test case failed.")
         }
     }
@@ -139,7 +139,7 @@ class EdgeEndpointTests: XCTestCase {
                      (.integration, "", "https://edge-int.adobedc.net/ee/v1/privacy/set-consent", "DefaultIntegrationEndpointWithEmptyRegionId")]
 
         cases.forEach {
-            let endpoint = EdgeEndpoint(requestType: EdgeRequestType.consent, environmentType: $0, optionalDomain: nil, regionId: $1)
+            let endpoint = EdgeEndpoint(requestType: EdgeRequestType.consent, environmentType: $0, optionalDomain: nil, locationHint: $1)
             XCTAssertEqual($2, endpoint.url?.absoluteString, "\($3) test case failed.")
         }
     }
@@ -170,7 +170,7 @@ class EdgeEndpointTests: XCTestCase {
                      (.integration, domain1, "", "https://edge-int.adobedc.net/ee/v1/privacy/set-consent", "CustomIntegrationEndpointWithEmptyRegionId")]
 
         cases.forEach {
-            let endpoint = EdgeEndpoint(requestType: EdgeRequestType.consent, environmentType: $0, optionalDomain: $1, regionId: $2)
+            let endpoint = EdgeEndpoint(requestType: EdgeRequestType.consent, environmentType: $0, optionalDomain: $1, locationHint: $2)
             XCTAssertEqual($3, endpoint.url?.absoluteString, "\($4) test case failed.")
         }
     }

--- a/Tests/UnitTests/EdgeEndpointTests.swift
+++ b/Tests/UnitTests/EdgeEndpointTests.swift
@@ -71,6 +71,21 @@ class EdgeEndpointTests: XCTestCase {
         }
     }
 
+    func testEdgeEndpoint_interact_regionId_defaultDomain() {
+        // cases defined as: ($0: input EnvironmentType, $1: region id, $2: expected output EdgeEndpoint URL, $3: Test case name)
+        let cases = [(EdgeEnvironmentType.production, "or2", "https://edge.adobedc.net/ee/or2/v1/interact", "DefaultProductionEndpointWithRegionIdWithRegionId"),
+                     (.preProduction, "or2", "https://edge.adobedc.net/ee-pre-prd/or2/v1/interact", "DefaultPreProductionEndpointWithRegionIdWithRegionId"),
+                     (.integration, "or2", "https://edge-int.adobedc.net/ee/or2/v1/interact", "DefaultIntegrationEndpointWithRegionIdWithRegionId"),
+                     (EdgeEnvironmentType.production, "", "https://edge.adobedc.net/ee/v1/interact", "DefaultProductionEndpointWithRegionIdWithEmptyRegionId"),
+                     (.preProduction, "", "https://edge.adobedc.net/ee-pre-prd/v1/interact", "DefaultPreProductionEndpointWithRegionIdWithEmptyRegionId"),
+                     (.integration, "", "https://edge-int.adobedc.net/ee/v1/interact", "DefaultIntegrationEndpointWithRegionIdWithEmptyRegionId")]
+
+        cases.forEach {
+            let endpoint = EdgeEndpoint(requestType: EdgeRequestType.interact, environmentType: $0, optionalDomain: nil, regionId: $1)
+            XCTAssertEqual($2, endpoint.url?.absoluteString, "\($3) test case failed.")
+        }
+    }
+
     func testEdgeEndpoint_interact_customDomain() {
         let domain1 = "my.awesome.site"
         let domain2 = ""
@@ -86,6 +101,22 @@ class EdgeEndpointTests: XCTestCase {
         }
     }
 
+    func testEdgeEndpoint_interact_regionId_customDomain() {
+        let domain1 = "my.awesome.site"
+        // cases defined as: ($0: input EnvironmentType, $1: input custom domain, $2: region id, $3: expected output EdgeEndpoint URL, $4: Test case name)
+        let cases = [(EdgeEnvironmentType.production, domain1, "or2", "https://\(domain1)/ee/or2/v1/interact", "CustomProductionEndpointWithRegionId"),
+                     (.preProduction, domain1, "or2", "https://\(domain1)/ee-pre-prd/or2/v1/interact", "CustomPreProductionEndpointWithRegionId"),
+                     (.integration, domain1, "or2", "https://edge-int.adobedc.net/ee/or2/v1/interact", "CustomIntegrationEndpointWithRegionId"),
+                     (EdgeEnvironmentType.production, domain1, "", "https://\(domain1)/ee/v1/interact", "CustomProductionEndpointWithEmptyRegionId"),
+                     (.preProduction, domain1, "", "https://\(domain1)/ee-pre-prd/v1/interact", "CustomPreProductionEndpointWithEmptyRegionId"),
+                     (.integration, domain1, "", "https://edge-int.adobedc.net/ee/v1/interact", "CustomIntegrationEndpointWithEmptyRegionId")]
+
+        cases.forEach {
+            let endpoint = EdgeEndpoint(requestType: EdgeRequestType.interact, environmentType: $0, optionalDomain: $1, regionId: $2)
+            XCTAssertEqual($3, endpoint.url?.absoluteString, "\($4) test case failed.")
+        }
+    }
+
     func testEdgeEndpoint_consent_defaultDomain() {
         // cases defined as: ($0: input EnvironmentType, $1: expected output EdgeEndpoint URL, $2: Test case name)
         let cases = [(EdgeEnvironmentType.production, "https://edge.adobedc.net/ee/v1/privacy/set-consent", "DefaultProductionEndpoint"),
@@ -95,6 +126,21 @@ class EdgeEndpointTests: XCTestCase {
         cases.forEach {
             let endpoint = EdgeEndpoint(requestType: EdgeRequestType.consent, environmentType: $0)
             XCTAssertEqual($1, endpoint.url?.absoluteString, "\($2) test case failed.")
+        }
+    }
+
+    func testEdgeEndpoint_consent_regionId_defaultDomain() {
+        // cases defined as: ($0: input EnvironmentType, $1: region id, $2: expected output EdgeEndpoint URL, $3: Test case name)
+        let cases = [(EdgeEnvironmentType.production, "or2", "https://edge.adobedc.net/ee/or2/v1/privacy/set-consent", "DefaultProductionEndpointWithRegionId"),
+                     (.preProduction, "or2", "https://edge.adobedc.net/ee-pre-prd/or2/v1/privacy/set-consent", "DefaultProductionEndpointWithRegionId"),
+                     (.integration, "or2", "https://edge-int.adobedc.net/ee/or2/v1/privacy/set-consent", "DefaultIntegrationEndpointWithRegionId"),
+                     (EdgeEnvironmentType.production, "", "https://edge.adobedc.net/ee/v1/privacy/set-consent", "DefaultProductionEndpointWithEmptyRegionId"),
+                     (.preProduction, "", "https://edge.adobedc.net/ee-pre-prd/v1/privacy/set-consent", "DefaultProductionEndpointWithEmptyRegionId"),
+                     (.integration, "", "https://edge-int.adobedc.net/ee/v1/privacy/set-consent", "DefaultIntegrationEndpointWithEmptyRegionId")]
+
+        cases.forEach {
+            let endpoint = EdgeEndpoint(requestType: EdgeRequestType.consent, environmentType: $0, optionalDomain: nil, regionId: $1)
+            XCTAssertEqual($2, endpoint.url?.absoluteString, "\($3) test case failed.")
         }
     }
 
@@ -110,6 +156,22 @@ class EdgeEndpointTests: XCTestCase {
         cases.forEach {
             let endpoint = EdgeEndpoint(requestType: EdgeRequestType.consent, environmentType: $0, optionalDomain: $1)
             XCTAssertEqual($2, endpoint.url?.absoluteString, "\($3) test case failed.")
+        }
+    }
+
+    func testEdgeEndpoint_consent_regionId_customDomain() {
+        let domain1 = "my.awesome.site"
+        // cases defined as: ($0: input EnvironmentType, $1: input custom domain, $2: region id, $3: expected output EdgeEndpoint URL, $4: Test case name)
+        let cases = [(EdgeEnvironmentType.production, domain1, "or2", "https://\(domain1)/ee/or2/v1/privacy/set-consent", "CustomProductionEndpointWithRegionId"),
+                     (.preProduction, domain1, "or2", "https://\(domain1)/ee-pre-prd/or2/v1/privacy/set-consent", "CustomPreProductionEndpointWithRegionId"),
+                     (.integration, domain1, "or2", "https://edge-int.adobedc.net/ee/or2/v1/privacy/set-consent", "CustomIntegrationEndpointWithRegionId"),
+                     (EdgeEnvironmentType.production, domain1, "", "https://\(domain1)/ee/v1/privacy/set-consent", "CustomProductionEndpointWithEmptyRegionId"),
+                     (.preProduction, domain1, "", "https://\(domain1)/ee-pre-prd/v1/privacy/set-consent", "CustomPreProductionEndpointWithEmptyRegionId"),
+                     (.integration, domain1, "", "https://edge-int.adobedc.net/ee/v1/privacy/set-consent", "CustomIntegrationEndpointWithEmptyRegionId")]
+
+        cases.forEach {
+            let endpoint = EdgeEndpoint(requestType: EdgeRequestType.consent, environmentType: $0, optionalDomain: $1, regionId: $2)
+            XCTAssertEqual($3, endpoint.url?.absoluteString, "\($4) test case failed.")
         }
     }
 

--- a/Tests/UnitTests/EdgeExtensionTests.swift
+++ b/Tests/UnitTests/EdgeExtensionTests.swift
@@ -23,12 +23,14 @@ class EdgeExtensionTests: XCTestCase {
     var mockHitProcessor: MockHitProcessor!
 
     override func setUp() {
+        ServiceProvider.shared.namedKeyValueService = MockDataStore()
         mockRuntime = TestableExtensionRuntime()
         mockDataQueue = MockDataQueue()
         mockHitProcessor = MockHitProcessor()
 
         edge = Edge(runtime: mockRuntime)
-        edge.state = EdgeState(hitQueue: PersistentHitQueue(dataQueue: mockDataQueue, processor: mockHitProcessor))
+        edge.state = EdgeState(hitQueue: PersistentHitQueue(dataQueue: mockDataQueue, processor: mockHitProcessor),
+                               edgeProperties: EdgeProperties())
         edge.onRegistered()
     }
 

--- a/Tests/UnitTests/EdgeHitProcessorTests.swift
+++ b/Tests/UnitTests/EdgeHitProcessorTests.swift
@@ -31,11 +31,20 @@ class EdgeHitProcessorTests: XCTestCase {
     private let INTERACT_ENDPOINT_PROD = "https://edge.adobedc.net/ee/v1/interact"
     private let INTERACT_ENDPOINT_PRE_PROD = "https://edge.adobedc.net/ee-pre-prd/v1/interact"
     private let INTERACT_ENDPOINT_INTEGRATION = "https://edge-int.adobedc.net/ee/v1/interact"
+    private let CONSENT_ENDPOINT_LOCATION_HINT = "https://edge.adobedc.net/ee/lh1/v1/privacy/set-consent"
+    private let CONSENT_ENDPOINT_PRE_PROD_LOCATION_HINT = "https://edge.adobedc.net/ee-pre-prd/lh1/v1/privacy/set-consent"
+    private let CONSENT_ENDPOINT_INTEGRATION_LOCATION_HINT = "https://edge-int.adobedc.net/ee/lh1/v1/privacy/set-consent"
+    private let INTERACT_ENDPOINT_PROD_LOCATION_HINT = "https://edge.adobedc.net/ee/lh1/v1/interact"
+    private let INTERACT_ENDPOINT_PRE_PROD_LOCATION_HINT = "https://edge.adobedc.net/ee-pre-prd/lh1/v1/interact"
+    private let INTERACT_ENDPOINT_INTEGRATION_LOCATION_HINT = "https://edge-int.adobedc.net/ee/lh1/v1/interact"
     private static let CUSTOM_DOMAIN = "my.awesome.site"
     private static let CUSTOM_CONSENT_ENDPOINT = "https://\(CUSTOM_DOMAIN)/ee/v1/privacy/set-consent"
     private static let CUSTOM_CONSENT_ENDPOINT_PRE_PROD = "https://\(CUSTOM_DOMAIN)/ee-pre-prd/v1/privacy/set-consent"
     private static let CUSTOM_INTERACT_ENDPOINT_PROD = "https://\(CUSTOM_DOMAIN)/ee/v1/interact"
     private static let CUSTOM_INTERACT_ENDPOINT_PRE_PROD = "https://\(CUSTOM_DOMAIN)/ee-pre-prd/v1/interact"
+
+    // getLocationHint function
+    let locationHintClosure = { return "lh1" }
 
     var hitProcessor: EdgeHitProcessor!
     var networkService: EdgeNetworkService!
@@ -51,13 +60,14 @@ class EdgeHitProcessorTests: XCTestCase {
     override func setUp() {
         ServiceProvider.shared.networkService = MockNetworking()
         networkService = EdgeNetworkService()
-        networkResponseHandler = NetworkResponseHandler()
+        networkResponseHandler = NetworkResponseHandler(updateLocationHint: { (_ :String?, _ :TimeInterval?) -> Void in  })
         hitProcessor = EdgeHitProcessor(networkService: networkService,
                                         networkResponseHandler: networkResponseHandler,
                                         getSharedState: resolveSharedState(extensionName:event:),
                                         getXDMSharedState: resolveXDMSharedState(extensionName:event:barrier:),
                                         readyForEvent: readyForEvent(_:),
-                                        getImplementationDetails: { return nil })
+                                        getImplementationDetails: { return nil },
+                                        getLocationHint: { return nil })
     }
 
     private func resolveSharedState(extensionName: String, event: Event?) -> SharedStateResult? {
@@ -123,7 +133,8 @@ class EdgeHitProcessorTests: XCTestCase {
                                         readyForEvent: { _ -> Bool in
                                             return false
                                         },
-                                        getImplementationDetails: { return nil })
+                                        getImplementationDetails: { return nil },
+                                        getLocationHint: { return nil })
 
         // test
         assertProcessHit(entity: entity, sendsNetworkRequest: false, returns: false)
@@ -145,7 +156,8 @@ class EdgeHitProcessorTests: XCTestCase {
                                         },
                                         getXDMSharedState: resolveXDMSharedState(extensionName:event:barrier:),
                                         readyForEvent: readyForEvent(_:),
-                                        getImplementationDetails: { return nil })
+                                        getImplementationDetails: { return nil },
+                                        getLocationHint: { return nil })
 
         // test
         assertProcessHit(entity: entity, sendsNetworkRequest: false, returns: true)
@@ -167,7 +179,8 @@ class EdgeHitProcessorTests: XCTestCase {
                                         },
                                         getXDMSharedState: resolveXDMSharedState(extensionName:event:barrier:),
                                         readyForEvent: readyForEvent(_:),
-                                        getImplementationDetails: { return nil })
+                                        getImplementationDetails: { return nil },
+                                        getLocationHint: { return nil })
 
         // test
         assertProcessHit(entity: entity, sendsNetworkRequest: false, returns: true)
@@ -267,7 +280,8 @@ class EdgeHitProcessorTests: XCTestCase {
                                         },
                                         getXDMSharedState: resolveXDMSharedState(extensionName:event:barrier:),
                                         readyForEvent: readyForEvent(_:),
-                                        getImplementationDetails: { return nil })
+                                        getImplementationDetails: { return nil },
+                                        getLocationHint: { return nil })
         mockNetworkService?.connectAsyncMockReturnConnection = HttpConnection(data: "{}".data(using: .utf8), response: HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil), error: nil)
 
         let edgeEntity = EdgeDataEntity(event: experienceEvent, identityMap: [:])
@@ -278,52 +292,76 @@ class EdgeHitProcessorTests: XCTestCase {
         XCTAssertTrue( (mockNetworkService?.connectAsyncCalledWithNetworkRequest?.url.absoluteString ?? "").starts(with: INTERACT_ENDPOINT_PROD))
     }
 
-    func testProcessHit_consentUpdateEvent_whenConfigEndpointProduction() {
+    func testProcessHit_consentUpdateEvent_whenConfigEndpointProduction_hasCorrectEndpoint() {
         assertNetworkRequestUrl(event: consentUpdateEvent, environment: "prod", domain: nil, expectedEndpoint: CONSENT_ENDPOINT)
     }
 
-    func testProcessHit_consentUpdateEvent_whenConfigEndpointPreProduction() {
+    func testProcessHit_consentUpdateEvent_whenConfigEndpointPreProduction_hasCorrectEndpoint() {
         assertNetworkRequestUrl(event: consentUpdateEvent, environment: "pre-prod", domain: nil, expectedEndpoint: CONSENT_ENDPOINT_PRE_PROD)
     }
 
-    func testProcessHit_consentUpdateEvent_whenConfigEndpointIntegration() {
+    func testProcessHit_consentUpdateEvent_whenConfigEndpointIntegration_hasCorrectEndpoint() {
         assertNetworkRequestUrl(event: consentUpdateEvent, environment: "int", domain: nil, expectedEndpoint: CONSENT_ENDPOINT_INTEGRATION)
     }
 
-    func testProcessHit_consentUpdateEvent_whenConfigEndpointProductionAndCustomDomain() {
+    func testProcessHit_consentUpdateEvent_whenConfigEndpointProductionWithLocationHint_hasCorrectEndpoint() {
+        assertNetworkRequestUrl(event: consentUpdateEvent, environment: "prod", domain: nil, expectedEndpoint: CONSENT_ENDPOINT_LOCATION_HINT, getLocationHint: locationHintClosure)
+    }
+
+    func testProcessHit_consentUpdateEvent_whenConfigEndpointPreProductionWithLocationHint_hasCorrectEndpoint() {
+        assertNetworkRequestUrl(event: consentUpdateEvent, environment: "pre-prod", domain: nil, expectedEndpoint: CONSENT_ENDPOINT_PRE_PROD_LOCATION_HINT, getLocationHint: locationHintClosure)
+    }
+
+    func testProcessHit_consentUpdateEvent_whenConfigEndpointIntegrationWithLocationHint_hasCorrectEndpoint() {
+        assertNetworkRequestUrl(event: consentUpdateEvent, environment: "int", domain: nil, expectedEndpoint: CONSENT_ENDPOINT_INTEGRATION_LOCATION_HINT, getLocationHint: locationHintClosure)
+    }
+
+    func testProcessHit_consentUpdateEvent_whenConfigEndpointProductionAndCustomDomain_hasCorrectEndpoint() {
         assertNetworkRequestUrl(event: consentUpdateEvent, environment: "prod", domain: EdgeHitProcessorTests.CUSTOM_DOMAIN, expectedEndpoint: EdgeHitProcessorTests.CUSTOM_CONSENT_ENDPOINT)
     }
 
-    func testProcessHit_consentUpdateEvent_whenConfigEndpointPreProductionAndCustomDomain() {
+    func testProcessHit_consentUpdateEvent_whenConfigEndpointPreProductionAndCustomDomain_hasCorrectEndpoint() {
         assertNetworkRequestUrl(event: consentUpdateEvent, environment: "pre-prod", domain: EdgeHitProcessorTests.CUSTOM_DOMAIN, expectedEndpoint: EdgeHitProcessorTests.CUSTOM_CONSENT_ENDPOINT_PRE_PROD)
     }
 
-    func testProcessHit_consentUpdateEvent_whenConfigEndpointIntegrationAndCustomDomain() {
+    func testProcessHit_consentUpdateEvent_whenConfigEndpointIntegrationAndCustomDomain_hasCorrectEndpoint() {
         // Note, custom domains are not supported with the integration endpoint
         assertNetworkRequestUrl(event: consentUpdateEvent, environment: "int", domain: EdgeHitProcessorTests.CUSTOM_DOMAIN, expectedEndpoint: CONSENT_ENDPOINT_INTEGRATION)
     }
 
-    func testProcessHit_experienceEvent_whenConfigEndpointProduction() {
+    func testProcessHit_experienceEvent_whenConfigEndpointProduction_hasCorrectEndpoint() {
         assertNetworkRequestUrl(event: experienceEvent, environment: "prod", domain: nil, expectedEndpoint: INTERACT_ENDPOINT_PROD)
     }
 
-    func testProcessHit_experienceEvent_whenConfigEndpointPreProduction() {
+    func testProcessHit_experienceEvent_whenConfigEndpointPreProduction_hasCorrectEndpoint() {
         assertNetworkRequestUrl(event: experienceEvent, environment: "pre-prod", domain: nil, expectedEndpoint: INTERACT_ENDPOINT_PRE_PROD)
     }
 
-    func testProcessHit_experienceEvent_whenConfigEndpointIntegration() {
+    func testProcessHit_experienceEvent_whenConfigEndpointIntegration_hasCorrectEndpoint() {
         assertNetworkRequestUrl(event: experienceEvent, environment: "int", domain: nil, expectedEndpoint: INTERACT_ENDPOINT_INTEGRATION)
     }
 
-    func testProcessHit_experienceEvent_whenConfigEndpointProductionAndCustomDomain() {
+    func testProcessHit_experienceEvent_whenConfigEndpointProductionWithLocationHint_hasCorrectEndpoint() {
+        assertNetworkRequestUrl(event: experienceEvent, environment: "prod", domain: nil, expectedEndpoint: INTERACT_ENDPOINT_PROD_LOCATION_HINT, getLocationHint: locationHintClosure)
+    }
+
+    func testProcessHit_experienceEvent_whenConfigEndpointPreProductionWithLocationHint_hasCorrectEndpoint() {
+        assertNetworkRequestUrl(event: experienceEvent, environment: "pre-prod", domain: nil, expectedEndpoint: INTERACT_ENDPOINT_PRE_PROD_LOCATION_HINT, getLocationHint: locationHintClosure)
+    }
+
+    func testProcessHit_experienceEvent_whenConfigEndpointIntegrationWithLocationHint_hasCorrectEndpoint() {
+        assertNetworkRequestUrl(event: experienceEvent, environment: "int", domain: nil, expectedEndpoint: INTERACT_ENDPOINT_INTEGRATION_LOCATION_HINT, getLocationHint: locationHintClosure)
+    }
+
+    func testProcessHit_experienceEvent_whenConfigEndpointProductionAndCustomDomain_hasCorrectEndpoint() {
         assertNetworkRequestUrl(event: experienceEvent, environment: "prod", domain: EdgeHitProcessorTests.CUSTOM_DOMAIN, expectedEndpoint: EdgeHitProcessorTests.CUSTOM_INTERACT_ENDPOINT_PROD)
     }
 
-    func testProcessHit_experienceEvent_whenConfigEndpointPreProductionAndCustomDomain() {
+    func testProcessHit_experienceEvent_whenConfigEndpointPreProductionAndCustomDomain_hasCorrectEndpoint() {
         assertNetworkRequestUrl(event: experienceEvent, environment: "pre-prod", domain: EdgeHitProcessorTests.CUSTOM_DOMAIN, expectedEndpoint: EdgeHitProcessorTests.CUSTOM_INTERACT_ENDPOINT_PRE_PROD)
     }
 
-    func testProcessHit_experienceEvent_whenConfigEndpointIntegrationAndCustomDomain() {
+    func testProcessHit_experienceEvent_whenConfigEndpointIntegrationAndCustomDomain_hasCorrectEndpoint() {
         // Note, custom domains are not supported with the integration endpoint
         assertNetworkRequestUrl(event: experienceEvent, environment: "int", domain: EdgeHitProcessorTests.CUSTOM_DOMAIN, expectedEndpoint: INTERACT_ENDPOINT_INTEGRATION)
     }
@@ -465,7 +503,8 @@ class EdgeHitProcessorTests: XCTestCase {
                                                 "environment": "app",
                                                 "version": "3.3.1+1.0.0"
                                             ]
-                                        })
+                                        },
+                                        getLocationHint: { return nil })
 
         mockNetworkService?.connectAsyncMockReturnConnection = HttpConnection(data: "{}".data(using: .utf8), response: HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil), error: nil)
 
@@ -494,7 +533,8 @@ class EdgeHitProcessorTests: XCTestCase {
                                         getSharedState: resolveSharedState(extensionName:event:),
                                         getXDMSharedState: resolveXDMSharedState(extensionName:event:barrier:),
                                         readyForEvent: readyForEvent(_:),
-                                        getImplementationDetails: { return nil })
+                                        getImplementationDetails: { return nil },
+                                        getLocationHint: { return nil })
 
         mockNetworkService?.connectAsyncMockReturnConnection = HttpConnection(data: "{}".data(using: .utf8), response: HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil), error: nil)
 
@@ -529,7 +569,8 @@ class EdgeHitProcessorTests: XCTestCase {
                                                 "environment": "app",
                                                 "version": "3.3.1+1.0.0"
                                             ]
-                                        })
+                                        },
+                                        getLocationHint: { return nil })
 
         mockNetworkService?.connectAsyncMockReturnConnection = HttpConnection(data: "{}".data(using: .utf8), response: HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil), error: nil)
 
@@ -568,7 +609,7 @@ class EdgeHitProcessorTests: XCTestCase {
         XCTAssertEqual(sendsNetworkRequest, mockNetworkService?.connectAsyncCalled, "Expected network request to be \(sendsNetworkRequest), but it was \(mockNetworkService?.connectAsyncCalled ?? false)", line: line)
     }
 
-    private func assertNetworkRequestUrl(event: Event, environment: String?, domain: String?, expectedEndpoint: String) {
+    private func assertNetworkRequestUrl(event: Event, environment: String?, domain: String?, expectedEndpoint: String, getLocationHint: @escaping () -> String? = { return nil }) {
         var config: [String: Any] = [self.EDGE_CONFIG_ID: "test-config-id"]
         if let env = environment {
             config[self.EDGE_ENV] = env
@@ -588,7 +629,8 @@ class EdgeHitProcessorTests: XCTestCase {
                                         },
                                         getXDMSharedState: resolveXDMSharedState(extensionName:event:barrier:),
                                         readyForEvent: readyForEvent(_:),
-                                        getImplementationDetails: { return nil })
+                                        getImplementationDetails: { return nil },
+                                        getLocationHint: getLocationHint)
         mockNetworkService?.connectAsyncMockReturnConnection = HttpConnection(data: "{}".data(using: .utf8), response: HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil), error: nil)
 
         let edgeEntity = EdgeDataEntity(event: event, identityMap: [:])

--- a/Tests/UnitTests/EdgeHitProcessorTests.swift
+++ b/Tests/UnitTests/EdgeHitProcessorTests.swift
@@ -27,16 +27,16 @@ class EdgeHitProcessorTests: XCTestCase {
     // Edge Endpoints
     private let CONSENT_ENDPOINT = "https://edge.adobedc.net/ee/v1/privacy/set-consent"
     private let CONSENT_ENDPOINT_PRE_PROD = "https://edge.adobedc.net/ee-pre-prd/v1/privacy/set-consent"
-    private let CONSENT_ENDPOINT_INTEGRATION = "https://edge-int.adobedc.net/ee/v1/privacy/set-consent"
+    private let CONSENT_ENDPOINT_INT = "https://edge-int.adobedc.net/ee/v1/privacy/set-consent"
     private let INTERACT_ENDPOINT_PROD = "https://edge.adobedc.net/ee/v1/interact"
     private let INTERACT_ENDPOINT_PRE_PROD = "https://edge.adobedc.net/ee-pre-prd/v1/interact"
-    private let INTERACT_ENDPOINT_INTEGRATION = "https://edge-int.adobedc.net/ee/v1/interact"
+    private let INTERACT_ENDPOINT_INT = "https://edge-int.adobedc.net/ee/v1/interact"
     private let CONSENT_ENDPOINT_LOCATION_HINT = "https://edge.adobedc.net/ee/lh1/v1/privacy/set-consent"
     private let CONSENT_ENDPOINT_PRE_PROD_LOCATION_HINT = "https://edge.adobedc.net/ee-pre-prd/lh1/v1/privacy/set-consent"
-    private let CONSENT_ENDPOINT_INTEGRATION_LOCATION_HINT = "https://edge-int.adobedc.net/ee/lh1/v1/privacy/set-consent"
+    private let CONSENT_ENDPOINT_INT_LOCATION_HINT = "https://edge-int.adobedc.net/ee/lh1/v1/privacy/set-consent"
     private let INTERACT_ENDPOINT_PROD_LOCATION_HINT = "https://edge.adobedc.net/ee/lh1/v1/interact"
     private let INTERACT_ENDPOINT_PRE_PROD_LOCATION_HINT = "https://edge.adobedc.net/ee-pre-prd/lh1/v1/interact"
-    private let INTERACT_ENDPOINT_INTEGRATION_LOCATION_HINT = "https://edge-int.adobedc.net/ee/lh1/v1/interact"
+    private let INTERACT_ENDPOINT_INT_LOCATION_HINT = "https://edge-int.adobedc.net/ee/lh1/v1/interact"
     private static let CUSTOM_DOMAIN = "my.awesome.site"
     private static let CUSTOM_CONSENT_ENDPOINT = "https://\(CUSTOM_DOMAIN)/ee/v1/privacy/set-consent"
     private static let CUSTOM_CONSENT_ENDPOINT_PRE_PROD = "https://\(CUSTOM_DOMAIN)/ee-pre-prd/v1/privacy/set-consent"
@@ -301,7 +301,7 @@ class EdgeHitProcessorTests: XCTestCase {
     }
 
     func testProcessHit_consentUpdateEvent_whenConfigEndpointIntegration_hasCorrectEndpoint() {
-        assertNetworkRequestUrl(event: consentUpdateEvent, environment: "int", domain: nil, expectedEndpoint: CONSENT_ENDPOINT_INTEGRATION)
+        assertNetworkRequestUrl(event: consentUpdateEvent, environment: "int", domain: nil, expectedEndpoint: CONSENT_ENDPOINT_INT)
     }
 
     func testProcessHit_consentUpdateEvent_whenConfigEndpointProductionWithLocationHint_hasCorrectEndpoint() {
@@ -313,7 +313,7 @@ class EdgeHitProcessorTests: XCTestCase {
     }
 
     func testProcessHit_consentUpdateEvent_whenConfigEndpointIntegrationWithLocationHint_hasCorrectEndpoint() {
-        assertNetworkRequestUrl(event: consentUpdateEvent, environment: "int", domain: nil, expectedEndpoint: CONSENT_ENDPOINT_INTEGRATION_LOCATION_HINT, getLocationHint: locationHintClosure)
+        assertNetworkRequestUrl(event: consentUpdateEvent, environment: "int", domain: nil, expectedEndpoint: CONSENT_ENDPOINT_INT_LOCATION_HINT, getLocationHint: locationHintClosure)
     }
 
     func testProcessHit_consentUpdateEvent_whenConfigEndpointProductionAndCustomDomain_hasCorrectEndpoint() {
@@ -326,7 +326,7 @@ class EdgeHitProcessorTests: XCTestCase {
 
     func testProcessHit_consentUpdateEvent_whenConfigEndpointIntegrationAndCustomDomain_hasCorrectEndpoint() {
         // Note, custom domains are not supported with the integration endpoint
-        assertNetworkRequestUrl(event: consentUpdateEvent, environment: "int", domain: EdgeHitProcessorTests.CUSTOM_DOMAIN, expectedEndpoint: CONSENT_ENDPOINT_INTEGRATION)
+        assertNetworkRequestUrl(event: consentUpdateEvent, environment: "int", domain: EdgeHitProcessorTests.CUSTOM_DOMAIN, expectedEndpoint: CONSENT_ENDPOINT_INT)
     }
 
     func testProcessHit_experienceEvent_whenConfigEndpointProduction_hasCorrectEndpoint() {
@@ -338,7 +338,7 @@ class EdgeHitProcessorTests: XCTestCase {
     }
 
     func testProcessHit_experienceEvent_whenConfigEndpointIntegration_hasCorrectEndpoint() {
-        assertNetworkRequestUrl(event: experienceEvent, environment: "int", domain: nil, expectedEndpoint: INTERACT_ENDPOINT_INTEGRATION)
+        assertNetworkRequestUrl(event: experienceEvent, environment: "int", domain: nil, expectedEndpoint: INTERACT_ENDPOINT_INT)
     }
 
     func testProcessHit_experienceEvent_whenConfigEndpointProductionWithLocationHint_hasCorrectEndpoint() {
@@ -350,7 +350,7 @@ class EdgeHitProcessorTests: XCTestCase {
     }
 
     func testProcessHit_experienceEvent_whenConfigEndpointIntegrationWithLocationHint_hasCorrectEndpoint() {
-        assertNetworkRequestUrl(event: experienceEvent, environment: "int", domain: nil, expectedEndpoint: INTERACT_ENDPOINT_INTEGRATION_LOCATION_HINT, getLocationHint: locationHintClosure)
+        assertNetworkRequestUrl(event: experienceEvent, environment: "int", domain: nil, expectedEndpoint: INTERACT_ENDPOINT_INT_LOCATION_HINT, getLocationHint: locationHintClosure)
     }
 
     func testProcessHit_experienceEvent_whenConfigEndpointProductionAndCustomDomain_hasCorrectEndpoint() {
@@ -363,7 +363,7 @@ class EdgeHitProcessorTests: XCTestCase {
 
     func testProcessHit_experienceEvent_whenConfigEndpointIntegrationAndCustomDomain_hasCorrectEndpoint() {
         // Note, custom domains are not supported with the integration endpoint
-        assertNetworkRequestUrl(event: experienceEvent, environment: "int", domain: EdgeHitProcessorTests.CUSTOM_DOMAIN, expectedEndpoint: INTERACT_ENDPOINT_INTEGRATION)
+        assertNetworkRequestUrl(event: experienceEvent, environment: "int", domain: EdgeHitProcessorTests.CUSTOM_DOMAIN, expectedEndpoint: INTERACT_ENDPOINT_INT)
     }
 
     func testProcessHit_experienceEvent_nilData_doesNotSendNetworkRequest_returnsTrue() {

--- a/Tests/UnitTests/EdgeHitProcessorTests.swift
+++ b/Tests/UnitTests/EdgeHitProcessorTests.swift
@@ -31,21 +31,21 @@ class EdgeHitProcessorTests: XCTestCase {
     private let INTERACT_ENDPOINT_PROD = "https://edge.adobedc.net/ee/v1/interact"
     private let INTERACT_ENDPOINT_PRE_PROD = "https://edge.adobedc.net/ee-pre-prd/v1/interact"
     private let INTERACT_ENDPOINT_INT = "https://edge-int.adobedc.net/ee/v1/interact"
-    
+
     private let CONSENT_ENDPOINT_LOCATION_HINT = "https://edge.adobedc.net/ee/lh1/v1/privacy/set-consent"
     private let CONSENT_ENDPOINT_PRE_PROD_LOCATION_HINT = "https://edge.adobedc.net/ee-pre-prd/lh1/v1/privacy/set-consent"
     private let CONSENT_ENDPOINT_INT_LOCATION_HINT = "https://edge-int.adobedc.net/ee/lh1/v1/privacy/set-consent"
     private let INTERACT_ENDPOINT_PROD_LOCATION_HINT = "https://edge.adobedc.net/ee/lh1/v1/interact"
     private let INTERACT_ENDPOINT_PRE_PROD_LOCATION_HINT = "https://edge.adobedc.net/ee-pre-prd/lh1/v1/interact"
     private let INTERACT_ENDPOINT_INT_LOCATION_HINT = "https://edge-int.adobedc.net/ee/lh1/v1/interact"
-    
+
     private let MEDIA_ENDPOINT = "https://edge.adobedc.net/ee/va/v1/sessionstart"
     private let MEDIA_ENDPOINT_PRE_PROD = "https://edge.adobedc.net/ee-pre-prd/va/v1/sessionstart"
     private let MEDIA_ENDPOINT_INTEGRATION = "https://edge-int.adobedc.net/ee/va/v1/sessionstart"
     private let MEDIA_ENDPOINT_LOC_HINT = "https://edge.adobedc.net/ee/lh1/va/v1/sessionstart"
     private let MEDIA_ENDPOINT_PRE_PROD_LOC_HINT = "https://edge.adobedc.net/ee-pre-prd/lh1/va/v1/sessionstart"
     private let MEDIA_ENDPOINT_INT_LOC_HINT = "https://edge-int.adobedc.net/ee/lh1/va/v1/sessionstart"
-    
+
     private static let CUSTOM_DOMAIN = "my.awesome.site"
     private static let CUSTOM_CONSENT_ENDPOINT = "https://\(CUSTOM_DOMAIN)/ee/v1/privacy/set-consent"
     private static let CUSTOM_CONSENT_ENDPOINT_PRE_PROD = "https://\(CUSTOM_DOMAIN)/ee-pre-prd/v1/privacy/set-consent"
@@ -427,7 +427,7 @@ class EdgeHitProcessorTests: XCTestCase {
     func testProcessHit_experienceEvent_whenConfigEndpointIntegrationWithLocationHint_hasCorrectEndpoint() {
         assertNetworkRequestUrl(event: experienceEvent, environment: "int", domain: nil, expectedEndpoint: INTERACT_ENDPOINT_INT_LOCATION_HINT, getLocationHint: locationHintClosure)
     }
-    
+
     func testProcessHit_experienceEvent_withOverwritePath_whenConfigEndpointProductionWithLocationHint_hasCorrectEndpoint() {
         assertNetworkRequestUrl(event: experienceEventWithOverwritePath, environment: "prod", domain: nil, expectedEndpoint: MEDIA_ENDPOINT_LOC_HINT, getLocationHint: locationHintClosure)
     }

--- a/Tests/UnitTests/EdgeHitProcessorTests.swift
+++ b/Tests/UnitTests/EdgeHitProcessorTests.swift
@@ -42,6 +42,9 @@ class EdgeHitProcessorTests: XCTestCase {
     private let MEDIA_ENDPOINT = "https://edge.adobedc.net/ee/va/v1/sessionstart"
     private let MEDIA_ENDPOINT_PRE_PROD = "https://edge.adobedc.net/ee-pre-prd/va/v1/sessionstart"
     private let MEDIA_ENDPOINT_INTEGRATION = "https://edge-int.adobedc.net/ee/va/v1/sessionstart"
+    private let MEDIA_ENDPOINT_LOC_HINT = "https://edge.adobedc.net/ee/lh1/va/v1/sessionstart"
+    private let MEDIA_ENDPOINT_PRE_PROD_LOC_HINT = "https://edge.adobedc.net/ee-pre-prd/lh1/va/v1/sessionstart"
+    private let MEDIA_ENDPOINT_INT_LOC_HINT = "https://edge-int.adobedc.net/ee/lh1/va/v1/sessionstart"
     
     private static let CUSTOM_DOMAIN = "my.awesome.site"
     private static let CUSTOM_CONSENT_ENDPOINT = "https://\(CUSTOM_DOMAIN)/ee/v1/privacy/set-consent"
@@ -423,6 +426,18 @@ class EdgeHitProcessorTests: XCTestCase {
 
     func testProcessHit_experienceEvent_whenConfigEndpointIntegrationWithLocationHint_hasCorrectEndpoint() {
         assertNetworkRequestUrl(event: experienceEvent, environment: "int", domain: nil, expectedEndpoint: INTERACT_ENDPOINT_INT_LOCATION_HINT, getLocationHint: locationHintClosure)
+    }
+    
+    func testProcessHit_experienceEvent_withOverwritePath_whenConfigEndpointProductionWithLocationHint_hasCorrectEndpoint() {
+        assertNetworkRequestUrl(event: experienceEventWithOverwritePath, environment: "prod", domain: nil, expectedEndpoint: MEDIA_ENDPOINT_LOC_HINT, getLocationHint: locationHintClosure)
+    }
+
+    func testProcessHit_experienceEvent_withOverwritePath_whenConfigEndpointPreProductionWithLocationHint_hasCorrectEndpoint() {
+        assertNetworkRequestUrl(event: experienceEventWithOverwritePath, environment: "pre-prod", domain: nil, expectedEndpoint: MEDIA_ENDPOINT_PRE_PROD_LOC_HINT, getLocationHint: locationHintClosure)
+    }
+
+    func testProcessHit_experienceEvent_withOverwritePath_whenConfigEndpointIntegrationWithLocationHint_hasCorrectEndpoint() {
+        assertNetworkRequestUrl(event: experienceEventWithOverwritePath, environment: "int", domain: nil, expectedEndpoint: MEDIA_ENDPOINT_INT_LOC_HINT, getLocationHint: locationHintClosure)
     }
 
     func testProcessHit_experienceEvent_whenConfigEndpointProductionAndCustomDomain_hasCorrectEndpoint() {

--- a/Tests/UnitTests/EdgeNetworkServiceTests.swift
+++ b/Tests/UnitTests/EdgeNetworkServiceTests.swift
@@ -15,6 +15,7 @@ import XCTest
 
 @testable import AEPEdge
 
+// swiftlint:disable type_body_length
 class EdgeNetworkServiceTests: XCTestCase {
 
     private var mockNetworking = MockNetworking()

--- a/Tests/UnitTests/EdgeStateTests.swift
+++ b/Tests/UnitTests/EdgeStateTests.swift
@@ -1,0 +1,261 @@
+//
+// Copyright 2022 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+import AEPCore
+@testable import AEPEdge
+import AEPServices
+import XCTest
+
+class EdgeStateTests: XCTestCase {
+    let experienceEvent = Event(name: "Experience event", type: EventType.edge, source: EventSource.requestContent, data: ["xdm": ["data": "example"]])
+    var edgeState: EdgeState!
+    var mockDataQueue: MockDataQueue!
+    var mockHitProcessor: MockHitProcessor!
+
+    var mockDataStore: MockDataStore {
+        return ServiceProvider.shared.namedKeyValueService as! MockDataStore
+    }
+
+    override func setUp() {
+        ServiceProvider.shared.namedKeyValueService = MockDataStore()
+        mockDataQueue = MockDataQueue()
+        mockHitProcessor = MockHitProcessor()
+
+        edgeState = EdgeState(hitQueue: PersistentHitQueue(dataQueue: mockDataQueue, processor: mockHitProcessor),
+                              edgeProperties: EdgeProperties())
+    }
+
+    func testBootupIfNeeded_loadsEdgePropertiesFromPersistence_andCreatesSharedState_withLocationHint() {
+        var storedProperties = EdgeProperties()
+        XCTAssertTrue(storedProperties.setLocationHint(hint: "or2", ttlSeconds: 100))
+        storedProperties.saveToPersistence()
+
+        guard let expectedExpiryDate = storedProperties.locationHintExpiryDate else {
+            XCTFail("Failed to setup test with stored properties. Expiry Date not set.")
+            return
+        }
+
+        let expectation = XCTestExpectation(description: "createSharedState callback")
+        edgeState.bootupIfNeeded(event: experienceEvent,
+                                 getSharedState: {_, _, _ in return nil },
+                                 createSharedState: { data, _ in
+                                    // Verify shared state is created with correct location hint value
+                                    XCTAssertEqual("or2", data[EdgeConstants.SharedState.Edge.LOCATION_HINT] as? String)
+                                    expectation.fulfill()
+                                 })
+
+        wait(for: [expectation], timeout: 1)
+
+        // Verify Edge Properties loaded correct location hint and expiry date
+        XCTAssertEqual("or2", edgeState.edgeProperties.locationHint)
+        XCTAssertEqual(expectedExpiryDate.timeIntervalSince1970, edgeState.edgeProperties.locationHintExpiryDate?.timeIntervalSince1970 ?? 0)
+    }
+
+    func testBootupIfNeeded_loadsEdgePropertiesFromPersistence_andCreatesSharedState_withExpiredLocationHint() {
+        var storedProperties = EdgeProperties()
+        XCTAssertTrue(storedProperties.setLocationHint(hint: "or2", ttlSeconds: 1))
+        storedProperties.saveToPersistence()
+
+        guard let expectedExpiryDate = storedProperties.locationHintExpiryDate else {
+            XCTFail("Failed to setup test with stored properties. Expiry Date not set.")
+            return
+        }
+
+        sleep(1)
+
+        let expectation = XCTestExpectation(description: "createSharedState callback")
+        edgeState.bootupIfNeeded(event: experienceEvent,
+                                 getSharedState: {_, _, _ in return nil },
+                                 createSharedState: { data, _ in
+                                    // Verify shared state is created but without location hint value as it expired
+                                    XCTAssertNil(data[EdgeConstants.SharedState.Edge.LOCATION_HINT] as? String)
+                                    expectation.fulfill()
+                                 })
+
+        wait(for: [expectation], timeout: 1)
+
+        // Verify Edge Properties loaded correct location hint and expiry date
+        // Location Hint is expired so returns nil, but expiry date isn't cleared
+        XCTAssertNil(edgeState.edgeProperties.locationHint)
+        XCTAssertEqual(expectedExpiryDate.timeIntervalSince1970, edgeState.edgeProperties.locationHintExpiryDate?.timeIntervalSince1970 ?? 0)
+    }
+
+    func testGetLocationHint_returnsHint_forValidHint() {
+        XCTAssertTrue(edgeState.edgeProperties.setLocationHint(hint: "or2", ttlSeconds: 100))
+        XCTAssertEqual("or2", edgeState.getLocationHint())
+    }
+
+    func testGetLocationHint_returnsNil_forExpiredHint() {
+        XCTAssertTrue(edgeState.edgeProperties.setLocationHint(hint: "or2", ttlSeconds: 1))
+        sleep(1)
+        XCTAssertNil(edgeState.getLocationHint())
+    }
+
+    func testSetLocationHint_updatesHintAndExpiryDate_andSharesState() {
+        let expectation = XCTestExpectation(description: "createSharedState callback")
+        let expectedExpiryDate = Date() + 100
+        edgeState.setLocationHint(hint: "or2", ttlSeconds: 100, createSharedState: {data, _ in
+            // Verify shared state is created with new location hint
+            XCTAssertEqual("or2", data[EdgeConstants.SharedState.Edge.LOCATION_HINT] as? String)
+            expectation.fulfill()
+        })
+
+        wait(for: [expectation], timeout: 1)
+
+        // Verify Edge Properties updated with correct location hint and expiry date
+        XCTAssertEqual("or2", edgeState.edgeProperties.locationHint)
+        XCTAssertEqual(expectedExpiryDate.timeIntervalSince1970, edgeState.edgeProperties.locationHintExpiryDate?.timeIntervalSince1970 ?? 0, accuracy: 2)
+
+        // Verify Edge Properties stored in data store
+        guard let storedProps = getPropertiesFromMockDataStore() else {
+            XCTFail("Failed to read EdgeProperties from MockDataStore.")
+            return
+        }
+
+        XCTAssertEqual("or2", storedProps.locationHint)
+        XCTAssertEqual(expectedExpiryDate.timeIntervalSince1970, storedProps.locationHintExpiryDate?.timeIntervalSince1970 ?? 0, accuracy: 2)
+    }
+
+    func testSetLocationHint_updatesHintAndExpiryDate_andDoesNotShareState_whenHintDoesNotChange() {
+        // Set a previous Hint and Date
+        XCTAssertTrue(edgeState.edgeProperties.setLocationHint(hint: "or2", ttlSeconds: 10))
+
+        let expectedExpiryDate = Date() + 1000
+        edgeState.setLocationHint(hint: "or2", ttlSeconds: 1000, createSharedState: {_, _ in
+            XCTFail("Shared state not expected.")
+        })
+
+        sleep(1) // short wait to verify shared state is not called, as EdgeState uses async dispatch queue
+
+        // Verify Edge Properties updated with correct location hint and expiry date
+        XCTAssertEqual("or2", edgeState.edgeProperties.locationHint)
+        XCTAssertEqual(expectedExpiryDate.timeIntervalSince1970, edgeState.edgeProperties.locationHintExpiryDate?.timeIntervalSince1970 ?? 0, accuracy: 2)
+
+        // Verify Edge Properties stored in data store
+        guard let storedProps = getPropertiesFromMockDataStore() else {
+            XCTFail("Failed to read EdgeProperties from MockDataStore.")
+            return
+        }
+
+        XCTAssertEqual("or2", storedProps.locationHint)
+        XCTAssertEqual(expectedExpiryDate.timeIntervalSince1970, storedProps.locationHintExpiryDate?.timeIntervalSince1970 ?? 0, accuracy: 2)
+    }
+
+    func testSetLocationHint_updatesHintAndExpiryDate_andSharesState_whenHintHasExpired() {
+        // Set a previous Hint and Date
+        XCTAssertTrue(edgeState.edgeProperties.setLocationHint(hint: "or2", ttlSeconds: 1))
+
+        sleep(1) // wait for hint to expire
+
+        // Set hint to same value and verify shared state is created, as previous hint expired
+        let expectation = XCTestExpectation(description: "createSharedState callback")
+        let expectedExpiryDate = Date() + 100
+        edgeState.setLocationHint(hint: "or2", ttlSeconds: 100, createSharedState: {data, _ in
+            // Verify shared state is created with new location hint
+            XCTAssertEqual("or2", data[EdgeConstants.SharedState.Edge.LOCATION_HINT] as? String)
+            expectation.fulfill()
+        })
+
+        wait(for: [expectation], timeout: 1)
+
+        // Verify Edge Properties updated with correct location hint and expiry date
+        XCTAssertEqual("or2", edgeState.edgeProperties.locationHint)
+        XCTAssertEqual(expectedExpiryDate.timeIntervalSince1970, edgeState.edgeProperties.locationHintExpiryDate?.timeIntervalSince1970 ?? 0, accuracy: 2)
+
+        // Verify Edge Properties stored in data store
+        guard let storedProps = getPropertiesFromMockDataStore() else {
+            XCTFail("Failed to read EdgeProperties from MockDataStore.")
+            return
+        }
+
+        XCTAssertEqual("or2", storedProps.locationHint)
+        XCTAssertEqual(expectedExpiryDate.timeIntervalSince1970, storedProps.locationHintExpiryDate?.timeIntervalSince1970 ?? 0, accuracy: 2)
+    }
+
+    func testClearLocationHint_clearsHintAndExpiryDate_andCreatesSharedState() {
+        // Set a previous Hint and Date
+        XCTAssertTrue(edgeState.edgeProperties.setLocationHint(hint: "or2", ttlSeconds: 100))
+
+        let expectation = XCTestExpectation(description: "createSharedState callback")
+        edgeState.clearLocationHint(createSharedState: {data, _ in
+            // Verify shared state is created without location hint as hint value changed
+            XCTAssertNil(data[EdgeConstants.SharedState.Edge.LOCATION_HINT] as? String)
+            expectation.fulfill()
+        })
+
+        wait(for: [expectation], timeout: 1)
+
+        // Verify Edge Properties clears location hint and expiry date
+        XCTAssertNil(edgeState.edgeProperties.locationHint)
+        XCTAssertNil(edgeState.edgeProperties.locationHintExpiryDate)
+
+        // Verify Edge Properties clears hint in data store
+        guard let storedProps = getPropertiesFromMockDataStore() else {
+            XCTFail("Failed to read EdgeProperties from MockDataStore.")
+            return
+        }
+
+        XCTAssertNil(storedProps.locationHint)
+        XCTAssertNil(storedProps.locationHintExpiryDate)
+    }
+
+    func testClearLocationHint_whenNoHitSet_doesNotCreateSharedState() {
+        // Clear hint, but as no previous hint is set (hint == nil) then no shared state is created
+        edgeState.clearLocationHint(createSharedState: {_, _ in
+            XCTFail("Shared state not expected.")
+        })
+
+        sleep(1) // short wait to verify shared state is not called, as EdgeState uses async dispatch queue
+    }
+
+    func testClearLocationHint_clearsHintAndExpiryDate_andCreatesSharedState_whenHintHasExpired() {
+        // Set a previous Hint and Date
+        XCTAssertTrue(edgeState.edgeProperties.setLocationHint(hint: "or2", ttlSeconds: 1))
+
+        sleep(1) // wait for hint to expire
+
+        // Clear hint and verify shared state is created even though previous hint expired
+        let expectation = XCTestExpectation(description: "createSharedState callback")
+        edgeState.clearLocationHint(createSharedState: {data, _ in
+            // Verify shared state is created with not location hint
+            XCTAssertNil(data[EdgeConstants.SharedState.Edge.LOCATION_HINT] as? String)
+            expectation.fulfill()
+        })
+
+        wait(for: [expectation], timeout: 1)
+
+        // Verify Edge Properties updated with correct location hint and expiry date
+        XCTAssertNil(edgeState.edgeProperties.locationHint)
+        XCTAssertNil(edgeState.edgeProperties.locationHintExpiryDate)
+
+        // Verify Edge Properties stored in data store
+        guard let storedProps = getPropertiesFromMockDataStore() else {
+            XCTFail("Failed to read EdgeProperties from MockDataStore.")
+            return
+        }
+
+        XCTAssertNil(storedProps.locationHint)
+        XCTAssertNil(storedProps.locationHintExpiryDate)
+    }
+
+    /// Helper to read `EdgeProperties` from `MockDataStore`.
+    /// - Returns: EdgeProperties from MockDataStore under key "edge.properties", or nil if no value found or an error occurred while reading properties.
+    private func getPropertiesFromMockDataStore() -> EdgeProperties? {
+        guard let data = mockDataStore.dict["edge.properties"] as? Data else {
+            return nil
+        }
+
+        let decoder = JSONDecoder()
+        return try? decoder.decode(EdgeProperties.self, from: data)
+    }
+
+}

--- a/Tests/UnitTests/NetworkResponseHandlerTests.swift
+++ b/Tests/UnitTests/NetworkResponseHandlerTests.swift
@@ -15,14 +15,14 @@ import AEPCore
 import XCTest
 
 class NetworkResponseHandlerTests: XCTestCase {
-    private var networkResponseHandler = NetworkResponseHandler()
+    private var networkResponseHandler = NetworkResponseHandler(updateLocationHint: { (_ :String?, _ :TimeInterval?) -> Void in  })
     private let event1 = Event(name: "e1", type: "eventType", source: "eventSource", data: nil)
     private let event2 = Event(name: "e2", type: "eventType", source: "eventSource", data: nil)
     private let event3 = Event(name: "e3", type: "eventType", source: "eventSource", data: nil)
 
     override func setUp() {
         continueAfterFailure = false // fail so nil checks stop execution
-        networkResponseHandler = NetworkResponseHandler()
+        networkResponseHandler = NetworkResponseHandler(updateLocationHint: { (_ :String?, _ :TimeInterval?) -> Void in  })
     }
 
     // MARK: addWaitingEvents, getWaitingEvents, removeWaitingEvents


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Handle the EdgeNetwork location hint response from Konductor.

Reads location hint and ttl from Konductor response and stores in EdgeProperties. All requests from the Edge extension will include the location hint in the request URL if available and if not expired. The location hint and expiry date (calculated from the ttlSeconds) is persisted in User Defaults and loaded once the Edge extension launches.  
The Edge extension now creates a shared state which includes just the location hint. A shared state is created on launch of the extension and when ever the location hint value changes. A shared state is not created, however, if only the expiry date is updated but the hint value doesn't change.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
