### PR TITLE
Fix integration test setup to properly wait and clear expectations

### DIFF
--- a/Tests/UpstreamIntegrationTests/UpstreamIntegrationTests.swift
+++ b/Tests/UpstreamIntegrationTests/UpstreamIntegrationTests.swift
@@ -312,9 +312,14 @@ class UpstreamIntegrationTests: TestBase {
     /// Tests that a standard sendEvent with prior state receives the expected state store event handle.
     func testSendEvent_withPriorState_receivesExpectedStateStoreEventHandle() {
         // Setup
+        expectEdgeEventHandle(expectedHandleType: TestConstants.EventSource.STATE_STORE, expectedCount: 1)
+        
         let experienceEvent = ExperienceEvent(xdm: ["xdmtest": "data"], data: ["data": ["test": "data"]])
 
         Edge.sendEvent(experienceEvent: experienceEvent)
+        
+        // Allows waiting for expected responses before clearing expectations
+        assertExpectedEvents(ignoreUnexpectedEvents: true, timeout: 5)
         
         resetTestExpectations()
         networkService.reset()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes a test issue where the setup event and response was not being cleaned up properly, and causing unexpected location hints to be set.

The fix adds an expected event handle and waits for it in the test case setup before continuing with the main test case logic.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
MOB-19330

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
