### PR TITLE
Integration test cases

### DIFF
--- a/Tests/TestUtils/MockNetworkService.swift
+++ b/Tests/TestUtils/MockNetworkService.swift
@@ -75,15 +75,6 @@ class MockNetworkService: Networking {
     /// Set the expected number of times a `NetworkRequest` should be seen.
     ///
     /// - Parameters:
-    ///   - networkRequest: the `NetworkRequest` to set the expectation for
-    ///   - expectedCount: how many times a request with this url and httpMethod is expected to be sent, by default it is set to 1
-    func setExpectationForNetworkRequest(networkRequest: NetworkRequest, expectedCount: Int32 = 1, file: StaticString = #file, line: UInt = #line) {
-        helper.setExpectationForNetworkRequest(networkRequest: networkRequest, expectedCount: expectedCount, file: file, line: line)
-    }
-
-    /// Set the expected number of times a `NetworkRequest` should be seen.
-    ///
-    /// - Parameters:
     ///   - url: the URL string of the `NetworkRequest` to set the expectation for
     ///   - httpMethod: the `HttpMethod` of the `NetworkRequest` to set the expectation for
     ///   - expectedCount: how many times a request with this url and httpMethod is expected to be sent, by default it is set to 1

--- a/Tests/TestUtils/MockNetworkService.swift
+++ b/Tests/TestUtils/MockNetworkService.swift
@@ -86,7 +86,7 @@ class MockNetworkService: Networking {
         guard let networkRequest = NetworkRequest(urlString: url, httpMethod: httpMethod) else {
             return
         }
-        setExpectationForNetworkRequest(networkRequest: networkRequest)
+        setExpectationForNetworkRequest(networkRequest: networkRequest, expectedCount: expectedCount, file: file, line: line)
     }
 
     func assertAllNetworkRequestExpectations(file: StaticString = #file, line: UInt = #line) {

--- a/Tests/TestUtils/MockNetworkService.swift
+++ b/Tests/TestUtils/MockNetworkService.swift
@@ -71,7 +71,7 @@ class MockNetworkService: Networking {
     }
 
     // MARK: - Passthrough for shared helper APIs
-    
+
     /// Set the expected number of times a `NetworkRequest` should be seen.
     ///
     /// - Parameters:
@@ -80,7 +80,7 @@ class MockNetworkService: Networking {
     func setExpectationForNetworkRequest(networkRequest: NetworkRequest, expectedCount: Int32 = 1, file: StaticString = #file, line: UInt = #line) {
         helper.setExpectationForNetworkRequest(networkRequest: networkRequest, expectedCount: expectedCount, file: file, line: line)
     }
-    
+
     /// Convenience method that allows using URL string and `HttpMethod` instead of `NetworkRequest`
     func setExpectationForNetworkRequest(url: String, httpMethod: HttpMethod, expectedCount: Int32 = 1, file: StaticString = #file, line: UInt = #line) {
         guard let networkRequest = NetworkRequest(urlString: url, httpMethod: httpMethod) else {

--- a/Tests/TestUtils/MockNetworkService.swift
+++ b/Tests/TestUtils/MockNetworkService.swift
@@ -14,7 +14,7 @@
 import Foundation
 import XCTest
 
-/// Overriding NetworkService used for functional tests when extending the TestBase
+/// `Networking` adhering network service utility used for tests that require mocked network requests and mocked responses
 class MockNetworkService: Networking {
     private let helper: NetworkRequestHelper = NetworkRequestHelper()
     private var responseDelay: UInt32 = 0

--- a/Tests/TestUtils/MockNetworkService.swift
+++ b/Tests/TestUtils/MockNetworkService.swift
@@ -71,8 +71,22 @@ class MockNetworkService: Networking {
     }
 
     // MARK: - Passthrough for shared helper APIs
+    
+    /// Set the expected number of times a `NetworkRequest` should be seen.
+    ///
+    /// - Parameters:
+    ///   - networkRequest: the `NetworkRequest` to set the expectation for
+    ///   - expectedCount: how many times a request with this url and httpMethod is expected to be sent, by default it is set to 1
+    func setExpectationForNetworkRequest(networkRequest: NetworkRequest, expectedCount: Int32 = 1, file: StaticString = #file, line: UInt = #line) {
+        helper.setExpectationForNetworkRequest(networkRequest: networkRequest, expectedCount: expectedCount, file: file, line: line)
+    }
+    
+    /// Convenience method that allows using URL string and `HttpMethod` instead of `NetworkRequest`
     func setExpectationForNetworkRequest(url: String, httpMethod: HttpMethod, expectedCount: Int32 = 1, file: StaticString = #file, line: UInt = #line) {
-        helper.setExpectationForNetworkRequest(url: url, httpMethod: httpMethod, expectedCount: expectedCount, file: file, line: line)
+        guard let networkRequest = NetworkRequest(urlString: url, httpMethod: httpMethod) else {
+            return
+        }
+        setExpectationForNetworkRequest(networkRequest: networkRequest)
     }
 
     func assertAllNetworkRequestExpectations(file: StaticString = #file, line: UInt = #line) {

--- a/Tests/TestUtils/MockNetworkService.swift
+++ b/Tests/TestUtils/MockNetworkService.swift
@@ -81,12 +81,17 @@ class MockNetworkService: Networking {
         helper.setExpectationForNetworkRequest(networkRequest: networkRequest, expectedCount: expectedCount, file: file, line: line)
     }
 
-    /// Convenience method that allows using URL string and `HttpMethod` instead of `NetworkRequest`
+    /// Set the expected number of times a `NetworkRequest` should be seen.
+    ///
+    /// - Parameters:
+    ///   - url: the URL string of the `NetworkRequest` to set the expectation for
+    ///   - httpMethod: the `HttpMethod` of the `NetworkRequest` to set the expectation for
+    ///   - expectedCount: how many times a request with this url and httpMethod is expected to be sent, by default it is set to 1
     func setExpectationForNetworkRequest(url: String, httpMethod: HttpMethod, expectedCount: Int32 = 1, file: StaticString = #file, line: UInt = #line) {
         guard let networkRequest = NetworkRequest(urlString: url, httpMethod: httpMethod) else {
             return
         }
-        setExpectationForNetworkRequest(networkRequest: networkRequest, expectedCount: expectedCount, file: file, line: line)
+        helper.setExpectationForNetworkRequest(networkRequest: networkRequest, expectedCount: expectedCount, file: file, line: line)
     }
 
     func assertAllNetworkRequestExpectations(file: StaticString = #file, line: UInt = #line) {

--- a/Tests/TestUtils/NetworkRequestHelper.swift
+++ b/Tests/TestUtils/NetworkRequestHelper.swift
@@ -94,22 +94,15 @@ class NetworkRequestHelper {
     }
 
     // MARK: Assertion helpers
-    /// Set the expected number of times a NetworkRequest should be seen.
+    
+    /// Set the expected number of times a `NetworkRequest` should be seen.
     ///
     /// - Parameters:
-    ///   - url: The URL for which to set the expectation
-    ///   - httpMethod: the `HttpMethod` for which to set the expectation, along with the `url`
-    ///   - count: how many times a request with this url and httpMethod is expected to be sent, by default it is set to 1
-    /// - See also:
-    ///     - assertNetworkRequestsCount()
-    ///     - getNetworkRequestsWith(url:httpMethod:)
-    func setExpectationForNetworkRequest(url: String, httpMethod: HttpMethod, expectedCount: Int32 = 1, file: StaticString = #file, line: UInt = #line) {
+    ///   - networkRequest: the `NetworkRequest` to set the expectation for
+    ///   - expectedCount: how many times a request with this url and httpMethod is expected to be sent, by default it is set to 1
+    func setExpectationForNetworkRequest(networkRequest: NetworkRequest, expectedCount: Int32 = 1, file: StaticString = #file, line: UInt = #line) {
         guard expectedCount > 0 else {
             assertionFailure("Expected event count should be greater than 0")
-            return
-        }
-
-        guard let networkRequest = NetworkRequest(urlString: url, httpMethod: httpMethod) else {
             return
         }
 

--- a/Tests/TestUtils/NetworkRequestHelper.swift
+++ b/Tests/TestUtils/NetworkRequestHelper.swift
@@ -94,7 +94,7 @@ class NetworkRequestHelper {
     }
 
     // MARK: Assertion helpers
-    
+
     /// Set the expected number of times a `NetworkRequest` should be seen.
     ///
     /// - Parameters:

--- a/Tests/TestUtils/RealNetworkService.swift
+++ b/Tests/TestUtils/RealNetworkService.swift
@@ -35,6 +35,10 @@ class RealNetworkService: NetworkService {
     }
 
     // MARK: - Passthrough for shared helper APIs
+    func assertAllNetworkRequestExpectations() {
+        helper.assertAllNetworkRequestExpectations()
+    }
+    
     func reset() {
         helper.reset()
     }

--- a/Tests/TestUtils/RealNetworkService.swift
+++ b/Tests/TestUtils/RealNetworkService.swift
@@ -38,8 +38,13 @@ class RealNetworkService: NetworkService {
     func reset() {
         helper.reset()
     }
-
-    func setExpectationForNetworkRequest(url: String, httpMethod: HttpMethod, expectedCount: Int32 = 1, file: StaticString = #file, line: UInt = #line) {
-        helper.setExpectationForNetworkRequest(url: url, httpMethod: httpMethod, expectedCount: expectedCount, file: file, line: line)
+    
+    /// Set the expected number of times a `NetworkRequest` should be seen.
+    ///
+    /// - Parameters:
+    ///   - networkRequest: the `NetworkRequest` to set the expectation for
+    ///   - expectedCount: how many times a request with this url and httpMethod is expected to be sent, by default it is set to 1
+    func setExpectationForNetworkRequest(networkRequest: NetworkRequest, expectedCount: Int32 = 1, file: StaticString = #file, line: UInt = #line) {
+        helper.setExpectationForNetworkRequest(networkRequest: networkRequest, expectedCount: expectedCount, file: file, line: line)
     }
 }

--- a/Tests/TestUtils/RealNetworkService.swift
+++ b/Tests/TestUtils/RealNetworkService.swift
@@ -38,7 +38,7 @@ class RealNetworkService: NetworkService {
     func reset() {
         helper.reset()
     }
-    
+
     /// Set the expected number of times a `NetworkRequest` should be seen.
     ///
     /// - Parameters:

--- a/Tests/TestUtils/RealNetworkService.swift
+++ b/Tests/TestUtils/RealNetworkService.swift
@@ -14,7 +14,7 @@
 import Foundation
 import XCTest
 
-/// Overriding NetworkService used for integration tests
+/// Overriding NetworkService used for tests that require real outgoing network requests
 class RealNetworkService: NetworkService {
     private let helper: NetworkRequestHelper = NetworkRequestHelper()
 

--- a/Tests/TestUtils/TestBase.swift
+++ b/Tests/TestUtils/TestBase.swift
@@ -112,7 +112,7 @@ class TestBase: XCTestCase {
     /// - See also:
     ///   - setExpectationEvent(type: source: count:)
     ///   - assertUnexpectedEvents()
-    func assertExpectedEvents(ignoreUnexpectedEvents: Bool = false, file: StaticString = #file, line: UInt = #line) {
+    func assertExpectedEvents(ignoreUnexpectedEvents: Bool = false, timeout: TimeInterval = TestConstants.Defaults.WAIT_EVENT_TIMEOUT, file: StaticString = #file, line: UInt = #line) {
         guard InstrumentedExtension.expectedEvents.count > 0 else { // swiftlint:disable:this empty_count
             assertionFailure("There are no event expectations set, use this API after calling setExpectationEvent", file: file, line: line)
             return
@@ -120,7 +120,7 @@ class TestBase: XCTestCase {
 
         let currentExpectedEvents = InstrumentedExtension.expectedEvents.shallowCopy
         for expectedEvent in currentExpectedEvents {
-            let waitResult = expectedEvent.value.await(timeout: TestConstants.Defaults.WAIT_EVENT_TIMEOUT)
+            let waitResult = expectedEvent.value.await(timeout: timeout)
             let expectedCount: Int32 = expectedEvent.value.getInitialCount()
             let receivedCount: Int32 = expectedEvent.value.getInitialCount() - expectedEvent.value.getCurrentCount()
             XCTAssertFalse(waitResult == DispatchTimeoutResult.timedOut, "Timed out waiting for event type \(expectedEvent.key.type) and source \(expectedEvent.key.source), expected \(expectedCount), but received \(receivedCount)", file: (file), line: line)

--- a/Tests/TestUtils/TestBase.swift
+++ b/Tests/TestUtils/TestBase.swift
@@ -99,7 +99,7 @@ class TestBase: XCTestCase {
             return
         }
         guard !type.isEmpty, !source.isEmpty else {
-            assertionFailure("Expected event type and source should be non-empty trings")
+            assertionFailure("Expected event type and source should be non-empty strings")
             return
         }
 
@@ -167,7 +167,7 @@ class TestBase: XCTestCase {
             sleep(timeout)
         }
     }
-
+    
     /// Returns the `ACPExtensionEvent`(s) dispatched through the Event Hub, or empty if none was found.
     /// Use this API after calling `setExpectationEvent(type:source:count:)` to wait for the right amount of time
     /// - Parameters:

--- a/Tests/TestUtils/TestConstants.swift
+++ b/Tests/TestUtils/TestConstants.swift
@@ -34,6 +34,8 @@ enum TestConstants {
         static let RESPONSE_IDENTITY = "com.adobe.eventSource.responseIdentity"
         static let REQUEST_IDENTITY = "com.adobe.eventSource.requestIdentity"
         static let BOOTED = "com.adobe.eventSource.booted"
+        static let LOCATION_HINT_RESULT = "locationHint:result"
+        static let STATE_STORE = "state:store"
     }
 
     enum EventDataKey {

--- a/Tests/TestUtils/XCTestCase+AnyCodableAsserts.swift
+++ b/Tests/TestUtils/XCTestCase+AnyCodableAsserts.swift
@@ -27,8 +27,15 @@ enum PayloadType: String {
 
 extension XCTestCase {
     // MARK: - AnyCodable helpers
+    
+    /// Gets the `AnyCodable` representation of a JSON string
     func getAnyCodable(_ jsonString: String) -> AnyCodable? {
         return try? JSONDecoder().decode(AnyCodable.self, from: jsonString.data(using: .utf8)!)
+    }
+    
+    /// Gets an event's data payload converted into `AnyCodable` format
+    func getAnyCodable(_ event: Event) -> AnyCodable? {
+        return AnyCodable(AnyCodable.from(dictionary: event.data))
     }
     
     func getAnyCodableAndPayload(_ jsonString: String, type: PayloadType) -> (anyCodable: AnyCodable, payload: [String: Any])? {

--- a/Tests/TestUtils/XCTestCase+AnyCodableAsserts.swift
+++ b/Tests/TestUtils/XCTestCase+AnyCodableAsserts.swift
@@ -89,7 +89,7 @@ extension XCTestCase {
     ///    - exactMatchPaths: the key paths in the expected JSON that should use exact matching mode, where values require the same type and literal value.
     ///    - file: the file to show test assertion failures in
     ///    - line: the line to show test assertion failures on
-    func assertTypeMatch(expected: AnyCodable?, actual: AnyCodable?, exactMatchPaths: [String] = [], file: StaticString = #file, line: UInt = #line) {
+    func assertTypeMatch(expected: AnyCodable, actual: AnyCodable?, exactMatchPaths: [String] = [], file: StaticString = #file, line: UInt = #line) {
         let pathTree = generatePathTree(paths: exactMatchPaths, file: file, line: line)
         assertFlexibleEqual(expected: expected, actual: actual, pathTree: pathTree, exactMatchMode: false, file: file, line: line)
     }
@@ -119,7 +119,7 @@ extension XCTestCase {
     ///    - typeMatchPaths: Optionally, the key paths in the expected JSON that should use type matching mode, where values require only the same type (and non-nil, given the expected value is not `nil` itself)
     ///    - file: the file to show test assertion failures in
     ///    - line: the line to show test assertion failures on
-    func assertExactMatch(expected: AnyCodable?, actual: AnyCodable?, typeMatchPaths: [String] = [], file: StaticString = #file, line: UInt = #line) {
+    func assertExactMatch(expected: AnyCodable, actual: AnyCodable?, typeMatchPaths: [String] = [], file: StaticString = #file, line: UInt = #line) {
         let pathTree = generatePathTree(paths: typeMatchPaths, file: file, line: line)
         assertFlexibleEqual(expected: expected, actual: actual, pathTree: pathTree, exactMatchMode: true, file: file, line: line)
     }

--- a/Tests/UpstreamIntegrationTests/UpstreamIntegrationTests.swift
+++ b/Tests/UpstreamIntegrationTests/UpstreamIntegrationTests.swift
@@ -624,26 +624,4 @@ class UpstreamIntegrationTests: TestBase {
         }
         return payload[2]["hint"] as? String
     }
-    
-    private func sendEventAndResetExpectations() {
-        let interactNetworkRequest = NetworkRequest(urlString: createURLWith(locationHint: edgeLocationHint), httpMethod: .post)!
-        
-        // These expectations are used as a barrier for the event processing to complete
-        networkService.setExpectationForNetworkRequest(networkRequest: interactNetworkRequest)
-        expectEdgeEventHandle(expectedHandleType: TestConstants.EventSource.LOCATION_HINT_RESULT)
-        expectEdgeEventHandle(expectedHandleType: TestConstants.EventSource.STATE_STORE)
-
-        let experienceEvent = ExperienceEvent(xdm: ["xdmtest": "data"],
-                                              data: ["data": ["test": "data"]])
-        
-        Edge.sendEvent(experienceEvent: experienceEvent)
-        
-        // Wait on all expectations to finish processing before clearing expectations
-        networkService.assertAllNetworkRequestExpectations()
-        assertExpectedEvents(ignoreUnexpectedEvents: true, timeout: 10)
-        
-        // Reset all test expectations
-        networkService.reset()
-        resetTestExpectations()
-    }
 }

--- a/Tests/UpstreamIntegrationTests/UpstreamIntegrationTests.swift
+++ b/Tests/UpstreamIntegrationTests/UpstreamIntegrationTests.swift
@@ -17,7 +17,7 @@ import AEPServices
 import Foundation
 import XCTest
 
-/// This test class validates proper intergration with upstream services, specifically Edge Network
+/// Performs validation on intergration with the Edge Network upstream service
 class UpstreamIntegrationTests: TestBase {
     private var edgeEnvironment: EdgeEnvironment = .prod
     private var edgeLocationHint: EdgeLocationHint?
@@ -89,6 +89,9 @@ class UpstreamIntegrationTests: TestBase {
 
         // MARK: Response Event assertions
         // Only validate for the location hint relevant to Edge Network extension
+        // NOTE: the key value pair "hint": "stringType" is taking advantage of the flexible
+        // JSON comparison system defined in XCTestCase+AnyCodableAsserts where test assertions
+        // between JSON values can be based on their data types instead of exact values.
         let expectedJSON = #"""
         {
           "payload": [

--- a/Tests/UpstreamIntegrationTests/UpstreamIntegrationTests.swift
+++ b/Tests/UpstreamIntegrationTests/UpstreamIntegrationTests.swift
@@ -121,7 +121,25 @@ class UpstreamIntegrationTests: TestBase {
     
     // error scenarios
     // 1. invalid datastream id
-    // 2. invalid location hint set manually
+        // DONE // 2. invalid location hint set manually
+    
+    func testSendEvent_withInvalidDatastreamID_receivesExpectedError() {
+        // Setup
+        let validRequest = NetworkRequest(urlString: "https://obumobile5.data.adobedc.net/ee/v1/interact", httpMethod: .post)!
+        
+        setExpectationNetworkRequest(url: validRequest.url.absoluteString, httpMethod: validRequest.httpMethod, expectedCount: 1)
+        
+        MobileCore.updateConfigurationWith(configDict: ["edge.configId": "12345-example"])
+        // Test
+        let experienceEvent = ExperienceEvent(xdm: ["xdmtest": "data"],
+                                              data: ["data": ["test": "data"]])
+        Edge.sendEvent(experienceEvent: experienceEvent)
+
+        // Verify
+        // MARK: Network response assertions
+        let matchedResponse = getResponsesForRequestWith(url: validRequest.url.absoluteString, httpMethod: validRequest.httpMethod, timeout: 5)
+        XCTAssertEqual(200, matchedResponse.first?.responseCode)
+    }
     
     func testSendEvent_withInvalidLocationHint_receivesExpectedError() {
         // Setup
@@ -137,31 +155,12 @@ class UpstreamIntegrationTests: TestBase {
 
         // Verify
         // MARK: Network response assertions
-        let matchedResponse = getResponsesForRequestWith(spec: invalidRequestSpec, timeout: 5)
-        XCTAssertEqual(404, matchedResponse.first?.responseCode)
-        // NOTE: the actual network response has NO data body (0 bytes)
-        // and the content length header supports that with content size 0
-        // Then validating against the literal strings for title and detail
-        // which Edge automatically uses as a the default when there is no error
-        // text effectively checks this fact?
-        // although in an integration case, only the data body from the response matters in this case
-        // since the way Edge converts no data body is an implementation detail on our side
-        
-        // so the test can be split:
-        // 1. the integration test handles the direct response from konductor, validating the
-        //     a. httpcode - 404
-        //     b. data payload, maybe the header?
-        // 2. the functional test handles the conversion of empty payload error responses into
-        // the expected format; that is, title + detail
-        let expectedErrorJSON = #"""
-        {
-          "title" : "Unexpected Error",
-          "detail" : "",
-          "requestEventId" : "stringType",
-          "requestId" : "stringType"
+        guard let matchedResponse = getResponsesForRequestWith(spec: invalidRequestSpec, timeout: 5).first else {
+            XCTFail("No valid response found for request: \(invalidRequestSpec)")
+            return
         }
-        """#
-        assertEdgeResponseEvent(expectedJSON: expectedErrorJSON, eventSource: TestConstants.EventSource.ERROR_RESPONSE_CONTENT, exactMatchPaths: ["title", "detail"])
+        XCTAssertEqual(404, matchedResponse.responseCode)
+        XCTAssertEqual(0, matchedResponse.data?.count)
     }
 
     // MARK: - Test helper methods

--- a/Tests/UpstreamIntegrationTests/UpstreamIntegrationTests.swift
+++ b/Tests/UpstreamIntegrationTests/UpstreamIntegrationTests.swift
@@ -70,7 +70,7 @@ class UpstreamIntegrationTests: TestBase {
     func testSendEvent_withStandardExperienceEventTwice_receivesExpectedEventHandles() {
         // Setup
         // Test constructs should always be valid
-        let interactNetworkRequest = NetworkRequest(urlString: "https://obumobile5.data.adobedc.net/ee/v1/interact", httpMethod: .post)!
+        let interactNetworkRequest = NetworkRequest(urlString: createURLWith(locationHint: edgeLocationHint), httpMethod: .post)!
         // Setting expectation allows for both:
         // 1. Validation that the network request was sent out
         // 2. Waiting on a response for the specific network request (with timeout)
@@ -105,7 +105,7 @@ class UpstreamIntegrationTests: TestBase {
         }
         """#
        
-        assertEdgeResponseHandle(expectedHandleType: TestConstants.EventSource.LOCATION_HINT_RESULT, expectedHandle: expectedLocationHintJSON, exactMatchPaths: ["payload[*].scope"])
+        assertEdgeResponse(expectedType: TestConstants.EventSource.LOCATION_HINT_RESULT, expectedPayload: expectedLocationHintJSON, exactMatchPaths: ["payload[*].scope"])
         
         let expectedStateStore1stJSON = #"""
         {
@@ -124,21 +124,21 @@ class UpstreamIntegrationTests: TestBase {
         }
         """#
         
-        assertEdgeResponseHandle(expectedHandleType: TestConstants.EventSource.STATE_STORE, expectedHandle: expectedStateStore1stJSON)
+        assertEdgeResponse(expectedType: TestConstants.EventSource.STATE_STORE, expectedPayload: expectedStateStore1stJSON)
         
         // MARK: 2nd send event
         resetTestExpectations()
         Edge.sendEvent(experienceEvent: experienceEvent)
         
         // Assert location hint response is correct
-        assertEdgeResponseHandle(expectedHandleType: TestConstants.EventSource.LOCATION_HINT_RESULT, expectedHandle: expectedLocationHintJSON, exactMatchPaths: ["payload[*].scope"])
-        // TODO: strong validation against org ID portion of key
+        assertEdgeResponse(expectedType: TestConstants.EventSource.LOCATION_HINT_RESULT, expectedPayload: expectedLocationHintJSON, exactMatchPaths: ["payload[*].scope"])
+
         let expectedStateStore2ndJSON = #"""
         {
           "payload": [
             {
               "maxAge": 1,
-              "key": "stringType",
+              "key": "kndctr_972C898555E9F7BC7F000101_AdobeOrg_cluster",
               "value": "stringType"
             }
           ]
@@ -146,14 +146,14 @@ class UpstreamIntegrationTests: TestBase {
         """#
         
         // Assert state store response is correct
-        assertEdgeResponseHandle(expectedHandleType: TestConstants.EventSource.STATE_STORE, expectedHandle: expectedStateStore2ndJSON)
+        assertEdgeResponse(expectedType: TestConstants.EventSource.STATE_STORE, expectedPayload: expectedStateStore2ndJSON, exactMatchPaths: ["payload[*].key"])
     }
 
     // Tests standard sendEvent with both XDM and data, where data is complex - many keys and
     // different value types
     func testSendEvent_withEventXDMAndData_receivesExpectedEventHandles() {
         // Setup
-        let interactNetworkRequest = NetworkRequest(urlString: "https://obumobile5.data.adobedc.net/ee/v1/interact", httpMethod: .post)!
+        let interactNetworkRequest = NetworkRequest(urlString: createURLWith(locationHint: edgeLocationHint), httpMethod: .post)!
         networkService.setExpectationForNetworkRequest(networkRequest: interactNetworkRequest, expectedCount: 1)
 
         let eventPayloadJSON = #"""
@@ -202,7 +202,7 @@ class UpstreamIntegrationTests: TestBase {
         }
         """#
 
-        assertEdgeResponseHandle(expectedHandleType: TestConstants.EventSource.LOCATION_HINT_RESULT, expectedHandle: expectedLocationHintJSON, exactMatchPaths: ["payload[*].scope"])
+        assertEdgeResponse(expectedType: TestConstants.EventSource.LOCATION_HINT_RESULT, expectedPayload: expectedLocationHintJSON, exactMatchPaths: ["payload[*].scope"])
 
         let expectedStateStore1stJSON = #"""
         {
@@ -221,13 +221,13 @@ class UpstreamIntegrationTests: TestBase {
         }
         """#
 
-        assertEdgeResponseHandle(expectedHandleType: TestConstants.EventSource.STATE_STORE, expectedHandle: expectedStateStore1stJSON)
+        assertEdgeResponse(expectedType: TestConstants.EventSource.STATE_STORE, expectedPayload: expectedStateStore1stJSON)
     }
 
     // Tests standard sendEvent with complex XDM - many keys and different value types
     func testSendEvent_withEventXDMOnly_receivesExpectedEventHandles() {
         // Setup
-        let interactNetworkRequest = NetworkRequest(urlString: "https://obumobile5.data.adobedc.net/ee/v1/interact", httpMethod: .post)!
+        let interactNetworkRequest = NetworkRequest(urlString: createURLWith(locationHint: edgeLocationHint), httpMethod: .post)!
         networkService.setExpectationForNetworkRequest(networkRequest: interactNetworkRequest, expectedCount: 1)
 
         let eventPayloadJSON = #"""
@@ -271,7 +271,7 @@ class UpstreamIntegrationTests: TestBase {
         }
         """#
 
-        assertEdgeResponseHandle(expectedHandleType: TestConstants.EventSource.LOCATION_HINT_RESULT, expectedHandle: expectedLocationHintJSON, exactMatchPaths: ["payload[*].scope"])
+        assertEdgeResponse(expectedType: TestConstants.EventSource.LOCATION_HINT_RESULT, expectedPayload: expectedLocationHintJSON, exactMatchPaths: ["payload[*].scope"])
 
         let expectedStateStore1stJSON = #"""
         {
@@ -290,7 +290,7 @@ class UpstreamIntegrationTests: TestBase {
         }
         """#
 
-        assertEdgeResponseHandle(expectedHandleType: TestConstants.EventSource.STATE_STORE, expectedHandle: expectedStateStore1stJSON)
+        assertEdgeResponse(expectedType: TestConstants.EventSource.STATE_STORE, expectedPayload: expectedStateStore1stJSON)
     }
 
     // MARK: - Configuration tests
@@ -298,7 +298,7 @@ class UpstreamIntegrationTests: TestBase {
     func testSendEvent_withSetLocationHint_receivesExpectedEventHandles() {
         // Setup
         let locationHint = "va6"
-        let locationHintNetworkRequest = NetworkRequest(urlString: "https://obumobile5.data.adobedc.net/ee/\(locationHint)/v1/interact", httpMethod: .post)!
+        let locationHintNetworkRequest = NetworkRequest(urlString: createURLWith(locationHint: locationHint), httpMethod: .post)!
         networkService.setExpectationForNetworkRequest(networkRequest: locationHintNetworkRequest, expectedCount: 1)
 
         Edge.setLocationHint(locationHint)
@@ -341,7 +341,7 @@ class UpstreamIntegrationTests: TestBase {
         }
         """#
 
-        assertEdgeResponseHandle(expectedHandleType: TestConstants.EventSource.LOCATION_HINT_RESULT, expectedHandle: expectedLocationHintJSON, exactMatchPaths: ["payload[*].scope", "payload[*].hint"])
+        assertEdgeResponse(expectedType: TestConstants.EventSource.LOCATION_HINT_RESULT, expectedPayload: expectedLocationHintJSON, exactMatchPaths: ["payload[*].scope", "payload[*].hint"])
 
         let expectedStateStore1stJSON = #"""
         {
@@ -360,7 +360,7 @@ class UpstreamIntegrationTests: TestBase {
         }
         """#
 
-        assertEdgeResponseHandle(expectedHandleType: TestConstants.EventSource.STATE_STORE, expectedHandle: expectedStateStore1stJSON)
+        assertEdgeResponse(expectedType: TestConstants.EventSource.STATE_STORE, expectedPayload: expectedStateStore1stJSON)
     }
 
     // MARK: - Error scenarios
@@ -368,7 +368,7 @@ class UpstreamIntegrationTests: TestBase {
     // Tests that an invalid datastream ID returns the expected error
     func testSendEvent_withInvalidDatastreamID_receivesExpectedError() {
         // Setup
-        let interactNetworkRequest = NetworkRequest(urlString: "https://obumobile5.data.adobedc.net/ee/v1/interact", httpMethod: .post)!
+        let interactNetworkRequest = NetworkRequest(urlString: createURLWith(locationHint: edgeLocationHint), httpMethod: .post)!
 
         networkService.setExpectationForNetworkRequest(networkRequest: interactNetworkRequest, expectedCount: 1)
 
@@ -404,7 +404,7 @@ class UpstreamIntegrationTests: TestBase {
     // Tests that an invalid location hint returns the expected error with 0 byte data body
     func testSendEvent_withInvalidLocationHint_receivesExpectedError() {
         // Setup
-        let invalidNetworkRequest = NetworkRequest(urlString: "https://obumobile5.data.adobedc.net/ee/invalid/v1/interact", httpMethod: .post)!
+        let invalidNetworkRequest = NetworkRequest(urlString: createURLWith(locationHint: "invalid"), httpMethod: .post)!
         networkService.setExpectationForNetworkRequest(networkRequest: invalidNetworkRequest, expectedCount: 1)
 
         Edge.setLocationHint("invalid")
@@ -437,13 +437,32 @@ class UpstreamIntegrationTests: TestBase {
         }
     }
     
-    private func assertEdgeResponseHandle(expectedHandleType: String, expectedHandle: String, exactMatchPaths: [String] = [], file: StaticString = #file, line: UInt = #line) {
-        guard let expected = getAnyCodable(expectedHandle) else {
+    /// Creates a valid interact URL using the provided location hint. If location hint is invalid, returns default URL with no location hint.
+    /// - Parameters:
+    ///    - locationHint: The `EdgeLocationHint`'s raw value to use in the URL
+    /// - Returns: The interact URL with location hint applied, default URL if location hint is invalid
+    private func createURLWith(locationHint: EdgeLocationHint?) -> String {
+        guard let locationHint = locationHint else {
+            return "https://obumobile5.data.adobedc.net/ee/v1/interact"
+        }
+        return createURLWith(locationHint: locationHint.rawValue)
+    }
+    
+    /// Creates a valid interact URL using the provided location hint.
+    /// - Parameters:
+    ///    - locationHint: The location hint String to use in the URL
+    /// - Returns: The interact URL with location hint applied
+    private func createURLWith(locationHint: String) -> String {
+        return "https://obumobile5.data.adobedc.net/ee/\(locationHint)/v1/interact"
+    }
+    
+    private func assertEdgeResponse(expectedType: String, expectedPayload: String, exactMatchPaths: [String] = [], file: StaticString = #file, line: UInt = #line) {
+        guard let expected = getAnyCodable(expectedPayload) else {
             XCTFail("Unable to decode JSON string. Test case unable to proceed.", file: file, line: line)
             return
         }
         
-        let responseHandleEvents = getDispatchedEventsWith(type: TestConstants.EventType.EDGE, source: expectedHandleType)
+        let responseHandleEvents = getDispatchedEventsWith(type: TestConstants.EventType.EDGE, source: expectedType)
         
         XCTAssertEqual(1, responseHandleEvents.count, file: file, line: line)
         
@@ -456,6 +475,6 @@ class UpstreamIntegrationTests: TestBase {
     }
     
     private func assertEdgeResponseError(expectedErrorDetails: String, exactMatchPaths: [String] = [], file: StaticString = #file, line: UInt = #line) {
-        assertEdgeResponseHandle(expectedHandleType: TestConstants.EventSource.ERROR_RESPONSE_CONTENT, expectedHandle: expectedErrorDetails, file: file, line: line)
+        assertEdgeResponse(expectedType: TestConstants.EventSource.ERROR_RESPONSE_CONTENT, expectedPayload: expectedErrorDetails, file: file, line: line)
     }
 }

--- a/Tests/UpstreamIntegrationTests/UpstreamIntegrationTests.swift
+++ b/Tests/UpstreamIntegrationTests/UpstreamIntegrationTests.swift
@@ -63,21 +63,23 @@ class UpstreamIntegrationTests: TestBase {
         resetTestExpectations()
         networkService.reset()
     }
-
+ 
     // MARK: - Upstream integration test cases
 
     // MARK: 1st launch scenarios
     func testSendEvent_withStandardExperienceEvent_receivesExpectedEventHandles() {
         // Setup
+        // Test constructs should always be valid
         let standardNetworkRequest = NetworkRequest(urlString: "https://obumobile5.data.adobedc.net/ee/v1/interact", httpMethod: .post)!
         // Setting expectation allows for both:
         // 1. Validation that the network request was sent out
         // 2. Waiting on a response for the specific network request (with timeout)
         networkService.setExpectationForNetworkRequest(networkRequest: standardNetworkRequest, expectedCount: 1)
 
-        // Test
+        
         let experienceEvent = ExperienceEvent(xdm: ["xdmtest": "data"],
                                               data: ["data": ["test": "data"]])
+        // Test
         Edge.sendEvent(experienceEvent: experienceEvent)
 
         // Verify
@@ -137,7 +139,6 @@ class UpstreamIntegrationTests: TestBase {
         }
         """#
         
-        // Test constructs should always be valid
         let xdm = getAnyCodableAndPayload(eventPayloadJSON, type: .xdm)!
         let data = getAnyCodableAndPayload(eventPayloadJSON, type: .data)!
         
@@ -209,7 +210,6 @@ class UpstreamIntegrationTests: TestBase {
         }
         """#
         
-        // Test constructs should always be valid
         let xdm = getAnyCodableAndPayload(eventPayloadJSON, type: .xdm)!
         
         let experienceEvent = ExperienceEvent(xdm: xdm.payload)
@@ -279,7 +279,6 @@ class UpstreamIntegrationTests: TestBase {
         }
         """#
         
-        // Test constructs should always be valid
         let xdm = getAnyCodableAndPayload(eventPayloadJSON, type: .xdm)!
         let data = getAnyCodableAndPayload(eventPayloadJSON, type: .data)!
         

--- a/Tests/UpstreamIntegrationTests/UpstreamIntegrationTests.swift
+++ b/Tests/UpstreamIntegrationTests/UpstreamIntegrationTests.swift
@@ -83,9 +83,10 @@ class UpstreamIntegrationTests: TestBase {
 
         // Verify
         // MARK: Network response assertions
-        let receivedResponses = networkService.getResponsesFor(networkRequest: interactNetworkRequest, timeout: 5)
-        XCTAssertEqual(1, receivedResponses.count)
-        XCTAssertEqual(200, receivedResponses.first?.responseCode)
+        let matchingResponses = networkService.getResponsesFor(networkRequest: interactNetworkRequest, timeout: 5)
+        
+        XCTAssertEqual(1, matchingResponses.count)
+        XCTAssertEqual(200, matchingResponses.first?.responseCode)
 
         // MARK: Response Event assertions
         // Only validate for the location hint relevant to Edge Network extension
@@ -184,9 +185,10 @@ class UpstreamIntegrationTests: TestBase {
 
         // Verify
         // MARK: Network response assertions
-        let matchedResponse = networkService.getResponsesFor(networkRequest: interactNetworkRequest, timeout: 5)
+        let matchingResponses = networkService.getResponsesFor(networkRequest: interactNetworkRequest, timeout: 5)
 
-        XCTAssertEqual(200, matchedResponse.first?.responseCode)
+        XCTAssertEqual(1, matchingResponses.count)
+        XCTAssertEqual(200, matchingResponses.first?.responseCode)
 
         // MARK: Response Event assertions
         // Only validate for the location hint relevant to Edge Network extension
@@ -254,8 +256,10 @@ class UpstreamIntegrationTests: TestBase {
 
         // Verify
         // MARK: Network response assertions
-        let matchedResponse = networkService.getResponsesFor(networkRequest: interactNetworkRequest, timeout: 5)
-        XCTAssertEqual(200, matchedResponse.first?.responseCode)
+        let matchingResponses = networkService.getResponsesFor(networkRequest: interactNetworkRequest, timeout: 5)
+        
+        XCTAssertEqual(1, matchingResponses.count)
+        XCTAssertEqual(200, matchingResponses.first?.responseCode)
 
         // MARK: Response Event assertions
         // Only validate for the location hint relevant to Edge Network extension
@@ -324,8 +328,10 @@ class UpstreamIntegrationTests: TestBase {
 
         // Verify
         // MARK: Network response assertions
-        let matchedResponse = networkService.getResponsesFor(networkRequest: locationHintNetworkRequest, timeout: 5)
-        XCTAssertEqual(200, matchedResponse.first?.responseCode)
+        let matchingResponses = networkService.getResponsesFor(networkRequest: locationHintNetworkRequest, timeout: 5)
+        
+        XCTAssertEqual(1, matchingResponses.count)
+        XCTAssertEqual(200, matchingResponses.first?.responseCode)
 
         // MARK: Response Event assertions
         // Only validate for the location hint relevant to Edge Network extension
@@ -380,8 +386,10 @@ class UpstreamIntegrationTests: TestBase {
 
         // Verify
         // MARK: Network response assertions
-        let matchedResponse = networkService.getResponsesFor(networkRequest: interactNetworkRequest, timeout: 5)
-        XCTAssertEqual(400, matchedResponse.first?.responseCode)
+        let matchingResponses = networkService.getResponsesFor(networkRequest: interactNetworkRequest, timeout: 5)
+        
+        XCTAssertEqual(1, matchingResponses.count)
+        XCTAssertEqual(400, matchingResponses.first?.responseCode)
 
         // MARK: Event assertions
         let expectedErrorJSON = #"""
@@ -416,12 +424,11 @@ class UpstreamIntegrationTests: TestBase {
 
         // Verify
         // MARK: Network response assertions
-        guard let matchedResponse = networkService.getResponsesFor(networkRequest: invalidNetworkRequest, timeout: 5).first else {
-            XCTFail("No valid response found for request: \(invalidNetworkRequest)")
-            return
-        }
-        XCTAssertEqual(404, matchedResponse.responseCode)
-        XCTAssertEqual(0, matchedResponse.data?.count)
+        let matchingResponses = networkService.getResponsesFor(networkRequest: invalidNetworkRequest, timeout: 5)
+        
+        XCTAssertEqual(1, matchingResponses.count)
+        XCTAssertEqual(404, matchingResponses.first?.responseCode)
+        XCTAssertEqual(0, matchingResponses.first?.data?.count)
     }
 
     // MARK: - Test helper methods

--- a/Tests/UpstreamIntegrationTests/UpstreamIntegrationTests.swift
+++ b/Tests/UpstreamIntegrationTests/UpstreamIntegrationTests.swift
@@ -106,33 +106,33 @@ class UpstreamIntegrationTests: TestBase {
         }
         """#
        
-        assertEdgeResponse(expectedType: TestConstants.EventSource.LOCATION_HINT_RESULT, expectedPayload: expectedLocationHintJSON, exactMatchPaths: ["payload[*].scope"])
+        assertEdgeResponseHandle(expectedHandleType: TestConstants.EventSource.LOCATION_HINT_RESULT, expectedHandle: expectedLocationHintJSON, exactMatchPaths: ["payload[*].scope"])
         
         let expectedStateStore1stJSON = #"""
         {
           "payload": [
             {
               "maxAge": 1,
-              "key": "stringType",
+              "key": "kndctr_972C898555E9F7BC7F000101_AdobeOrg_cluster",
               "value": "stringType"
             },
             {
               "maxAge": 1,
-              "key": "stringType",
+              "key": "kndctr_972C898555E9F7BC7F000101_AdobeOrg_identity",
               "value": "stringType"
             }
           ]
         }
         """#
         
-        assertEdgeResponse(expectedType: TestConstants.EventSource.STATE_STORE, expectedPayload: expectedStateStore1stJSON)
+        assertEdgeResponseHandle(expectedHandleType: TestConstants.EventSource.STATE_STORE, expectedHandle: expectedStateStore1stJSON, exactMatchPaths: ["payload[0].key", "payload[1].key"])
         
         // MARK: 2nd send event
         resetTestExpectations()
         Edge.sendEvent(experienceEvent: experienceEvent)
         
         // Assert location hint response is correct
-        assertEdgeResponse(expectedType: TestConstants.EventSource.LOCATION_HINT_RESULT, expectedPayload: expectedLocationHintJSON, exactMatchPaths: ["payload[*].scope"])
+        assertEdgeResponseHandle(expectedHandleType: TestConstants.EventSource.LOCATION_HINT_RESULT, expectedHandle: expectedLocationHintJSON, exactMatchPaths: ["payload[*].scope"])
 
         let expectedStateStore2ndJSON = #"""
         {
@@ -147,7 +147,7 @@ class UpstreamIntegrationTests: TestBase {
         """#
         
         // Assert state store response is correct
-        assertEdgeResponse(expectedType: TestConstants.EventSource.STATE_STORE, expectedPayload: expectedStateStore2ndJSON, exactMatchPaths: ["payload[*].key"])
+        assertEdgeResponseHandle(expectedHandleType: TestConstants.EventSource.STATE_STORE, expectedHandle: expectedStateStore2ndJSON, exactMatchPaths: ["payload[0].key"])
     }
 
     // Tests standard sendEvent with both XDM and data, where data is complex - many keys and
@@ -204,26 +204,26 @@ class UpstreamIntegrationTests: TestBase {
         }
         """#
 
-        assertEdgeResponse(expectedType: TestConstants.EventSource.LOCATION_HINT_RESULT, expectedPayload: expectedLocationHintJSON, exactMatchPaths: ["payload[*].scope"])
+        assertEdgeResponseHandle(expectedHandleType: TestConstants.EventSource.LOCATION_HINT_RESULT, expectedHandle: expectedLocationHintJSON, exactMatchPaths: ["payload[*].scope"])
 
         let expectedStateStore1stJSON = #"""
         {
           "payload": [
             {
               "maxAge": 1,
-              "key": "stringType",
+              "key": "kndctr_972C898555E9F7BC7F000101_AdobeOrg_cluster",
               "value": "stringType"
             },
             {
               "maxAge": 1,
-              "key": "stringType",
+              "key": "kndctr_972C898555E9F7BC7F000101_AdobeOrg_identity",
               "value": "stringType"
             }
           ]
         }
         """#
 
-        assertEdgeResponse(expectedType: TestConstants.EventSource.STATE_STORE, expectedPayload: expectedStateStore1stJSON)
+        assertEdgeResponseHandle(expectedHandleType: TestConstants.EventSource.STATE_STORE, expectedHandle: expectedStateStore1stJSON, exactMatchPaths: ["payload[0].key", "payload[1].key"])
     }
 
     // Tests standard sendEvent with complex XDM - many keys and different value types
@@ -275,26 +275,26 @@ class UpstreamIntegrationTests: TestBase {
         }
         """#
 
-        assertEdgeResponse(expectedType: TestConstants.EventSource.LOCATION_HINT_RESULT, expectedPayload: expectedLocationHintJSON, exactMatchPaths: ["payload[*].scope"])
+        assertEdgeResponseHandle(expectedHandleType: TestConstants.EventSource.LOCATION_HINT_RESULT, expectedHandle: expectedLocationHintJSON, exactMatchPaths: ["payload[*].scope"])
 
         let expectedStateStore1stJSON = #"""
         {
           "payload": [
             {
               "maxAge": 1,
-              "key": "stringType",
+              "key": "kndctr_972C898555E9F7BC7F000101_AdobeOrg_cluster",
               "value": "stringType"
             },
             {
               "maxAge": 1,
-              "key": "stringType",
+              "key": "kndctr_972C898555E9F7BC7F000101_AdobeOrg_identity",
               "value": "stringType"
             }
           ]
         }
         """#
 
-        assertEdgeResponse(expectedType: TestConstants.EventSource.STATE_STORE, expectedPayload: expectedStateStore1stJSON)
+        assertEdgeResponseHandle(expectedHandleType: TestConstants.EventSource.STATE_STORE, expectedHandle: expectedStateStore1stJSON, exactMatchPaths: ["payload[0].key", "payload[1].key"])
     }
 
     // MARK: - Configuration tests
@@ -347,26 +347,26 @@ class UpstreamIntegrationTests: TestBase {
         }
         """#
 
-        assertEdgeResponse(expectedType: TestConstants.EventSource.LOCATION_HINT_RESULT, expectedPayload: expectedLocationHintJSON, exactMatchPaths: ["payload[*].scope", "payload[*].hint"])
+        assertEdgeResponseHandle(expectedHandleType: TestConstants.EventSource.LOCATION_HINT_RESULT, expectedHandle: expectedLocationHintJSON, exactMatchPaths: ["payload[*].scope", "payload[*].hint"])
 
         let expectedStateStore1stJSON = #"""
         {
           "payload": [
             {
               "maxAge": 1,
-              "key": "stringType",
+              "key": "kndctr_972C898555E9F7BC7F000101_AdobeOrg_cluster",
               "value": "stringType"
             },
             {
               "maxAge": 1,
-              "key": "stringType",
+              "key": "kndctr_972C898555E9F7BC7F000101_AdobeOrg_identity",
               "value": "stringType"
             }
           ]
         }
         """#
 
-        assertEdgeResponse(expectedType: TestConstants.EventSource.STATE_STORE, expectedPayload: expectedStateStore1stJSON)
+        assertEdgeResponseHandle(expectedHandleType: TestConstants.EventSource.STATE_STORE, expectedHandle: expectedStateStore1stJSON, exactMatchPaths: ["payload[0].key", "payload[1].key"])
     }
 
     // MARK: - Error scenarios
@@ -401,12 +401,12 @@ class UpstreamIntegrationTests: TestBase {
             },
             "requestEventId": "stringType",
             "title": "Invalid datastream ID",
-            "type": "stringType",
+            "type": "https://ns.adobe.com/aep/errors/EXEG-0003-400",
             "requestId": "stringType"
           }
         """#
 
-        assertEdgeResponseError(expectedErrorDetails: expectedErrorJSON, exactMatchPaths: ["status", "title"])
+        assertEdgeResponseError(expectedErrorDetails: expectedErrorJSON, exactMatchPaths: ["status", "title", "type"])
     }
 
     // Tests that an invalid location hint returns the expected error with 0 byte data body
@@ -463,25 +463,33 @@ class UpstreamIntegrationTests: TestBase {
         return "https://obumobile5.data.adobedc.net/ee/\(locationHint)/v1/interact"
     }
     
-    private func assertEdgeResponse(expectedType: String, expectedPayload: String, exactMatchPaths: [String] = [], file: StaticString = #file, line: UInt = #line) {
-        guard let expected = getAnyCodable(expectedPayload) else {
+    private func assertEdgeResponseHandle(expectedHandleType: String, expectedHandle: String, expectedCount: Int = 1, exactMatchPaths: [String] = [], file: StaticString = #file, line: UInt = #line) {
+        guard let expected = getAnyCodable(expectedHandle) else {
             XCTFail("Unable to decode JSON string. Test case unable to proceed.", file: file, line: line)
             return
         }
         
-        let responseHandleEvents = getDispatchedEventsWith(type: TestConstants.EventType.EDGE, source: expectedType)
+        let responseHandleEvents = getDispatchedEventsWith(type: TestConstants.EventType.EDGE, source: expectedHandleType)
         
-        XCTAssertEqual(1, responseHandleEvents.count, file: file, line: line)
+        XCTAssertEqual(expectedCount, responseHandleEvents.count, file: file, line: line)
         
-        guard let responseHandleEvent = responseHandleEvents.first else {
-            XCTFail("No valid response handle event found", file: file, line: line)
+        for event in responseHandleEvents {
+            assertTypeMatch(expected: expected, actual: getAnyCodableFromEventPayload(event: event), exactMatchPaths: exactMatchPaths, file: file, line: line)
+        }
+    }
+    
+    private func assertEdgeResponseError(expectedErrorDetails: String, expectedCount: Int = 1, exactMatchPaths: [String] = [], file: StaticString = #file, line: UInt = #line) {
+        guard let expected = getAnyCodable(expectedErrorDetails) else {
+            XCTFail("Unable to decode JSON string. Test case unable to proceed.", file: file, line: line)
             return
         }
         
-        assertTypeMatch(expected: expected, actual: getAnyCodableFromEventPayload(event: responseHandleEvent), exactMatchPaths: exactMatchPaths, file: file, line: line)
-    }
-    
-    private func assertEdgeResponseError(expectedErrorDetails: String, exactMatchPaths: [String] = [], file: StaticString = #file, line: UInt = #line) {
-        assertEdgeResponse(expectedType: TestConstants.EventSource.ERROR_RESPONSE_CONTENT, expectedPayload: expectedErrorDetails, file: file, line: line)
+        let responseHandleEvents = getDispatchedEventsWith(type: TestConstants.EventType.EDGE, source: TestConstants.EventSource.ERROR_RESPONSE_CONTENT)
+        
+        XCTAssertEqual(expectedCount, responseHandleEvents.count, file: file, line: line)
+        
+        for event in responseHandleEvents {
+            assertTypeMatch(expected: expected, actual: getAnyCodableFromEventPayload(event: event), exactMatchPaths: exactMatchPaths, file: file, line: line)
+        }
     }
 }

--- a/Tests/UpstreamIntegrationTests/UpstreamIntegrationTests.swift
+++ b/Tests/UpstreamIntegrationTests/UpstreamIntegrationTests.swift
@@ -228,8 +228,6 @@ class UpstreamIntegrationTests: TestBase {
         // See testSendEvent_receivesExpectedEventHandles for existence validation
         let locationHintResult = getEdgeEventHandles(expectedHandleType: TestConstants.EventSource.LOCATION_HINT_RESULT).first!
         
-        // Even though assertTypeMatch can accept a nil AnyCodable, expected uses ! because expectation is
-        // a test construct that should not be nil, and will be able to catch a nil actual
         assertTypeMatch(expected: getAnyCodable(expectedLocationHintJSON)!,
                         actual: getAnyCodable(locationHintResult),
                         exactMatchPaths: ["payload[*].scope"])
@@ -404,28 +402,30 @@ class UpstreamIntegrationTests: TestBase {
     }
     
     func testSendEventx2_receivesExpectedEventHandles() {
+        // Setup
         expectEdgeEventHandle(expectedHandleType: TestConstants.EventSource.LOCATION_HINT_RESULT, expectedCount: 2)
         expectEdgeEventHandle(expectedHandleType: TestConstants.EventSource.STATE_STORE, expectedCount: 2)
 
         let experienceEvent = ExperienceEvent(xdm: ["xdmtest": "data"],
                                               data: ["data": ["test": "data"]])
         
+        // Test
         Edge.sendEvent(experienceEvent: experienceEvent)
         Edge.sendEvent(experienceEvent: experienceEvent)
         
+        // Verify
         assertExpectedEvents(ignoreUnexpectedEvents: true, timeout: 10)
     }
     
     func testSendEventx2_doesNotReceivesErrorEvent() {
         // Setup
-        sendEventAndResetExpectations()
-        
-        expectEdgeEventHandle(expectedHandleType: TestConstants.EventSource.LOCATION_HINT_RESULT, expectedCount: 1)
-        expectEdgeEventHandle(expectedHandleType: TestConstants.EventSource.STATE_STORE, expectedCount: 1)
+        expectEdgeEventHandle(expectedHandleType: TestConstants.EventSource.LOCATION_HINT_RESULT, expectedCount: 2)
+        expectEdgeEventHandle(expectedHandleType: TestConstants.EventSource.STATE_STORE, expectedCount: 2)
         
         let experienceEvent = ExperienceEvent(xdm: ["xdmtest": "data"], data: ["data": ["test": "data"]])
 
         // Test
+        Edge.sendEvent(experienceEvent: experienceEvent)
         Edge.sendEvent(experienceEvent: experienceEvent)
         
         // Verify

--- a/Tests/UpstreamIntegrationTests/UpstreamIntegrationTests.swift
+++ b/Tests/UpstreamIntegrationTests/UpstreamIntegrationTests.swift
@@ -21,7 +21,7 @@ import XCTest
 class UpstreamIntegrationTests: TestBase {
     private var edgeEnvironment: EdgeEnvironment = .prod
     private var edgeLocationHint: EdgeLocationHint?
-    
+
     private var networkService: RealNetworkService = RealNetworkService()
 
     let LOG_SOURCE = "UpstreamIntegrationTests"
@@ -31,9 +31,9 @@ class UpstreamIntegrationTests: TestBase {
     // Run before each test case
     override func setUp() {
         ServiceProvider.shared.networkService = networkService
-        
+
         super.setUp()
-        
+
         continueAfterFailure = true
         TestBase.debugEnabled = true
         // Extract Edge Network environment level from shell environment; see init for default value
@@ -63,7 +63,7 @@ class UpstreamIntegrationTests: TestBase {
         resetTestExpectations()
         networkService.reset()
     }
- 
+
     // MARK: - Upstream integration test cases
 
     // MARK: 1st launch scenarios
@@ -76,7 +76,6 @@ class UpstreamIntegrationTests: TestBase {
         // 2. Waiting on a response for the specific network request (with timeout)
         networkService.setExpectationForNetworkRequest(networkRequest: standardNetworkRequest, expectedCount: 1)
 
-        
         let experienceEvent = ExperienceEvent(xdm: ["xdmtest": "data"],
                                               data: ["data": ["test": "data"]])
         // Test
@@ -116,14 +115,14 @@ class UpstreamIntegrationTests: TestBase {
         assertTypeMatch(expected: expected, actual: getAnyCodableFromEventPayload(event: locationHintEvent), exactMatchPaths: ["payload[*].scope"])
         print(resultEvents)
     }
-    
+
     // Tests standard sendEvent with both XDM and data, where data is complex - many keys and
     // different value types
     func testSendEvent_withEventXDMAndData_receivesExpectedEventHandles() {
         // Setup
         let standardNetworkRequest = NetworkRequest(urlString: "https://obumobile5.data.adobedc.net/ee/v1/interact", httpMethod: .post)!
         networkService.setExpectationForNetworkRequest(networkRequest: standardNetworkRequest, expectedCount: 1)
-        
+
         let eventPayloadJSON = #"""
         {
           "xdm": {
@@ -141,21 +140,21 @@ class UpstreamIntegrationTests: TestBase {
           }
         }
         """#
-        
+
         let xdm = getAnyCodableAndPayload(eventPayloadJSON, type: .xdm)!
         let data = getAnyCodableAndPayload(eventPayloadJSON, type: .data)!
-        
+
         let experienceEvent = ExperienceEvent(xdm: xdm.payload, data: data.payload)
-        
+
         // Test
         Edge.sendEvent(experienceEvent: experienceEvent)
 
         // Verify
         // MARK: Network response assertions
         let matchedResponse = networkService.getResponsesFor(networkRequest: standardNetworkRequest, timeout: 5)
-        
+
         XCTAssertEqual(200, matchedResponse.first?.responseCode)
-        
+
         // MARK: Response Event assertions
         // Only validate for the location hint relevant to Edge Network extension
         let expectedLocationHintJSON = #"""
@@ -169,9 +168,9 @@ class UpstreamIntegrationTests: TestBase {
           ]
         }
         """#
-       
+
         assertEdgeResponseEvent(expectedJSON: expectedLocationHintJSON, eventSource: TestConstants.EventSource.LOCATION_HINT_RESULT, exactMatchPaths: ["payload[*].scope"])
-        
+
         let expectedStateStore1stJSON = #"""
         {
           "payload": [
@@ -188,16 +187,16 @@ class UpstreamIntegrationTests: TestBase {
           ]
         }
         """#
-        
+
         assertEdgeResponseEvent(expectedJSON: expectedStateStore1stJSON, eventSource: TestConstants.EventSource.STATE_STORE)
     }
-    
+
     // Tests standard sendEvent with complex XDM - many keys and different value types
     func testSendEvent_withEventXDMOnly_receivesExpectedEventHandles() {
         // Setup
         let standardNetworkRequest = NetworkRequest(urlString: "https://obumobile5.data.adobedc.net/ee/v1/interact", httpMethod: .post)!
         networkService.setExpectationForNetworkRequest(networkRequest: standardNetworkRequest, expectedCount: 1)
-        
+
         let eventPayloadJSON = #"""
         {
           "xdm": {
@@ -212,11 +211,11 @@ class UpstreamIntegrationTests: TestBase {
           }
         }
         """#
-        
+
         let xdm = getAnyCodableAndPayload(eventPayloadJSON, type: .xdm)!
-        
+
         let experienceEvent = ExperienceEvent(xdm: xdm.payload)
-        
+
         // Test
         Edge.sendEvent(experienceEvent: experienceEvent)
 
@@ -224,7 +223,7 @@ class UpstreamIntegrationTests: TestBase {
         // MARK: Network response assertions
         let matchedResponse = networkService.getResponsesFor(networkRequest: standardNetworkRequest, timeout: 5)
         XCTAssertEqual(200, matchedResponse.first?.responseCode)
-        
+
         // MARK: Response Event assertions
         // Only validate for the location hint relevant to Edge Network extension
         let expectedLocationHintJSON = #"""
@@ -238,9 +237,9 @@ class UpstreamIntegrationTests: TestBase {
           ]
         }
         """#
-       
+
         assertEdgeResponseEvent(expectedJSON: expectedLocationHintJSON, eventSource: TestConstants.EventSource.LOCATION_HINT_RESULT, exactMatchPaths: ["payload[*].scope"])
-        
+
         let expectedStateStore1stJSON = #"""
         {
           "payload": [
@@ -257,10 +256,10 @@ class UpstreamIntegrationTests: TestBase {
           ]
         }
         """#
-        
+
         assertEdgeResponseEvent(expectedJSON: expectedStateStore1stJSON, eventSource: TestConstants.EventSource.STATE_STORE)
     }
-    
+
     // MARK: - Configuration tests
     // Tests standard sendEvent with both XDM and data, where data is complex - many keys and
     // different value types
@@ -268,9 +267,9 @@ class UpstreamIntegrationTests: TestBase {
         // Setup
         let locationHintNetworkRequest = NetworkRequest(urlString: "https://obumobile5.data.adobedc.net/ee/va6/v1/interact", httpMethod: .post)!
         networkService.setExpectationForNetworkRequest(networkRequest: locationHintNetworkRequest, expectedCount: 1)
-        
+
         Edge.setLocationHint("va6")
-        
+
         let eventPayloadJSON = #"""
         {
           "xdm": {
@@ -281,12 +280,12 @@ class UpstreamIntegrationTests: TestBase {
           }
         }
         """#
-        
+
         let xdm = getAnyCodableAndPayload(eventPayloadJSON, type: .xdm)!
         let data = getAnyCodableAndPayload(eventPayloadJSON, type: .data)!
-        
+
         let experienceEvent = ExperienceEvent(xdm: xdm.payload, data: data.payload)
-        
+
         // Test
         Edge.sendEvent(experienceEvent: experienceEvent)
 
@@ -294,7 +293,7 @@ class UpstreamIntegrationTests: TestBase {
         // MARK: Network response assertions
         let matchedResponse = networkService.getResponsesFor(networkRequest: locationHintNetworkRequest, timeout: 5)
         XCTAssertEqual(200, matchedResponse.first?.responseCode)
-        
+
         // MARK: Response Event assertions
         // Only validate for the location hint relevant to Edge Network extension
         let expectedLocationHintJSON = #"""
@@ -308,9 +307,9 @@ class UpstreamIntegrationTests: TestBase {
           ]
         }
         """#
-       
+
         assertEdgeResponseEvent(expectedJSON: expectedLocationHintJSON, eventSource: TestConstants.EventSource.LOCATION_HINT_RESULT, exactMatchPaths: ["payload[*].scope", "payload[*].hint"])
-        
+
         let expectedStateStore1stJSON = #"""
         {
           "payload": [
@@ -327,19 +326,19 @@ class UpstreamIntegrationTests: TestBase {
           ]
         }
         """#
-        
+
         assertEdgeResponseEvent(expectedJSON: expectedStateStore1stJSON, eventSource: TestConstants.EventSource.STATE_STORE)
     }
-    
+
     // MARK: - Error scenarios
-    
+
     // Tests that an invalid datastream ID returns the expected error
     func testSendEvent_withInvalidDatastreamID_receivesExpectedError() {
         // Setup
         let standardNetworkRequest = NetworkRequest(urlString: "https://obumobile5.data.adobedc.net/ee/v1/interact", httpMethod: .post)!
-        
+
         networkService.setExpectationForNetworkRequest(networkRequest: standardNetworkRequest, expectedCount: 1)
-        
+
         MobileCore.updateConfigurationWith(configDict: ["edge.configId": "12345-example"])
         // Test
         let experienceEvent = ExperienceEvent(xdm: ["xdmtest": "data"],
@@ -350,7 +349,7 @@ class UpstreamIntegrationTests: TestBase {
         // MARK: Network response assertions
         let matchedResponse = networkService.getResponsesFor(networkRequest: standardNetworkRequest, timeout: 5)
         XCTAssertEqual(400, matchedResponse.first?.responseCode)
-        
+
         // MARK: Event assertions
         let expectedErrorJSON = #"""
         {
@@ -365,19 +364,19 @@ class UpstreamIntegrationTests: TestBase {
             "requestId": "stringType"
           }
         """#
-        
+
         assertEdgeResponseEvent(expectedJSON: expectedErrorJSON, eventSource: TestConstants.EventSource.ERROR_RESPONSE_CONTENT, exactMatchPaths: ["status", "title"])
-        
+
     }
-    
+
     // Tests that an invalid location hint returns the expected error with 0 byte data body
     func testSendEvent_withInvalidLocationHint_receivesExpectedError() {
         // Setup
         let invalidNetworkRequest = NetworkRequest(urlString: "https://obumobile5.data.adobedc.net/ee/invalid/v1/interact", httpMethod: .post)!
         networkService.setExpectationForNetworkRequest(networkRequest: invalidNetworkRequest, expectedCount: 1)
-        
+
         Edge.setLocationHint("invalid")
-        
+
         // Test
         let experienceEvent = ExperienceEvent(xdm: ["xdmtest": "data"],
                                               data: ["data": ["test": "data"]])

--- a/Tests/UpstreamIntegrationTests/util/EdgeLocationHint.swift
+++ b/Tests/UpstreamIntegrationTests/util/EdgeLocationHint.swift
@@ -14,7 +14,7 @@
 import Foundation
 
 /// All location hint values available for the Edge Network extension
-enum EdgeLocationHint: String {
+enum EdgeLocationHint: String, CaseIterable {
     /// Oregon, USA
     case or2
     /// Virginia, USA


### PR DESCRIPTION
## Description

This PR: 
### Implements the integration test cases:
Standard sendEvent
1. multiple times returns the expected event handles
2. complex XDM (multiple keys and data types)
3. complex data (multiple keys and data types)

Standard config changes
1. valid location hint

Expected errors
1. invalid datastream ID
2. invalid location hint value

It takes advantage of the AnyCodable assertion helpers and test methods to easily construct events and assert against event payloads with varying levels of strictness as required per test case.

### Updates network service test APIs 
to use NetworkRequest instances directly, and for new test cases in the integration test class, instantiates a NetworkRequest to reuse throughout the test.
* That is, network service APIs use NetworkRequest instances by default, and the previous url string + httpmethod are converted to convenience methods

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
