### PR TITLE
[CI] Run unit and functional tests separately in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
       - codecov/upload:
           flags: ios-unit-tests
           upload_name: Coverage report for iOS unit tests
-          xtra_args: -c -v --xc --xp iosUnitResults.xcresult
+          xtra_args: -c -v --xc --xp build/reports/iosUnitResults.xcresult
 
       - run:
           name: Run iOS Functional Tests
@@ -123,7 +123,7 @@ jobs:
       - codecov/upload:
           flags: ios-functional-tests
           upload_name: Coverage report for iOS functional tests
-          xtra_args: -c -v --xc --xp iosFunctionalResults.xcresult
+          xtra_args: -c -v --xc --xp build/reports/iosFunctionalResults.xcresult
   
   test-tvos:
     macos:
@@ -145,7 +145,7 @@ jobs:
       - codecov/upload:
           flags: tvos-unit-tests
           upload_name: Coverage report for tvOS unit tests
-          xtra_args: -c -v --xc --xp tvosUnitResults.xcresult
+          xtra_args: -c -v --xc --xp build/reports/tvosUnitResults.xcresult
 
       - run:
           name: Run tvOS Functional Tests
@@ -155,7 +155,7 @@ jobs:
       - codecov/upload:
           flags: tvos-functional-tests
           upload_name: Coverage report for tvOS functional tests
-          xtra_args: -c -v --xc --xp tvosFunctionalResults.xcresult
+          xtra_args: -c -v --xc --xp build/reports/tvosFunctionalResults.xcresult
       
   build_xcframework_and_app:  
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,17 +105,22 @@ jobs:
       - prestart_ios_simulator
 
       - run:
-          name: Run iOS Tests
-          command: make test-ios
+          name: Run iOS Unit Tests
+          command: make unit-test-ios
 
       # Code coverage upload using Codecov
       # See options explanation here: https://docs.codecov.com/docs/codecov-uploader
       - codecov/upload:
-          flags: ios-tests
+          flags: ios-unit-tests
           upload_name: Coverage report for iOS unit tests
           xtra_args: -c -v --xc --xp iosUnitResults.xcresult
+
+      - run:
+          name: Run iOS Functional Tests
+          command: make functional-test-ios
+
       - codecov/upload:
-          flags: ios-tests
+          flags: ios-functional-tests
           upload_name: Coverage report for iOS functional tests
           xtra_args: -c -v --xc --xp iosFunctionalResults.xcresult
   
@@ -131,17 +136,22 @@ jobs:
       - prestart_tvos_simulator
       
       - run:
-          name: Run tvOS Tests
-          command: make test-tvos
+          name: Run tvOS Unit Tests
+          command: make unit-test-tvos
 
       # Code coverage upload using Codecov
       # See options explanation here: https://docs.codecov.com/docs/codecov-uploader
       - codecov/upload:
-          flags: tvos-tests
+          flags: tvos-unit-tests
           upload_name: Coverage report for tvOS unit tests
           xtra_args: -c -v --xc --xp tvosUnitResults.xcresult
+
+      - run:
+          name: Run tvOS Functional Tests
+          command: make functional-test-tvos
+
       - codecov/upload:
-          flags: tvos-tests
+          flags: tvos-functional-tests
           upload_name: Coverage report for tvOS functional tests
           xtra_args: -c -v --xc --xp tvosFunctionalResults.xcresult
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,12 +112,12 @@ jobs:
       # See options explanation here: https://docs.codecov.com/docs/codecov-uploader
       - codecov/upload:
           flags: ios-tests
-          upload_name: Coverage report for iOS functional tests
-          xtra_args: -c -v --xc --xp iosFunctionalResults.xcresult
-      - codecov/upload:
-          flags: ios-tests
           upload_name: Coverage report for iOS unit tests
           xtra_args: -c -v --xc --xp iosUnitResults.xcresult
