### PR TITLE
Rename `extractArrayStyleComponents` and update method docs

### DIFF
--- a/Tests/TestUtils/XCTestCase+AnyCodableAsserts.swift
+++ b/Tests/TestUtils/XCTestCase+AnyCodableAsserts.swift
@@ -834,7 +834,7 @@ extension XCTestCase {
         }
     }
     
-    /// Extracts valid array format access components from an individual path component and returns the separated components.
+    /// Extracts valid array format access components from a given path component and returns the separated components.
     ///
     /// Given `"key1[0][1]"`, the result is `["key1", "[0]", "[1]"]`.
     /// Array format access can be escaped using a backslash character preceding an array bracket.

--- a/Tests/TestUtils/XCTestCase+AnyCodableAsserts.swift
+++ b/Tests/TestUtils/XCTestCase+AnyCodableAsserts.swift
@@ -840,7 +840,7 @@ extension XCTestCase {
     /// Array format access can be escaped using a backslash character preceding an array bracket.
     /// For example: `"key1\[0\]"` is treated as the single component `"key1[0]"`.
     ///
-    /// - Parameter pathComponent: The individual path component undergoing extraction into array format access components.
+    /// - Parameter pathComponent: The path component to be split into separate components given valid array formatted components.
     ///
     /// - Returns: An array of `String` path components, where the original path component is divided into individual elements. Valid array format
     ///  components in the original path are extracted as distinct elements, in order. If there are no array format components, the array contains only

--- a/Tests/TestUtils/XCTestCase+AnyCodableAsserts.swift
+++ b/Tests/TestUtils/XCTestCase+AnyCodableAsserts.swift
@@ -837,8 +837,9 @@ extension XCTestCase {
     /// Extracts valid array format access components from a given path component and returns the separated components.
     ///
     /// Given `"key1[0][1]"`, the result is `["key1", "[0]", "[1]"]`.
-    /// Array format access can be escaped using a backslash character preceding an array bracket.
-    /// For example: `"key1\[0\]"` is treated as the single component `"key1[0]"`.
+    /// Array format access can be escaped using a backslash character preceding an array bracket. Valid bracket escape sequences are cleaned so
+    /// that the final path component does not have the escape character.
+    /// For example: `"key1\[0\]"` results in the single path component `"key1[0]"`.
     ///
     /// - Parameter pathComponent: The path component to be split into separate components given valid array formatted components.
     ///

--- a/Tests/TestUtils/XCTestCase+AnyCodableAsserts.swift
+++ b/Tests/TestUtils/XCTestCase+AnyCodableAsserts.swift
@@ -833,17 +833,19 @@ extension XCTestCase {
             return [first: construct(path: path, pathString: pathString)]
         }
     }
-
-    /// Processes an individual path component element and extracts any valid array style access into separate components.
+    
+    /// Extracts valid array format access components from an individual path component and returns the separated components.
     ///
-    /// For example, `"key1[0][1]"` is split into `["key1", "[0]", "[1]"]`
-    /// Array style access can be escaped using a preceding backslash character. For instance:
-    /// `"key1\[0\]"` is interpreted as the single component `"key1[0]"`.
-    /// - Parameter pathComponent: The individual path component to be split into array style access components
+    /// Given `"key1[0][1]"`, the result is `["key1", "[0]", "[1]"]`.
+    /// Array format access can be escaped using a backslash character preceding an array bracket.
+    /// For example: `"key1\[0\]"` is treated as the single component `"key1[0]"`.
     ///
-    /// - Returns: An array of strings representing the individual array style components of the path. If
-    ///  there are no arary style components, returns a list with the original path component.
-    func extractArrayStyleComponents(pathComponent: String) -> [String] {
+    /// - Parameter pathComponent: The individual path component undergoing extraction into array format access components.
+    ///
+    /// - Returns: An array of `String` path components, where the original path component is divided into individual elements. Valid array format
+    ///  components in the original path are extracted as distinct elements, in order. If there are no array format components, the array contains only
+    ///  the original path component.
+    func extractArrayFormattedComponents(pathComponent: String) -> [String] {
         // Handle edge case where input is empty
         if pathComponent.isEmpty { return [""] }
 
@@ -925,7 +927,7 @@ extension XCTestCase {
             for pathComponent in keyPathComponents {
                 let pathComponent = pathComponent.replacingOccurrences(of: "\\.", with: ".")
 
-                let components = extractArrayStyleComponents(pathComponent: pathComponent)
+                let components = extractArrayFormattedComponents(pathComponent: pathComponent)
                 allPathComponents.append(contentsOf: components)
             }
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR renames the `extractArrayStyleComponents` -to-> `extractArrayFormattedComponents` to better reflect the intent of the method, and updates the method docs and usages.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
