### PR TITLE
[MOB-17169] Use EventSource xIdentity for location hint APIs

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -10,22 +10,22 @@ project 'AEPEdge.xcodeproj'
 pod 'SwiftLint', '0.44.0'
 
 target 'AEPEdge' do
-  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v3.7.1'
+  pod 'AEPCore'
 end
 
 target 'UnitTests' do
-  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v3.7.1'
+  pod 'AEPCore'
 end
 
 target 'FunctionalTests' do
-  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v3.7.1'
+  pod 'AEPCore'
   pod 'AEPEdgeIdentity'
   pod 'AEPEdgeConsent'
 end
 
 target 'TestAppSwiftUI' do
-  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v3.7.1'
-  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v3.7.1'
+  pod 'AEPCore'
+  pod 'AEPServices'
   pod 'AEPEdgeIdentity'
   pod 'AEPEdgeConsent'
   pod 'AEPAssurance'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -19,36 +19,22 @@ PODS:
 
 DEPENDENCIES:
   - AEPAssurance
-  - AEPCore (from `https://github.com/adobe/aepsdk-core-ios.git`, branch `dev-v3.7.1`)
+  - AEPCore
   - AEPEdgeConsent
   - AEPEdgeIdentity
-  - AEPServices (from `https://github.com/adobe/aepsdk-core-ios.git`, branch `dev-v3.7.1`)
+  - AEPServices
   - SwiftLint (= 0.44.0)
 
 SPEC REPOS:
   trunk:
     - AEPAssurance
+    - AEPCore
     - AEPEdge
     - AEPEdgeConsent
     - AEPEdgeIdentity
     - AEPRulesEngine
+    - AEPServices
     - SwiftLint
-
-EXTERNAL SOURCES:
-  AEPCore:
-    :branch: dev-v3.7.1
-    :git: https://github.com/adobe/aepsdk-core-ios.git
-  AEPServices:
-    :branch: dev-v3.7.1
-    :git: https://github.com/adobe/aepsdk-core-ios.git
-
-CHECKOUT OPTIONS:
-  AEPCore:
-    :commit: c178eb98f92d6451ad935dc2ac07612834b83d78
-    :git: https://github.com/adobe/aepsdk-core-ios.git
-  AEPServices:
-    :commit: c178eb98f92d6451ad935dc2ac07612834b83d78
-    :git: https://github.com/adobe/aepsdk-core-ios.git
 
 SPEC CHECKSUMS:
   AEPAssurance: b25880cd4b14f22c61a1dce19807bd0ca0fe9b17
@@ -60,6 +46,6 @@ SPEC CHECKSUMS:
   AEPServices: 7284c30359c789cd16bf366b4ea81094a66d21ab
   SwiftLint: e96c0a8c770c7ebbc4d36c55baf9096bb65c4584
 
-PODFILE CHECKSUM: 4d4c5f960174accf2988aa9e23ce73dc6552c159
+PODFILE CHECKSUM: 17831f176b9e10833aa35d43d5b8b873117ce5a1
 
 COCOAPODS: 1.11.2