+      - codecov/upload:
+          flags: ios-tests
+          upload_name: Coverage report for iOS functional tests
+          xtra_args: -c -v --xc --xp iosFunctionalResults.xcresult
   
   test-tvos:
     macos:
@@ -138,13 +138,13 @@ jobs:
       # See options explanation here: https://docs.codecov.com/docs/codecov-uploader
       - codecov/upload:
           flags: tvos-tests
-          upload_name: Coverage report for tvOS functional tests
-          xtra_args: -c -v --xc --xp tvosFunctionalResults.xcresult
-      - codecov/upload:
-          flags: tvos-tests
           upload_name: Coverage report for tvOS unit tests
           xtra_args: -c -v --xc --xp tvosUnitResults.xcresult
-
+      - codecov/upload:
+          flags: tvos-tests
+          upload_name: Coverage report for tvOS functional tests
+          xtra_args: -c -v --xc --xp tvosFunctionalResults.xcresult
+      
   build_xcframework_and_app:  
     macos:
       xcode: 14.1.0 # Specify the Xcode version to use

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,7 @@ jobs:
       - run:
           name: Run iOS Functional Tests
           command: make functional-test-ios
+          when: always # run even if unit tests fail
 
       - codecov/upload:
           flags: ios-functional-tests
@@ -149,6 +150,7 @@ jobs:
       - run:
           name: Run tvOS Functional Tests
           command: make functional-test-tvos
+          when: always # run even if unit tests fail
 
       - codecov/upload:
           flags: tvos-functional-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,8 +112,12 @@ jobs:
       # See options explanation here: https://docs.codecov.com/docs/codecov-uploader
       - codecov/upload:
           flags: ios-tests
-          upload_name: Coverage Report for iOS Tests
-          xtra_args: -c -v --xc --xp iosresults.xcresult
+          upload_name: Coverage report for iOS functional tests
+          xtra_args: -c -v --xc --xp iosFunctionalResults.xcresult
+      - codecov/upload:
+          flags: ios-tests
+          upload_name: Coverage report for iOS unit tests
+          xtra_args: -c -v --xc --xp iosUnitResults.xcresult
   
   test-tvos:
     macos:
@@ -134,8 +138,12 @@ jobs:
       # See options explanation here: https://docs.codecov.com/docs/codecov-uploader
       - codecov/upload:
           flags: tvos-tests
-          upload_name: Coverage Report for tvOS Tests
-          xtra_args: -c -v --xc --xp tvosresults.xcresult
+          upload_name: Coverage report for tvOS functional tests
+          xtra_args: -c -v --xc --xp tvosFunctionalResults.xcresult
+      - codecov/upload:
+          flags: tvos-tests
+          upload_name: Coverage report for tvOS unit tests
+          xtra_args: -c -v --xc --xp tvosUnitResults.xcresult
 
   build_xcframework_and_app:  
     macos:

--- a/AEPEdge.xcodeproj/project.pbxproj
+++ b/AEPEdge.xcodeproj/project.pbxproj
@@ -364,8 +364,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D4ABABAE251A7D95008076BF /* AEPEdge.framework in Frameworks */,
 				783A5F4E903F9B6EABA50D23 /* Pods_UnitTests.framework in Frameworks */,
+				D4ABABAE251A7D95008076BF /* AEPEdge.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -373,8 +373,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D4ABABAB251A7D41008076BF /* AEPEdge.framework in Frameworks */,
 				423B5033D43ADB49049383FB /* Pods_FunctionalTests.framework in Frameworks */,
