### PR TITLE
Add labels with issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,7 @@
-
+---
+name: Blank issue
+labels: task
+---
 ## Prerequisites
 <!--- Go through the items below before logging an issue -->
 - [ ] I have searched in this repository's issues to see if it has already been reported.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,7 @@
 ---
-name: Bug Report 
+name: Bug Report
 about: Create a report to help us improve
+labels: bug
 ---
 ## Prerequisites
 <!--- Go through the items below before logging an issue -->
@@ -8,7 +9,7 @@ about: Create a report to help us improve
 - [ ] This is not a Security Disclosure, otherwise please follow the guidelines in [Security Policy](https://github.com/adobe/aepsdk-edge-ios/security/policy).
 - [ ] I have updated to the latest released version of the SDK and the issue still persists.
 
-## Bug Summary 
+## Bug Summary
 
 <!---Please provide a summary of the bug you are reporting-->
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,12 +1,13 @@
 ---
-name: Feature Request 
+name: Feature Request
 about: Suggest an idea for this project
+labels: feature-request
 ---
 ##  Before Logging a feature request
 - [ ] I have searched in this repository's issues to see if it has already been reported.
 - [ ] This is not a Security Disclosure, otherwise please follow the guidelines in [Security Policy](https://github.com/adobe/aepsdk-edge-ios/security/policy).
 
-## Feature Request Summary 
+## Feature Request Summary
 
 <!---Please provide a summary of the feature you request-->
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Adds labels automatically on the issues created through Issue -> Select template flow. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This can help querying the issues based on a certain type and separating the issues/feature requests reported externally from the internal tasks reported in the repo.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