--- a/Sources/Edge+PublicAPI.swift
+++ b/Sources/Edge+PublicAPI.swift
@@ -47,7 +47,7 @@ public extension Edge {
     static func getLocationHint(_ completion: @escaping (String?, Error?) -> Void) {
         let event = Event(name: "Edge Request Location Hint",
                           type: EventType.edge,
-                          source: EventSource.requestProperty,
+                          source: EventSource.requestIdentity,
                           data: [EdgeConstants.EventDataKeys.LOCATION_HINT: true])
         MobileCore.dispatch(event: event) { responseEvent in
             guard let responseEvent = responseEvent else {
@@ -78,7 +78,7 @@ public extension Edge {
         let hintValue = hint ?? ""
         let event = Event(name: "Edge Update Location Hint",
                           type: EventType.edge,
-                          source: EventSource.updateProperty,
+                          source: EventSource.updateIdentity,
                           data: [EdgeConstants.EventDataKeys.LOCATION_HINT: hintValue as Any])
 
         MobileCore.dispatch(event: event)

--- a/Sources/Edge.swift
+++ b/Sources/Edge.swift
@@ -44,10 +44,10 @@ public class Edge: NSObject, Extension {
                          source: EventSource.requestContent,
                          listener: handleExperienceEventRequest)
         registerListener(type: EventType.edge,
-                         source: EventSource.requestProperty,
+                         source: EventSource.requestIdentity,
                          listener: handleRequestLocationHint)
         registerListener(type: EventType.edge,
-                         source: EventSource.updateProperty,
+                         source: EventSource.updateIdentity,
                          listener: handleUpdateLocationHint)
         registerListener(type: EventType.edgeConsent,
                          source: EventSource.responseContent,
@@ -189,7 +189,7 @@ public class Edge: NSObject, Extension {
 
         let responseEvent = event.createResponseEvent(name: "Edge Location Hint Response",
                                                       type: EventType.edge,
-                                                      source: EventSource.responseProperty,
+                                                      source: EventSource.responseIdentity,
                                                       data: data)
         dispatch(event: responseEvent)
     }

--- a/Tests/UnitTests/EdgePublicAPITests.swift
+++ b/Tests/UnitTests/EdgePublicAPITests.swift
@@ -82,10 +82,10 @@ class EdgePublicAPITests: XCTestCase {
         sleep(1)
     }
 
-    func testSetLocationHint_valueHint_dispatchesEdgeUpdateProperty() {
-        let expectation = XCTestExpectation(description: "Edge Update Property Event Dispatched")
+    func testSetLocationHint_valueHint_dispatchesEdgeUpdateIdentity() {
+        let expectation = XCTestExpectation(description: "Edge Update Identity Event Dispatched")
         expectation.assertForOverFulfill = true
-        MobileCore.registerEventListener(type: EventType.edge, source: EventSource.updateProperty) { event in
+        MobileCore.registerEventListener(type: EventType.edge, source: EventSource.updateIdentity) { event in
             let data = event.data ?? [:]
             XCTAssertEqual(1, data.count)
             XCTAssertEqual("or2", data["locationHint"] as? String)
@@ -97,10 +97,10 @@ class EdgePublicAPITests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
 
-    func testSetLocationHint_nilHint_dispatchesEdgeUpdateProperty() {
-        let expectation = XCTestExpectation(description: "Edge Update Property Event Dispatched")
+    func testSetLocationHint_nilHint_dispatchesEdgeUpdateIdentity() {
+        let expectation = XCTestExpectation(description: "Edge Update Identity Event Dispatched")
         expectation.assertForOverFulfill = true
-        MobileCore.registerEventListener(type: EventType.edge, source: EventSource.updateProperty) { event in
+        MobileCore.registerEventListener(type: EventType.edge, source: EventSource.updateIdentity) { event in
             let data = event.data ?? [:]
             XCTAssertEqual(1, data.count)
             XCTAssertEqual("", data["locationHint"] as? String) // expect to convert nil to empty string
@@ -112,10 +112,10 @@ class EdgePublicAPITests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
 
-    func testSetLocationHint_emptyHint_dispatchesEdgeUpdateProperty() {
-        let expectation = XCTestExpectation(description: "Edge Update Property Event Dispatched")
+    func testSetLocationHint_emptyHint_dispatchesEdgeUpdateIdentity() {
+        let expectation = XCTestExpectation(description: "Edge Update Identity Event Dispatched")
         expectation.assertForOverFulfill = true
-        MobileCore.registerEventListener(type: EventType.edge, source: EventSource.updateProperty) { event in
+        MobileCore.registerEventListener(type: EventType.edge, source: EventSource.updateIdentity) { event in
             let data = event.data ?? [:]
             XCTAssertEqual(1, data.count)
             XCTAssertEqual("", data["locationHint"] as? String)
@@ -128,14 +128,14 @@ class EdgePublicAPITests: XCTestCase {
     }
 
     // Test getLocationHint when valid Hint of OR2 is returned
-    func testGetLocationHint_dispatchesEdgeRequestProperty_receivesResponseProperty_withValidHint() {
+    func testGetLocationHint_dispatchesEdgeRequestIdentity_receivesResponseIdentity_withValidHint() {
         let expectation = XCTestExpectation(description: "Edge Get Location Hint")
         expectation.assertForOverFulfill = true
-        MobileCore.registerEventListener(type: EventType.edge, source: EventSource.requestProperty) { event in
+        MobileCore.registerEventListener(type: EventType.edge, source: EventSource.requestIdentity) { event in
             XCTAssertTrue(event.data?[EdgeConstants.EventDataKeys.LOCATION_HINT] as? Bool ?? false)
             let responseEvent = event.createResponseEvent(name: "Test Response Location Hint",
                                                           type: EventType.edge,
-                                                          source: EventSource.responseProperty,
+                                                          source: EventSource.responseIdentity,
                                                           data: ["locationHint": "or2"])
             MobileCore.dispatch(event: responseEvent)
         }
@@ -150,14 +150,14 @@ class EdgePublicAPITests: XCTestCase {
     }
 
     // Test getLocationHint when no data is returned which signifies no or expired Hint value
-    func testGetLocationHint_dispatchesEdgeRequestProperty_receivesResponseProperty_withEmptyHint() {
+    func testGetLocationHint_dispatchesEdgeRequestIdentity_receivesResponseIdentity_withEmptyHint() {
         let expectation = XCTestExpectation(description: "Edge Get Location Hint")
         expectation.assertForOverFulfill = true
-        MobileCore.registerEventListener(type: EventType.edge, source: EventSource.requestProperty) { event in
+        MobileCore.registerEventListener(type: EventType.edge, source: EventSource.requestIdentity) { event in
             XCTAssertTrue(event.data?[EdgeConstants.EventDataKeys.LOCATION_HINT] as? Bool ?? false)
             let responseEvent = event.createResponseEvent(name: "Test Response Location Hint",
                                                           type: EventType.edge,
-                                                          source: EventSource.responseProperty,
+                                                          source: EventSource.responseIdentity,
                                                           data: [:])
             MobileCore.dispatch(event: responseEvent)
         }
@@ -172,14 +172,14 @@ class EdgePublicAPITests: XCTestCase {
     }
 
     // Test getLocationHint with invalid Hint and unexpected error returned
-    func testGetLocationHint_dispatchesEdgeRequestProperty_receivesResponseProperty_withInvalidHint() {
+    func testGetLocationHint_dispatchesEdgeRequestIdentity_receivesResponseIdentity_withInvalidHint() {
         let expectation = XCTestExpectation(description: "Edge Get Location Hint")
         expectation.assertForOverFulfill = true
-        MobileCore.registerEventListener(type: EventType.edge, source: EventSource.requestProperty) { event in
+        MobileCore.registerEventListener(type: EventType.edge, source: EventSource.requestIdentity) { event in
             XCTAssertTrue(event.data?[EdgeConstants.EventDataKeys.LOCATION_HINT] as? Bool ?? false)
             let responseEvent = event.createResponseEvent(name: "Test Response Location Hint",
                                                           type: EventType.edge,
-                                                          source: EventSource.responseProperty,
+                                                          source: EventSource.responseIdentity,
                                                           data: ["locationHint": 5]) // correct key but wrong type
             MobileCore.dispatch(event: responseEvent)
         }
@@ -194,7 +194,7 @@ class EdgePublicAPITests: XCTestCase {
     }
 
     // Test getLocationHint with no response and callback timeout error returned
-    func testGetLocationHint_dispatchesEdgeRequestProperty_receivesResponseProperty_withNoData() {
+    func testGetLocationHint_dispatchesEdgeRequestIdentity_receivesResponseIdentity_withNoData() {
         let expectation = XCTestExpectation(description: "Edge Get Location Hint")
         expectation.assertForOverFulfill = true
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use `EventSource.requestIdentity`, `EventSource.responseIdentity` and `EventSource.updateIdentity` for `getLocationHint()` and `setLocationHint()` APIs. Updates Podfile to use current AEPCore release instead of `dev` branch.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
