### PR TITLE
Update the validation expected results for recordSeparator in functional tests

### DIFF
--- a/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
+++ b/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
@@ -280,7 +280,7 @@ class AEPEdgeFunctionalTests: TestBase {
         let requestBody = resultNetworkRequests[0].getFlattenedBody()
         XCTAssertEqual(19, requestBody.count)
         XCTAssertEqual(true, requestBody["meta.konductorConfig.streaming.enabled"] as? Bool)
-        if #available(iOS 17, *) {
+        if #available(iOS 17, tvOS 17, *) {
           XCTAssertEqual("", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
         } else {
           XCTAssertEqual("\u{0000}", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
@@ -333,7 +333,7 @@ class AEPEdgeFunctionalTests: TestBase {
         let requestBody = resultNetworkRequests[0].getFlattenedBody()
         XCTAssertEqual(20, requestBody.count)
         XCTAssertEqual(true, requestBody["meta.konductorConfig.streaming.enabled"] as? Bool)
-        if #available(iOS 17, *) {
+        if #available(iOS 17, tvOS 17, *) {
           XCTAssertEqual("", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
         } else {
           XCTAssertEqual("\u{0000}", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
@@ -391,7 +391,7 @@ class AEPEdgeFunctionalTests: TestBase {
         let requestBody = resultNetworkRequests[0].getFlattenedBody()
         XCTAssertEqual(17, requestBody.count)
         XCTAssertEqual(true, requestBody["meta.konductorConfig.streaming.enabled"] as? Bool)
-        if #available(iOS 17, *) {
+        if #available(iOS 17, tvOS 17, *) {
           XCTAssertEqual("", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
         } else {
           XCTAssertEqual("\u{0000}", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)

--- a/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
+++ b/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
@@ -65,11 +65,11 @@ class AEPEdgeFunctionalTests: TestBase {
         resetTestExpectations()
         mockNetworkService.reset()
     }
-    
+
     // Runs after each test case
     override func tearDown() {
         super.tearDown()
-        
+
         mockNetworkService.reset()
     }
 
@@ -280,7 +280,11 @@ class AEPEdgeFunctionalTests: TestBase {
         let requestBody = resultNetworkRequests[0].getFlattenedBody()
         XCTAssertEqual(19, requestBody.count)
         XCTAssertEqual(true, requestBody["meta.konductorConfig.streaming.enabled"] as? Bool)
-        XCTAssertEqual("\u{0000}", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
+        if #available(iOS 17, *) {
+          XCTAssertEqual("", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
+        } else {
+          XCTAssertEqual("\u{0000}", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
+        }
         XCTAssertEqual("\n", requestBody["meta.konductorConfig.streaming.lineFeed"] as? String)
         XCTAssertNotNil(requestBody["xdm.identityMap.ECID[0].id"] as? String)
         XCTAssertNotNil(requestBody["xdm.identityMap.ECID[0].authenticatedState"] as? String)
@@ -329,7 +333,11 @@ class AEPEdgeFunctionalTests: TestBase {
         let requestBody = resultNetworkRequests[0].getFlattenedBody()
         XCTAssertEqual(20, requestBody.count)
         XCTAssertEqual(true, requestBody["meta.konductorConfig.streaming.enabled"] as? Bool)
-        XCTAssertEqual("\u{0000}", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
+        if #available(iOS 17, *) {
+          XCTAssertEqual("", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
+        } else {
+          XCTAssertEqual("\u{0000}", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
+        }
         XCTAssertEqual("\n", requestBody["meta.konductorConfig.streaming.lineFeed"] as? String)
         XCTAssertNotNil(requestBody["xdm.identityMap.ECID[0].id"] as? String)
         XCTAssertNotNil(requestBody["xdm.identityMap.ECID[0].authenticatedState"] as? String)
@@ -383,7 +391,11 @@ class AEPEdgeFunctionalTests: TestBase {
         let requestBody = resultNetworkRequests[0].getFlattenedBody()
         XCTAssertEqual(17, requestBody.count)
         XCTAssertEqual(true, requestBody["meta.konductorConfig.streaming.enabled"] as? Bool)
-        XCTAssertEqual("\u{0000}", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
+        if #available(iOS 17, *) {
+          XCTAssertEqual("", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
+        } else {
+          XCTAssertEqual("\u{0000}", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
+        }
         XCTAssertEqual("\n", requestBody["meta.konductorConfig.streaming.lineFeed"] as? String)
         XCTAssertNotNil(requestBody["xdm.identityMap.ECID[0].id"] as? String)
         XCTAssertNotNil(requestBody["xdm.identityMap.ECID[0].authenticatedState"] as? String)

--- a/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
+++ b/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
@@ -32,9 +32,15 @@ class AEPEdgeFunctionalTests: TestBase {
     #elseif os(tvOS)
     private let EXPECTED_BASE_PATH = "https://ns.adobe.com/experience/mobilesdk/tvos"
     #endif
-
+    private var expectedRecordSeparatorString: String {
+       if #available(iOS 17, tvOS 17, *) {
+           return ""
+       } else {
+           return "\u{0000}"
+       }
+    }
     private let mockNetworkService: MockNetworkService = MockNetworkService()
-
+    
     // Runs before each test case
     override func setUp() {
         ServiceProvider.shared.networkService = mockNetworkService
@@ -280,11 +286,7 @@ class AEPEdgeFunctionalTests: TestBase {
         let requestBody = resultNetworkRequests[0].getFlattenedBody()
         XCTAssertEqual(19, requestBody.count)
         XCTAssertEqual(true, requestBody["meta.konductorConfig.streaming.enabled"] as? Bool)
-        if #available(iOS 17, tvOS 17, *) {
-          XCTAssertEqual("", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
-        } else {
-          XCTAssertEqual("\u{0000}", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
-        }
+        XCTAssertEqual(expectedRecordSeparatorString, requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
         XCTAssertEqual("\n", requestBody["meta.konductorConfig.streaming.lineFeed"] as? String)
         XCTAssertNotNil(requestBody["xdm.identityMap.ECID[0].id"] as? String)
         XCTAssertNotNil(requestBody["xdm.identityMap.ECID[0].authenticatedState"] as? String)
@@ -333,12 +335,7 @@ class AEPEdgeFunctionalTests: TestBase {
         let requestBody = resultNetworkRequests[0].getFlattenedBody()
         XCTAssertEqual(20, requestBody.count)
         XCTAssertEqual(true, requestBody["meta.konductorConfig.streaming.enabled"] as? Bool)
-        if #available(iOS 17, tvOS 17, *) {
-          XCTAssertEqual("", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
-        } else {
-          XCTAssertEqual("\u{0000}", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
-        }
-        XCTAssertEqual("\n", requestBody["meta.konductorConfig.streaming.lineFeed"] as? String)
+        XCTAssertEqual(expectedRecordSeparatorString, requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
         XCTAssertNotNil(requestBody["xdm.identityMap.ECID[0].id"] as? String)
         XCTAssertNotNil(requestBody["xdm.identityMap.ECID[0].authenticatedState"] as? String)
         XCTAssertNotNil(requestBody["xdm.identityMap.ECID[0].primary"] as? Bool)
@@ -391,11 +388,7 @@ class AEPEdgeFunctionalTests: TestBase {
         let requestBody = resultNetworkRequests[0].getFlattenedBody()
         XCTAssertEqual(17, requestBody.count)
         XCTAssertEqual(true, requestBody["meta.konductorConfig.streaming.enabled"] as? Bool)
-        if #available(iOS 17, tvOS 17, *) {
-          XCTAssertEqual("", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
-        } else {
-          XCTAssertEqual("\u{0000}", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
-        }
+        XCTAssertEqual(expectedRecordSeparatorString, requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
         XCTAssertEqual("\n", requestBody["meta.konductorConfig.streaming.lineFeed"] as? String)
         XCTAssertNotNil(requestBody["xdm.identityMap.ECID[0].id"] as? String)
         XCTAssertNotNil(requestBody["xdm.identityMap.ECID[0].authenticatedState"] as? String)

--- a/Tests/FunctionalTests/Edge+ConsentTests.swift
+++ b/Tests/FunctionalTests/Edge+ConsentTests.swift
@@ -47,6 +47,13 @@ class EdgeConsentTests: TestBase {
         "      ]" +
         "    }\n"
 
+    private var expectedRecordSeparatorString: String {
+       if #available(iOS 17, tvOS 17, *) {
+           return ""
+       } else {
+           return "\u{0000}"
+       }
+    }
     private let mockNetworkService: MockNetworkService = MockNetworkService()
 
     // Runs before each test case
@@ -226,11 +233,7 @@ class EdgeConsentTests: TestBase {
         XCTAssertEqual("n", requestBody["consent[0].value.collect.val"] as? String)
         XCTAssertNotNil(requestBody["consent[0].value.metadata.time"] as? String)
         XCTAssertEqual(true, requestBody["meta.konductorConfig.streaming.enabled"] as? Bool)
-        if #available(iOS 17, tvOS 17, *) {
-          XCTAssertEqual("", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
-        } else {
-          XCTAssertEqual("\u{0000}", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
-        }
+        XCTAssertEqual(expectedRecordSeparatorString, requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
         XCTAssertEqual("\n", requestBody["meta.konductorConfig.streaming.lineFeed"] as? String)
     }
 
@@ -258,11 +261,7 @@ class EdgeConsentTests: TestBase {
         XCTAssertEqual("y", requestBody["consent[0].value.collect.val"] as? String)
         XCTAssertNotNil(requestBody["consent[0].value.metadata.time"] as? String)
         XCTAssertEqual(true, requestBody["meta.konductorConfig.streaming.enabled"] as? Bool)
-        if #available(iOS 17, tvOS 17, *) {
-          XCTAssertEqual("", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
-        } else {
-          XCTAssertEqual("\u{0000}", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
-        }
+        XCTAssertEqual(expectedRecordSeparatorString, requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
         XCTAssertEqual("\n", requestBody["meta.konductorConfig.streaming.lineFeed"] as? String)
     }
 

--- a/Tests/FunctionalTests/Edge+ConsentTests.swift
+++ b/Tests/FunctionalTests/Edge+ConsentTests.swift
@@ -226,7 +226,7 @@ class EdgeConsentTests: TestBase {
         XCTAssertEqual("n", requestBody["consent[0].value.collect.val"] as? String)
         XCTAssertNotNil(requestBody["consent[0].value.metadata.time"] as? String)
         XCTAssertEqual(true, requestBody["meta.konductorConfig.streaming.enabled"] as? Bool)
-        if #available(iOS 17, *) {
+        if #available(iOS 17, tvOS 17, *) {
           XCTAssertEqual("", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
         } else {
           XCTAssertEqual("\u{0000}", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
@@ -258,7 +258,7 @@ class EdgeConsentTests: TestBase {
         XCTAssertEqual("y", requestBody["consent[0].value.collect.val"] as? String)
         XCTAssertNotNil(requestBody["consent[0].value.metadata.time"] as? String)
         XCTAssertEqual(true, requestBody["meta.konductorConfig.streaming.enabled"] as? Bool)
-        if #available(iOS 17, *) {
+        if #available(iOS 17, tvOS 17, *) {
           XCTAssertEqual("", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
         } else {
           XCTAssertEqual("\u{0000}", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)

--- a/Tests/FunctionalTests/Edge+ConsentTests.swift
+++ b/Tests/FunctionalTests/Edge+ConsentTests.swift
@@ -81,11 +81,11 @@ class EdgeConsentTests: TestBase {
         resetTestExpectations()
         mockNetworkService.reset()
     }
-    
+
     // Runs after each test case
     override func tearDown() {
         super.tearDown()
-        
+
         mockNetworkService.reset()
     }
 
@@ -226,7 +226,11 @@ class EdgeConsentTests: TestBase {
         XCTAssertEqual("n", requestBody["consent[0].value.collect.val"] as? String)
         XCTAssertNotNil(requestBody["consent[0].value.metadata.time"] as? String)
         XCTAssertEqual(true, requestBody["meta.konductorConfig.streaming.enabled"] as? Bool)
-        XCTAssertEqual("\u{0000}", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
+        if #available(iOS 17, *) {
+          XCTAssertEqual("", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
+        } else {
+          XCTAssertEqual("\u{0000}", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
+        }
         XCTAssertEqual("\n", requestBody["meta.konductorConfig.streaming.lineFeed"] as? String)
     }
 
@@ -254,7 +258,11 @@ class EdgeConsentTests: TestBase {
         XCTAssertEqual("y", requestBody["consent[0].value.collect.val"] as? String)
         XCTAssertNotNil(requestBody["consent[0].value.metadata.time"] as? String)
         XCTAssertEqual(true, requestBody["meta.konductorConfig.streaming.enabled"] as? Bool)
-        XCTAssertEqual("\u{0000}", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
+        if #available(iOS 17, *) {
+          XCTAssertEqual("", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
+        } else {
+          XCTAssertEqual("\u{0000}", requestBody["meta.konductorConfig.streaming.recordSeparator"] as? String)
+        }
         XCTAssertEqual("\n", requestBody["meta.konductorConfig.streaming.lineFeed"] as? String)
     }
 


### PR DESCRIPTION
MOB-19331
Update the validation expected results for recordSeparator. 
In iOS 17 and later, result displays " " (empty string). 
In iOS 16 and before, result displays "\u{0000}".

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