+				D4ABABAB251A7D41008076BF /* AEPEdge.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Makefile
+++ b/Makefile
@@ -93,23 +93,35 @@ build-app: setup
 	@echo "######################################################################"
 	xcodebuild clean build -workspace $(PROJECT_NAME).xcworkspace -scheme $(TEST_APP_TVOS_SCHEME) -destination 'generic/platform=tvOS Simulator'
 
-test: test-ios test-tvos
+test: unit-test-ios functional-test-ios unit-test-tvos functional-test-tvos
 
-test-ios: clean-ios-test-files
+unit-test-ios:
 	@echo "######################################################################"
-	@echo "### Testing iOS"
+	@echo "### Unit Testing iOS"
 	@echo "######################################################################"
-	@echo "List of available shared Schemes in xcworkspace"
-	xcodebuild test -workspace AEPEdge.xcworkspace -scheme "UnitTests" -destination "platform=iOS Simulator,name=iPhone 14" -derivedDataPath build/out -resultBundlePath iosUnitResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES; \
-	xcodebuild test -workspace AEPEdge.xcworkspace -scheme "FunctionalTests" -destination "platform=iOS Simulator,name=iPhone 14" -derivedDataPath build/out -resultBundlePath iosFunctionalResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
+	rm -rf iosUnitResults.xcresult
+	xcodebuild test -workspace $(PROJECT_NAME).xcworkspace -scheme "UnitTests" -destination "platform=iOS Simulator,name=iPhone 14" -derivedDataPath build/out -resultBundlePath iosUnitResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
 
-test-tvos: clean-tvos-test-files
+functional-test-ios:
 	@echo "######################################################################"
-	@echo "### Testing tvOS"
+	@echo "### Functional Testing iOS"
 	@echo "######################################################################"
-	@echo "List of available shared Schemes in xcworkspace"
-	xcodebuild test -workspace AEPEdge.xcworkspace -scheme "UnitTests" -destination 'platform=tvOS Simulator,name=Apple TV' -derivedDataPath build/out -resultBundlePath tvosUnitResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES; \
-	xcodebuild test -workspace AEPEdge.xcworkspace -scheme "FunctionalTests" -destination 'platform=tvOS Simulator,name=Apple TV' -derivedDataPath build/out -resultBundlePath tvosFunctionalResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
+	rm -rf iosFunctionalResults.xcresult
+	xcodebuild test -workspace $(PROJECT_NAME).xcworkspace -scheme "FunctionalTests" -destination "platform=iOS Simulator,name=iPhone 14" -derivedDataPath build/out -resultBundlePath iosFunctionalResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
+
+unit-test-tvos:
+	@echo "######################################################################"
+	@echo "### Unit Testing iOS"
+	@echo "######################################################################"
+	rm -rf tvosUnitResults.xcresult
+	xcodebuild test -workspace $(PROJECT_NAME).xcworkspace -scheme "UnitTests" -destination 'platform=tvOS Simulator,name=Apple TV' -derivedDataPath build/out -resultBundlePath tvosUnitResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
+
+functional-test-tvos:
+	@echo "######################################################################"
+	@echo "### Functional Testing iOS"
+	@echo "######################################################################"
+	rm -rf tvosFunctionalResults.xcresult
+	xcodebuild test -workspace $(PROJECT_NAME).xcworkspace -scheme "FunctionalTests" -destination 'platform=tvOS Simulator,name=Apple TV' -derivedDataPath build/out -resultBundlePath tvosFunctionalResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
 
 install-githook:
 	git config core.hooksPath .githooks

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,12 @@ clean:
 	rm -rf build
 
 clean-ios-test-files:
-	rm -rf iosresults.xcresult
+	rm -rf iosFunctionalResults.xcresult; \
+	rm -rf iosUnitResults.xcresult
 
 clean-tvos-test-files:
-	rm -rf tvosresults.xcresult
+	rm -rf tvosFunctionalResults.xcresult; \
+	rm -rf tvosUnitResults.xcresult
 
 pod-install:
 	pod install --repo-update
@@ -98,34 +100,16 @@ test-ios: clean-ios-test-files
 	@echo "### Testing iOS"
 	@echo "######################################################################"
 	@echo "List of available shared Schemes in xcworkspace"
-	xcodebuild -workspace $(PROJECT_NAME).xcworkspace -list
-	final_scheme=""; \
-	if xcodebuild -workspace $(PROJECT_NAME).xcworkspace -list | grep -q "($(PROJECT_NAME) project)"; \
-	then \
-	   final_scheme="$(EXTENSION_NAME) ($(PROJECT_NAME) project)" ; \
-	   echo $$final_scheme ; \
-	else \
-	   final_scheme="$(EXTENSION_NAME)" ; \
-	   echo $$final_scheme ; \
-	fi; \
-	xcodebuild test -workspace $(PROJECT_NAME).xcworkspace -scheme "$$final_scheme" -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath build/out -resultBundlePath iosresults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
+	xcodebuild test -workspace AEPEdge.xcworkspace -scheme "FunctionalTests" -destination "platform=iOS Simulator,name=iPhone 14" -derivedDataPath build/out -resultBundlePath iosFunctionalResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES; \
+	xcodebuild test -workspace AEPEdge.xcworkspace -scheme "UnitTests" -destination "platform=iOS Simulator,name=iPhone 14" -derivedDataPath build/out -resultBundlePath iosUnitResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
 
 test-tvos: clean-tvos-test-files
 	@echo "######################################################################"
 	@echo "### Testing tvOS"
 	@echo "######################################################################"
 	@echo "List of available shared Schemes in xcworkspace"
-	xcodebuild -workspace $(PROJECT_NAME).xcworkspace -list
-	final_scheme=""; \
-	if xcodebuild -workspace $(PROJECT_NAME).xcworkspace -list | grep -q "($(PROJECT_NAME) project)"; \
-	then \
-		 final_scheme="$(EXTENSION_NAME) ($(PROJECT_NAME) project)" ; \
-		 echo $$final_scheme ; \
-	else \
-		 final_scheme="$(EXTENSION_NAME)" ; \
-		 echo $$final_scheme ; \
-	fi; \
-	xcodebuild test -workspace $(PROJECT_NAME).xcworkspace -scheme "$$final_scheme" -destination 'platform=tvOS Simulator,name=Apple TV' -derivedDataPath build/out -resultBundlePath tvosresults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
+	xcodebuild test -workspace AEPEdge.xcworkspace -scheme "FunctionalTests" -destination 'platform=tvOS Simulator,name=Apple TV' -derivedDataPath build/out -resultBundlePath tvosFunctionalResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES; \
+	xcodebuild test -workspace AEPEdge.xcworkspace -scheme "UnitTests" -destination 'platform=tvOS Simulator,name=Apple TV' -derivedDataPath build/out -resultBundlePath tvosUnitResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
 
 install-githook:
 	git config core.hooksPath .githooks

--- a/Makefile
+++ b/Makefile
@@ -22,14 +22,6 @@ setup:
 clean:
 	rm -rf build
 
-clean-ios-test-files:
-	rm -rf iosUnitResults.xcresult; \
-	rm -rf iosFunctionalResults.xcresult
-
-clean-tvos-test-files:
-	rm -rf tvosUnitResults.xcresult; \
-	rm -rf tvosFunctionalResults.xcresult
-
 pod-install:
 	pod install --repo-update
 
@@ -99,29 +91,29 @@ unit-test-ios:
 	@echo "######################################################################"
 	@echo "### Unit Testing iOS"
 	@echo "######################################################################"
-	rm -rf iosUnitResults.xcresult
-	xcodebuild test -workspace $(PROJECT_NAME).xcworkspace -scheme "UnitTests" -destination "platform=iOS Simulator,name=iPhone 14" -derivedDataPath build/out -resultBundlePath iosUnitResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
+	rm -rf build/reports/iosUnitResults.xcresult
+	xcodebuild test -workspace $(PROJECT_NAME).xcworkspace -scheme "UnitTests" -destination "platform=iOS Simulator,name=iPhone 14" -derivedDataPath build/out -resultBundlePath build/reports/iosUnitResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
 
 functional-test-ios:
 	@echo "######################################################################"
 	@echo "### Functional Testing iOS"
 	@echo "######################################################################"
-	rm -rf iosFunctionalResults.xcresult
-	xcodebuild test -workspace $(PROJECT_NAME).xcworkspace -scheme "FunctionalTests" -destination "platform=iOS Simulator,name=iPhone 14" -derivedDataPath build/out -resultBundlePath iosFunctionalResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
+	rm -rf build/reports/iosFunctionalResults.xcresult
+	xcodebuild test -workspace $(PROJECT_NAME).xcworkspace -scheme "FunctionalTests" -destination "platform=iOS Simulator,name=iPhone 14" -derivedDataPath build/out -resultBundlePath build/reports/iosFunctionalResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
 
 unit-test-tvos:
 	@echo "######################################################################"
-	@echo "### Unit Testing iOS"
+	@echo "### Unit Testing tvOS"
 	@echo "######################################################################"
-	rm -rf tvosUnitResults.xcresult
-	xcodebuild test -workspace $(PROJECT_NAME).xcworkspace -scheme "UnitTests" -destination 'platform=tvOS Simulator,name=Apple TV' -derivedDataPath build/out -resultBundlePath tvosUnitResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
+	rm -rf build/reports/tvosUnitResults.xcresult
+	xcodebuild test -workspace $(PROJECT_NAME).xcworkspace -scheme "UnitTests" -destination 'platform=tvOS Simulator,name=Apple TV' -derivedDataPath build/out -resultBundlePath build/reports/tvosUnitResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
 
 functional-test-tvos:
 	@echo "######################################################################"
-	@echo "### Functional Testing iOS"
+	@echo "### Functional Testing tvOS"
 	@echo "######################################################################"
-	rm -rf tvosFunctionalResults.xcresult
-	xcodebuild test -workspace $(PROJECT_NAME).xcworkspace -scheme "FunctionalTests" -destination 'platform=tvOS Simulator,name=Apple TV' -derivedDataPath build/out -resultBundlePath tvosFunctionalResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
+	rm -rf build/reports/tvosFunctionalResults.xcresult
+	xcodebuild test -workspace $(PROJECT_NAME).xcworkspace -scheme "FunctionalTests" -destination 'platform=tvOS Simulator,name=Apple TV' -derivedDataPath build/out -resultBundlePath build/reports/tvosFunctionalResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
 
 install-githook:
 	git config core.hooksPath .githooks

--- a/Makefile
+++ b/Makefile
@@ -100,16 +100,16 @@ test-ios: clean-ios-test-files
 	@echo "### Testing iOS"
 	@echo "######################################################################"
 	@echo "List of available shared Schemes in xcworkspace"
-	xcodebuild test -workspace AEPEdge.xcworkspace -scheme "FunctionalTests" -destination "platform=iOS Simulator,name=iPhone 14" -derivedDataPath build/out -resultBundlePath iosFunctionalResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES; \
-	xcodebuild test -workspace AEPEdge.xcworkspace -scheme "UnitTests" -destination "platform=iOS Simulator,name=iPhone 14" -derivedDataPath build/out -resultBundlePath iosUnitResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
+	xcodebuild test -workspace AEPEdge.xcworkspace -scheme "UnitTests" -destination "platform=iOS Simulator,name=iPhone 14" -derivedDataPath build/out -resultBundlePath iosUnitResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES; \
+	xcodebuild test -workspace AEPEdge.xcworkspace -scheme "FunctionalTests" -destination "platform=iOS Simulator,name=iPhone 14" -derivedDataPath build/out -resultBundlePath iosFunctionalResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
 
 test-tvos: clean-tvos-test-files
 	@echo "######################################################################"
 	@echo "### Testing tvOS"
 	@echo "######################################################################"
 	@echo "List of available shared Schemes in xcworkspace"
-	xcodebuild test -workspace AEPEdge.xcworkspace -scheme "FunctionalTests" -destination 'platform=tvOS Simulator,name=Apple TV' -derivedDataPath build/out -resultBundlePath tvosFunctionalResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES; \
-	xcodebuild test -workspace AEPEdge.xcworkspace -scheme "UnitTests" -destination 'platform=tvOS Simulator,name=Apple TV' -derivedDataPath build/out -resultBundlePath tvosUnitResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
+	xcodebuild test -workspace AEPEdge.xcworkspace -scheme "UnitTests" -destination 'platform=tvOS Simulator,name=Apple TV' -derivedDataPath build/out -resultBundlePath tvosUnitResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES; \
+	xcodebuild test -workspace AEPEdge.xcworkspace -scheme "FunctionalTests" -destination 'platform=tvOS Simulator,name=Apple TV' -derivedDataPath build/out -resultBundlePath tvosFunctionalResults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
 
 install-githook:
 	git config core.hooksPath .githooks

--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,12 @@ clean:
 	rm -rf build
 
 clean-ios-test-files:
-	rm -rf iosFunctionalResults.xcresult; \
-	rm -rf iosUnitResults.xcresult
+	rm -rf iosUnitResults.xcresult; \
+	rm -rf iosFunctionalResults.xcresult
 
 clean-tvos-test-files:
-	rm -rf tvosFunctionalResults.xcresult; \
-	rm -rf tvosUnitResults.xcresult
+	rm -rf tvosUnitResults.xcresult; \
+	rm -rf tvosFunctionalResults.xcresult
 
 pod-install:
 	pod install --repo-update


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR:
1. Splits unit and functional test steps in the makefile to prevent the occasional interleaving of unit test build process with functional test case execution
    * This should address most of the test errors covered in #365 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

For future reference, the old method required extracting the true scheme, with output like (note the duplicate AEPEdge scheme differentiated with parentheses):
```
List of available shared Schemes in xcworkspace
xcodebuild -workspace AEPEdge.xcworkspace -list
Command line invocation:
    /Applications/Xcode-14.1.app/Contents/Developer/usr/bin/xcodebuild -workspace AEPEdge.xcworkspace -list

User defaults from command line:
    IDEPackageSupportUseBuiltinSCM = YES

Information about workspace "AEPEdge":
    Schemes:
        AEPAssurance
        AEPCore
        AEPEdge (AEPEdge project)
        AEPEdge (Pods project)
        AEPEdgeConsent
        AEPEdgeIdentity
        AEPEdgeXCF
        AEPRulesEngine
        AEPServices
        FunctionalTests
        Pods-AEPEdge
        Pods-FunctionalTests
        Pods-TestAppiOS
        Pods-TestApptvOS
        Pods-UnitTests
        Pods-UpstreamIntegrationTests
        SwiftLint
        TestAppiOS
        TestApptvOS
        UnitTests
        UpstreamIntegrationTests

final_scheme=""; \
	if xcodebuild -workspace AEPEdge.xcworkspace -list | grep -q "(AEPEdge project)"; \
	then \
	   final_scheme="AEPEdge (AEPEdge project)" ; \
	   echo $final_scheme ; \
	else \
	   final_scheme="AEPEdge" ; \
	   echo $final_scheme ; \
	fi; \
	xcodebuild test -workspace AEPEdge.xcworkspace -scheme "$final_scheme" -destination 'platform=iOS Simulator,name=iPhone 14' -derivedDataPath build/out -resultBundlePath iosresults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
AEPEdge (AEPEdge project)
Command line invocation:
    /Applications/Xcode-14.1.app/Contents/Developer/usr/bin/xcodebuild test -workspace AEPEdge.xcworkspace -scheme "AEPEdge (AEPEdge project)" -destination "platform=iOS Simulator,name=iPhone 14" -derivedDataPath build/out -resultBundlePath iosresults.xcresult -enableCodeCoverage YES ADB_SKIP_LINT=YES
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
