### PR TITLE
Update documentation for Datastream Override Feature

### DIFF
--- a/Documentation/api-reference.md
+++ b/Documentation/api-reference.md
@@ -100,7 +100,7 @@ See [MobileCore.resetIdentities](https://developer.adobe.com/client-sdks/documen
 
 Sends an Experience event to Edge Network.
 
-The sendEvent API has been improved to support Datastream overrides. This allows you to adjust your datastreams without the need for new ones or modifications to existing settings. The process involves two steps:
+Starting with 4.3.0 the sentEvent API supports optional Datastream overrides. This allows you to adjust your datastreams without the need for new ones or modifications to existing settings. The process involves two steps:
 
 1. Define your Datastream configuration overrides on the [datastream configuration page](https://experienceleague.adobe.com/docs/experience-platform/datastreams/configure.html?lang=en).
 2. Send these overrides to the Edge Network using the sendEvent API.
@@ -132,7 +132,7 @@ Edge.sendEvent(experienceEvent: experienceEvent) { (handles: [EdgeEventHandle]) 
 }
 ```
 
-##### Example with DatastreamIdOverride
+##### Example with Datastream ID override
 ```swift
 // Create Experience event from dictionary
 var xdmData : [String: Any] = ["eventType" : "SampleXDMEvent",
@@ -150,7 +150,7 @@ Edge.sendEvent(experienceEvent: experienceEvent) { (handles: [EdgeEventHandle]) 
 }
 ```
 
-##### Example with DatastreamConfigOverride
+##### Example with Datastream config override
 ```swift
 // Create Experience event from dictionary
 var xdmData : [String: Any] = ["eventType" : "SampleXDMEvent",
@@ -160,10 +160,10 @@ var xdmData : [String: Any] = ["eventType" : "SampleXDMEvent",
                                         "com_adobe_experience_platform": [
                                           "datasets": [
                                             "event": [
-                                              "datasetId": "eventDatasetIdOverride"
+                                              "datasetId": "SampleEventDatasetIdOverride"
                                             ],
                                             "profile": [
-                                              "datasetId": "profileDatasetIdOverride"
+                                              "datasetId": "SampleProfileDatasetIdOverride"
                                             ]
                                           ]
                                         ],
@@ -178,7 +178,7 @@ var xdmData : [String: Any] = ["eventType" : "SampleXDMEvent",
                                           "idSyncContainerId": "1234567"
                                         ],
                                         "com_adobe_target": [
-                                          "propertyToken": "63a46bbc-26cb-7cc3-def0-9ae1b51b6c62"
+                                          "propertyToken": "SamplePropertyToken"
                                         ]
                                       ]
 
@@ -207,6 +207,68 @@ Edge.sendEvent(experienceEvent: experienceEvent) { (handles: [EdgeEventHandle]) 
 // Create Experience event from dictionary:
 NSDictionary *xdmData = @{ @"eventType" : @"SampleXDMEvent"};
 NSDictionary *data = @{ @"sample" : @"data"};
+AEPExperienceEvent* event = [[AEPExperienceEvent alloc]initWithXdm:xdmData data:data];
+```
+```objectivec
+// Example 1 - send the Experience event without handling the Edge Network response
+[AEPMobileEdge sendExperienceEvent:event completion:nil];
+```
+```objectivec
+// Example 2 - send the Experience event and handle the Edge Network response onComplete
+[AEPMobileEdge sendExperienceEvent:event completion:^(NSArray<AEPEdgeEventHandle *> * _Nonnull handles) {
+  // Handle the Edge Network response
+}];
+```
+
+##### Example with Datastream ID override
+```objectivec
+// Create Experience event from dictionary:
+NSDictionary *xdmData = @{ @"eventType" : @"SampleXDMEvent"};
+NSDictionary *data = @{ @"sample" : @"data"};
+AEPExperienceEvent* event = [[AEPExperienceEvent alloc]initWithXdm:xdmData data:data datastreamIdOverride: @"SampleDatastreamIdOverride"];
+```
+```objectivec
+// Example 1 - send the Experience event without handling the Edge Network response
+[AEPMobileEdge sendExperienceEvent:event completion:nil];
+```
+```objectivec
+// Example 2 - send the Experience event and handle the Edge Network response onComplete
+[AEPMobileEdge sendExperienceEvent:event completion:^(NSArray<AEPEdgeEventHandle *> * _Nonnull handles) {
+  // Handle the Edge Network response
+}];
+```
+
+
+##### Example with Datastream config override
+```objectivec
+// Create Experience event from dictionary:
+NSDictionary *xdmData = @{ @"eventType" : @"SampleXDMEvent"};
+NSDictionary *data = @{ @"sample" : @"data"};
+NSDictionary *configOverrides = @{ @"com_adobe_experience_platform" : @{
+                                                                @"datasets" : @{
+                                                                    @"event" : @{
+                                                                        @"datasetId": @"SampleEventDatasetIdOverride"
+                                                                    },
+                                                                    @"profile" : @{
+                                                                        @"datasetId": @"SampleProfileDatasetIdOverride"
+                                                                    }
+                                                                }
+                                                            },
+                                       @"com_adobe_analytics" : @{
+                                           @"reportSuites" : @[
+                                               @"rsid1",
+                                               @"rsid2",
+                                               @"rsid3",
+                                           ]
+                                       },
+                                       @"com_adobe_identity" : @{
+                                           @"idSyncContainerId": @"1234567"
+                                       },
+                                       @"com_adobe_target" : @{
+                                           @"propertyToken": @"SamplePropertyToken"
+                                       }
+
+AEPExperienceEvent* event = [[AEPExperienceEvent alloc]initWithXdm:xdmData data:data datastreamConfigOverride: configOverrides];
 ```
 ```objectivec
 // Example 1 - send the Experience event without handling the Edge Network response

--- a/Documentation/api-reference.md
+++ b/Documentation/api-reference.md
@@ -245,28 +245,29 @@ AEPExperienceEvent* event = [[AEPExperienceEvent alloc]initWithXdm:xdmData data:
 NSDictionary *xdmData = @{ @"eventType" : @"SampleXDMEvent"};
 NSDictionary *data = @{ @"sample" : @"data"};
 NSDictionary *configOverrides = @{ @"com_adobe_experience_platform" : @{
-                                                                @"datasets" : @{
-                                                                    @"event" : @{
-                                                                        @"datasetId": @"SampleEventDatasetIdOverride"
-                                                                    },
-                                                                    @"profile" : @{
-                                                                        @"datasetId": @"SampleProfileDatasetIdOverride"
-                                                                    }
-                                                                }
-                                                            },
-                                       @"com_adobe_analytics" : @{
-                                           @"reportSuites" : @[
-                                               @"rsid1",
-                                               @"rsid2",
-                                               @"rsid3",
-                                           ]
-                                       },
-                                       @"com_adobe_identity" : @{
-                                           @"idSyncContainerId": @"1234567"
-                                       },
-                                       @"com_adobe_target" : @{
-                                           @"propertyToken": @"SamplePropertyToken"
-                                       }
+                                    @"datasets" : @{
+                                        @"event" : @{
+                                          @"datasetId": @"SampleEventDatasetIdOverride"
+                                        },
+                                        @"profile" : @{
+                                          @"datasetId": @"SampleProfileDatasetIdOverride"
+                                        }
+                                      }
+                                    },
+                                    @"com_adobe_analytics" : @{
+                                      @"reportSuites" : @[
+                                        @"rsid1",
+                                        @"rsid2",
+                                        @"rsid3",
+                                      ]
+                                    },
+                                    @"com_adobe_identity" : @{
+                                      @"idSyncContainerId": @"1234567"
+                                    },
+                                    @"com_adobe_target" : @{
+                                      @"propertyToken": @"SamplePropertyToken"
+                                    }
+                                  }
 
 AEPExperienceEvent* event = [[AEPExperienceEvent alloc]initWithXdm:xdmData data:data datastreamConfigOverride: configOverrides];
 ```

--- a/Documentation/api-reference.md
+++ b/Documentation/api-reference.md
@@ -81,7 +81,7 @@ Edge.getLocationHint { (hint, error) in
 
 ##### Example
 ```objectivec
-[AEPMobileEdge getLocationHint:^(NSString *hint, NSError *error) {   
+[AEPMobileEdge getLocationHint:^(NSString *hint, NSError *error) {
     // Handle the error and the hint here
 }];
 ```
@@ -100,13 +100,17 @@ See [MobileCore.resetIdentities](https://developer.adobe.com/client-sdks/documen
 
 Sends an Experience event to Edge Network.
 
+The sendEvent API has been improved to support Datastream overrides. This allows you to adjust your datastreams without the need for new ones or modifications to existing settings. The process involves two steps:
+
+1. Define your Datastream configuration overrides on the [datastream configuration page](https://experienceleague.adobe.com/docs/experience-platform/datastreams/configure.html?lang=en).
+2. Send these overrides to the Edge Network using the sendEvent API.
+
 #### Swift
 
 ##### Syntax
 ```swift
 static func sendEvent(experienceEvent: ExperienceEvent, _ completion: (([EdgeEventHandle]) -> Void)? = nil)
 ```
-
 * `experienceEvent` is the XDM [Experience Event](#experienceevent) sent to Edge Network.
 * `completion` is an optional callback invoked when the request is complete and returns the associated [EdgeEventHandle](#edgeeventhandle)(s) received from  Edge Network. It may be invoked on a different thread.
 
@@ -116,6 +120,69 @@ static func sendEvent(experienceEvent: ExperienceEvent, _ completion: (([EdgeEve
 var xdmData : [String: Any] = ["eventType" : "SampleXDMEvent",
                               "sample": "data"]
 let experienceEvent = ExperienceEvent(xdm: xdmData)
+```
+```swift
+// Example 1 - send the Experience event without handling the Edge Network response
+Edge.sendEvent(experienceEvent: experienceEvent)
+```
+```swift
+// Example 2 - send the Experience event and handle the Edge Network response onComplete
+Edge.sendEvent(experienceEvent: experienceEvent) { (handles: [EdgeEventHandle]) in
+  // Handle the Edge Network response
+}
+```
+
+##### Example with DatastreamIdOverride
+```swift
+// Create Experience event from dictionary
+var xdmData : [String: Any] = ["eventType" : "SampleXDMEvent",
+                              "sample": "data"]
+let experienceEvent = ExperienceEvent(xdm: xdmData, datastreamIdOverride: "SampleDatastreamId")
+```
+```swift
+// Example 1 - send the Experience event without handling the Edge Network response
+Edge.sendEvent(experienceEvent: experienceEvent)
+```
+```swift
+// Example 2 - send the Experience event and handle the Edge Network response onComplete
+Edge.sendEvent(experienceEvent: experienceEvent) { (handles: [EdgeEventHandle]) in
+  // Handle the Edge Network response
+}
+```
+
+##### Example with DatastreamConfigOverride
+```swift
+// Create Experience event from dictionary
+var xdmData : [String: Any] = ["eventType" : "SampleXDMEvent",
+                              "sample": "data"]
+
+ let configOverrides: [String: Any] = [
+                                        "com_adobe_experience_platform": [
+                                          "datasets": [
+                                            "event": [
+                                              "datasetId": "eventDatasetIdOverride"
+                                            ],
+                                            "profile": [
+                                              "datasetId": "profileDatasetIdOverride"
+                                            ]
+                                          ]
+                                        ],
+                                        "com_adobe_analytics": [
+                                          "reportSuites": [
+                                            "rsid1",
+                                            "rsid2",
+                                            "rsid3"
+                                            ]
+                                        ],
+                                        "com_adobe_identity": [
+                                          "idSyncContainerId": "1234567"
+                                        ],
+                                        "com_adobe_target": [
+                                          "propertyToken": "63a46bbc-26cb-7cc3-def0-9ae1b51b6c62"
+                                        ]
+                                      ]
+
+let experienceEvent = ExperienceEvent(xdm: xdmData, datastreamConfigOverride: configOverrides)
 ```
 ```swift
 // Example 1 - send the Experience event without handling the Edge Network response
@@ -157,7 +224,7 @@ NSDictionary *data = @{ @"sample" : @"data"};
 
 Sets the Edge Network location hint used in requests to Edge Network. Passing `nil` or an empty string (`""`) clears the existing location hint. Edge Network responses may overwrite the location hint to a new value when necessary to manage network traffic.
 
-> **Warning**  
+> **Warning**
 > Use caution when setting the location hint. Only use valid [location hints for the `EdgeNetwork` scope](https://experienceleague.adobe.com/docs/experience-platform/edge-network-server-api/location-hints.html). An invalid location hint value will cause all Edge Network requests to fail with a `404` response code.
 
 #### Swift
@@ -246,21 +313,49 @@ public class ExperienceEvent: NSObject {
     /// Optional free-form data associated with this event
     @objc public let data: [String: Any]?
 
+    /// Datastream identifier used to override the default datastream identifier set in the Edge configuration for this event
+    @objc public private(set) var datastreamIdOverride: String?
+
+    /// Datastream configuration used to override individual settings from the default datastream configuration for this event
+    @objc public private(set) var datastreamConfigOverride: [String: Any]?
+
     /// Adobe Experience Platform dataset identifier, if not set the default dataset identifier set in the Edge Configuration is used
-    @objc public let datasetIdentifier: String?
+    @objc public private(set) var datasetIdentifier: String?
+
+    /// Initialize an Experience Event with the provided event data
+    /// - Parameters:
+    ///   - xdm:  XDM formatted data for this event, passed as a raw XDM Schema data dictionary.
+    ///   - data: Any free form data in a [String : Any] dictionary structure.
+    @objc public init(xdm: [String: Any], data: [String: Any]? = nil) {...}
 
     /// Initialize an Experience Event with the provided event data
     /// - Parameters:
     ///   - xdm:  XDM formatted data for this event, passed as a raw XDM Schema data dictionary.
     ///   - data: Any free form data in a [String : Any] dictionary structure.
     ///   - datasetIdentifier: The Experience Platform dataset identifier where this event should be sent to; if not provided, the default dataset identifier set in the Edge configuration is used
-    @objc public init(xdm: [String: Any], data: [String: Any]? = nil, datasetIdentifier: String? = nil) {...}
+    @objc public convenience init(xdm: [String: Any], data: [String: Any]? = nil, datasetIdentifier: String? = nil) {...}
+
+    /// Initialize an Experience Event with the provided event data
+    /// - Parameters:
+    ///   - xdm:  XDM formatted data for this event, passed as a raw XDM Schema data dictionary.
+    ///   - data: Any free form data in a [String : Any] dictionary structure.
+    ///   - datastreamIdOverride: Datastream identifier used to override the default datastream identifier set in the Edge configuration for this event.
+    ///   - datastreamConfigOverride: Datastream configuration used to override individual settings from the default datastream configuration for this event.
+    @objc public convenience init(xdm: [String: Any], data: [String: Any]? = nil, datastreamIdOverride: String? = nil, datastreamConfigOverride: [String: Any]? = nil) {...}
 
     /// Initialize an Experience Event with the provided event data
     /// - Parameters:
     ///   - xdm: XDM formatted event data passed as an XDMSchema
     ///   - data: Any free form data in a [String : Any] dictionary structure.
     public init(xdm: XDMSchema, data: [String: Any]? = nil) {...}
+
+    /// Initialize an Experience Event with the provided event data
+    /// - Parameters:
+    ///   - xdm: XDM formatted event data passed as an XDMSchema
+    ///   - data: Any free form data in a [String : Any] dictionary structure.
+    ///   - datastreamIdOverride: Datastream identifier used to override the default datastream identifier set in the Edge configuration for this event.
+    ///   - datastreamConfigOverride: Datastream configuration used to override individual settings from the default datastream configuration for this event.
+    public convenience init(xdm: XDMSchema, data: [String: Any]? = nil, datastreamIdOverride: String? = nil, datastreamConfigOverride: [String: Any]? = nil) {...}
 }
 ```
 
@@ -293,7 +388,7 @@ public struct XDMSchemaExample : XDMSchema {
     enum CodingKeys: String, CodingKey {
     case eventType = "eventType"
     case otherField = "otherField"
-    }       
+    }
 }
 
 extension XDMSchemaExample {
@@ -329,13 +424,13 @@ Example 1: Set both the XDM and freeform data of an `ExperienceEvent`.
 // Set the freeform data of the Experience event
 NSDictionary *xdmData = @{ @"eventType" : @"SampleXDMEvent"};
 NSDictionary *data = @{ @"sample" : @"data"};
-    
+
 AEPExperienceEvent *event = [[AEPExperienceEvent alloc] initWithXdm:xdmData data:data datasetIdentifier:nil];
 ```
 Example 3: Set a custom destination Dataset ID when creating an `ExperienceEvent` instance.
 ```objectivec
 // Set the destination Dataset identifier of the Experience Event
 NSDictionary *xdmData = @{ @"eventType" : @"SampleXDMEvent"};
-   
+
 AEPExperienceEvent *event = [[AEPExperienceEvent alloc] initWithXdm:xdmData data:nil datasetIdentifier:@"datasetIdExample"];
 ```

--- a/Documentation/api-reference.md
+++ b/Documentation/api-reference.md
@@ -100,9 +100,9 @@ See [MobileCore.resetIdentities](https://developer.adobe.com/client-sdks/documen
 
 Sends an Experience event to Edge Network.
 
-Starting with 4.3.0 the sentEvent API supports optional Datastream overrides. This allows you to adjust your datastreams without the need for new ones or modifications to existing settings. The process involves two steps:
+Starting with `AEPEdge` extension version **4.3.0** onwards, the `sendEvent` API supports optional Datastream overrides. This allows you to adjust your datastreams without the need for new ones or modifications to existing settings. The process involves two steps:
 
-1. Define your Datastream configuration overrides on the [datastream configuration page](https://experienceleague.adobe.com/docs/experience-platform/datastreams/configure.html?lang=en).
+1. Define your Datastream configuration overrides on the [datastream configuration page](https://experienceleague.adobe.com/docs/experience-platform/datastreams/configure.html).
 2. Send these overrides to the Edge Network using the sendEvent API.
 
 #### Swift

--- a/Documentation/event-reference.md
+++ b/Documentation/event-reference.md
@@ -45,11 +45,11 @@ This event contains the latest consent preferences synced with the SDK. The Edge
 | --- | ---------- | -------- | ----------- |
 | consents | <code>[String:&nbsp;Any]</code> | No | XDM formatted consent preferences containing current collect consent settings. If not specified, defaults to `p` (pending) until the value is updated. |
 
------ 
+-----
 
 ### Edge identity reset complete
 
-This event signals that [Identity for Edge Network](https://github.com/adobe/aepsdk-edgeidentity-ios) has completed [resetting all identities](https://developer.adobe.com/client-sdks/documentation/identity-for-edge-network/api-reference/#resetidentities) usually following a call to [`MobileCore.resetIdentities()`](https://developer.adobe.com/client-sdks/documentation/mobile-core/api-reference/#resetidentities). 
+This event signals that [Identity for Edge Network](https://github.com/adobe/aepsdk-edgeidentity-ios) has completed [resetting all identities](https://developer.adobe.com/client-sdks/documentation/identity-for-edge-network/api-reference/#resetidentities) usually following a call to [`MobileCore.resetIdentities()`](https://developer.adobe.com/client-sdks/documentation/mobile-core/api-reference/#resetidentities).
 
 When this event is received, the Edge extension queues it up and removes the cached internal `state:store` settings. If other events are queued before this event, those events will be processed first in the order they were received.
 
@@ -89,10 +89,12 @@ If the required `xdm` key is not present in the event data payload, the event is
 | --- | ---------- | -------- | ----------- |
 | xdm | <code>[String:&nbsp;Any]</code> | Yes | XDM formatted data; use an `XDMSchema` implementation for better XDM data ingestion and data format control. |
 | data | <code>[String:&nbsp;Any]</code> | No | Optional free-form data associated with this event. |
+| datastreamIdOverride | `String` | No | Optional Datastream identifier used to override the default datastream identifier set in the Edge configuration. |
+| datastreamConfigOverride | <code>[String:&nbsp;Any]</code> | No | Optional Datastream configuration used to override individual settings from the default datastream configuration. |
 | datasetId | `String` | No | Optional custom dataset ID. If not set, the event uses the default Experience dataset ID set in the datastream configuration. |
 | request | <code>[String:&nbsp;Any]</code> | No | Optional request parameters. |
 
-> **Note**  
+> **Note**
 > Events of this type and source are only processed if the data collection consent status stored in the `collect` property is **not** `n` (no); that is, either `y` (yes) or `p` (pending).
 
 -----
@@ -143,7 +145,7 @@ This event is a request to process and deliver a Consent update event to Edge Ne
 
 This event is a request to set the Edge Network location hint used by the Edge Network extension in requests to Edge Network.
 
-> **Warning**  
+> **Warning**
 > Use caution when setting the location hint. Only use valid [location hints defined within the `EdgeNetwork` scope](https://experienceleague.adobe.com/docs/experience-platform/edge-network-server-api/location-hints.html). An invalid location hint value will cause all Edge Network requests to fail with a `404` response code.
 
 #### Event dispatched by<!-- omit in toc -->
@@ -180,7 +182,7 @@ This event is a response to an [Edge request content](#edge-request-content) eve
 | --- | ---------- | -------- | ----------- |
 | requestId | `String` | Yes | The ID (`UUID`) of the batched Edge Network request tied to the event that requested the completion response. |
 
------ 
+-----
 
 ### Edge error response content
 
@@ -199,7 +201,7 @@ This event is an error response to an originating event. If there are multiple e
 | requestId | `String` | Yes | The ID (`UUID`) of the batched Edge Network request tied to the event that triggered the error response. |
 | requestEventId | `String` | Yes | The ID (`UUID`) of the event that triggered the error response. |
 
------ 
+-----
 
 ### Edge identity response
 
@@ -217,7 +219,7 @@ This event is a response to the [Edge request identity event](#edge-request-iden
 | --- | ---------- | -------- | ----------- |
 | locationHint | `String` | Yes | The Edge Network location hint currently set for use when connecting to Edge Network. |
 
------ 
+-----
 
 ### Edge location hint result
 

--- a/Documentation/event-reference.md
+++ b/Documentation/event-reference.md
@@ -89,23 +89,23 @@ If the required `xdm` key is not present in the event data payload, the event is
 | --- | ---------- | -------- | ----------- |
 | xdm | <code>[String:&nbsp;Any]</code> | Yes | XDM formatted data; use an `XDMSchema` implementation for better XDM data ingestion and data format control. |
 | data | <code>[String:&nbsp;Any]</code> | No | Optional free-form data associated with this event. |
-| config | <code>[String:&nbsp;Any]</code> | No | Optional config overrides. |
+| config | <code>[String:&nbsp;Any]</code> | No | Optional config settings. Find the available keys for `config` below.|
 | datasetId | `String` | No | Optional custom dataset ID. If not set, the event uses the default Experience dataset ID set in the datastream configuration. |
-| request | <code>[String:&nbsp;Any]</code> | No | Optional request parameters. |
+| request | <code>[String:&nbsp;Any]</code> | No | Optional request parameters. Find the available keys for `request` below. |
 
 config
 
 | Key | Value type | Required | Description |
 | --- | ---------- | -------- | ----------- |
-| config.datastreamIdOverride | `String` | No | Optional Datastream identifier used to override the default datastream identifier set in the Edge configuration. |
-| config.datastreamConfigOverride | <code>[String:&nbsp;Any]</code> | No | Optional Datastream configuration used to override individual settings from the default datastream configuration. |
+| datastreamIdOverride | `String` | No | Optional Datastream identifier used to override the default datastream identifier set in the Edge configuration. |
+| datastreamConfigOverride | <code>[String:&nbsp;Any]</code> | No | Optional Datastream configuration used to override individual settings from the default datastream configuration. |
 
 request
 
 | Key | Value type | Required | Description |
 | --- | ---------- | -------- | ----------- |
-| request.path | `String` | No | Optional path to be used for the Edge request. |
-| request.sendCompletion | `Boolean` | No | Optional flag to determine if a "complete" event is requested. |
+| path | `String` | No | Optional path to be used for the Edge request. |
+| sendCompletion | `Boolean` | No | Optional flag to determine if a "complete" event is requested. |
 
 > **Note**
 > Events of this type and source are only processed if the data collection consent status stored in the `collect` property is **not** `n` (no); that is, either `y` (yes) or `p` (pending).

--- a/Documentation/event-reference.md
+++ b/Documentation/event-reference.md
@@ -89,10 +89,23 @@ If the required `xdm` key is not present in the event data payload, the event is
 | --- | ---------- | -------- | ----------- |
 | xdm | <code>[String:&nbsp;Any]</code> | Yes | XDM formatted data; use an `XDMSchema` implementation for better XDM data ingestion and data format control. |
 | data | <code>[String:&nbsp;Any]</code> | No | Optional free-form data associated with this event. |
-| datastreamIdOverride | `String` | No | Optional Datastream identifier used to override the default datastream identifier set in the Edge configuration. |
-| datastreamConfigOverride | <code>[String:&nbsp;Any]</code> | No | Optional Datastream configuration used to override individual settings from the default datastream configuration. |
+| config | <code>[String:&nbsp;Any]</code> | No | Optional config overrides. |
 | datasetId | `String` | No | Optional custom dataset ID. If not set, the event uses the default Experience dataset ID set in the datastream configuration. |
 | request | <code>[String:&nbsp;Any]</code> | No | Optional request parameters. |
+
+config
+
+| Key | Value type | Required | Description |
+| --- | ---------- | -------- | ----------- |
+| config.datastreamIdOverride | `String` | No | Optional Datastream identifier used to override the default datastream identifier set in the Edge configuration. |
+| config.datastreamConfigOverride | <code>[String:&nbsp;Any]</code> | No | Optional Datastream configuration used to override individual settings from the default datastream configuration. |
+
+request
+
+| Key | Value type | Required | Description |
+| --- | ---------- | -------- | ----------- |
+| request.path | `String` | No | Optional path to be used for the Edge request. |
+| request.sendCompletion | `Boolean` | No | Optional flag to determine if a "complete" event is requested. |
 
 > **Note**
 > Events of this type and source are only processed if the data collection consent status stored in the `collect` property is **not** `n` (no); that is, either `y` (yes) or `p` (pending).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Added short description for datastream overrides feature to the sendEvent API reference.
- Added Swift samples. 
- Added ObjectiveC sample
- Update ExperienceEvent class structure
- Updated Event reference with the new fields `datastreamIdOverride` and `datastreamConfigOverride`

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
