### PR TITLE
Use 'large' resource class when running tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,7 @@ jobs:
   test-ios:
     macos:
       xcode: 14.1.0 # Specify the Xcode version to use
+    resource_class: macos.m1.large.gen1 # Use large resource for iOS tests
 
     steps:
       - checkout
@@ -128,6 +129,7 @@ jobs:
   test-tvos:
     macos:
       xcode: 14.1.0 # Specify the Xcode version to use
+    resource_class: macos.m1.large.gen1 # Use large resource for tvOS tests
 
     steps:
       - checkout


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Bump Mac OS resource class in CI to macos.m1.large.gen1 when running tests. The tests runs in CI using the "medium" resource class use a lot of CPU. Additionally, we are noticing a lot of test failures which appear to be timing issue. Using a larger resource class may stabilize the test runs by allowing the tests to run more quickly.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
