### PR TITLE
[Test] Wait for sendEvent to return before continuing functional test.

### DIFF
--- a/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
+++ b/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
@@ -1120,8 +1120,13 @@ class AEPEdgeFunctionalTests: FunctionalTestBase {
 
         // Send two requests
         let experienceEvent = ExperienceEvent(xdm: ["testString": "xdm"])
-        Edge.sendEvent(experienceEvent: experienceEvent)
-        sleep(2)
+        let expectation = XCTestExpectation(description: "Send Event completion closure")
+        Edge.sendEvent(experienceEvent: experienceEvent) {_ in
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2)
+
+        usleep(1500000) // sleep test thread to expire received location hint
         Edge.sendEvent(experienceEvent: experienceEvent)
 
         // verify


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix failures from AEPEdgeFunctionalTests.testSendEvent_edgeNetworkResponseContainsLocationHint_sendEventDoesNotIncludeExpiredLocationHint()

This test sends two Edge.sendEvent() calls with a sleep between the two calls. The first sendEvent() will receive a location hint value with a 1 second timeout and the second sendEvent() is expected to not include the location hint as it expired. The test is failing because the second Edge.sendEvent() call contains the location hint when it is expected not to.

Looking at the logs it appears the execution of the first sendEvent() may take a second or so to complete, however the test thread is paused immediately after the api call. It appears the test thread is waking before the location hint expires because the sendEvent() call is taking longer than expected.

Fix by adding a completion callback closure to the first sendEvent() call so the test thread sleep does not start until after the first sendEvent() call completes.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
