### PR TITLE
Refactor functional tests to use JSON comparison (part 1)

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - AEPAssurance (4.1.0):
+  - AEPAssurance (4.1.1):
     - AEPCore (>= 4.0.0)
     - AEPServices (>= 4.0.0)
-  - AEPCore (4.2.1):
+  - AEPCore (4.2.2):
     - AEPRulesEngine (>= 4.0.0)
-    - AEPServices (>= 4.2.1)
+    - AEPServices (>= 4.2.2)
   - AEPEdge (4.3.0):
     - AEPCore (>= 4.1.0)
     - AEPEdgeIdentity (>= 4.0.0)
@@ -14,7 +14,7 @@ PODS:
   - AEPEdgeIdentity (4.0.0):
     - AEPCore (>= 4.0.0)
   - AEPRulesEngine (4.0.0)
-  - AEPServices (4.2.1)
+  - AEPServices (4.2.2)
   - AEPTestUtils (1.0.0-beta):
     - AEPCore (>= 4.0.0)
     - AEPServices (>= 4.0.0)
@@ -49,20 +49,20 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   AEPTestUtils:
-    :commit: ca9390409699e9e5de0a4df8849511934880ed95
+    :commit: 1b7e87fb0a3ae3202c11b82a5a93359b328da3a2
     :git: https://github.com/adobe/aepsdk-testutils-ios.git
 
 SPEC CHECKSUMS:
-  AEPAssurance: ee78c45752b29696f280854cfc4d4f8d11babad8
-  AEPCore: cc4ff17cfb5744b75cf41b72d4a68d93cc903696
+  AEPAssurance: 765587ef65481bab544aa25efcfa294e14161d49
+  AEPCore: 3c0367f3454ae9950ae1f92f0d5f417ed747a49b
   AEPEdge: 301fb849383fca513c1046fe90bac0bcd1f8e404
   AEPEdgeConsent: 54c1b6a30a3d646e3d4bc4bae1713755422b471e
   AEPEdgeIdentity: c2396b9119abd6eb530ea11efc58ec019b163bd4
   AEPRulesEngine: 458450a34922823286ead045a0c2bd8c27e224c6
-  AEPServices: d842a1905bf0dcf489716036caa7b0766e49bea1
+  AEPServices: cc895946c9fb56a74334bf3950a3b067b073fcd1
   AEPTestUtils: 756e5997318be74584057d7628941c737d358640
   SwiftLint: 13280e21cdda6786ad908dc6e416afe5acd1fcb7
 
 PODFILE CHECKSUM: 3a0161a5e905134e8be94474373633f8d12ff79f
 
-COCOAPODS: 1.12.0
+COCOAPODS: 1.14.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -49,7 +49,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   AEPTestUtils:
-    :commit: 23c6f0df33ec41b12320b3dfebbce1bef68b2cd6
+    :commit: ca9390409699e9e5de0a4df8849511934880ed95
     :git: https://github.com/adobe/aepsdk-testutils-ios.git
 
 SPEC CHECKSUMS:

--- a/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
+++ b/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
@@ -36,8 +36,7 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
     private var expectedRecordSeparatorString: String {
         if #available(iOS 17.2, tvOS 17.2, *) {
             return "\0"
-        }
-        else if #available(iOS 17, tvOS 17, *) {
+        } else if #available(iOS 17, tvOS 17, *) {
             return ""
         } else {
             return "\u{0000}"
@@ -469,7 +468,7 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
         assertExactMatch(
             expected: expectedJSON,
             actual: resultNetworkRequests[0],
-            pathOptions: 
+            pathOptions:
                 CollectionEqualCount(paths: nil, scope: .subtree),
                 ValueTypeMatch(paths: "xdm.identityMap.ECID[0].id",
                            "xdm.identityMap.ECID[0].authenticatedState",
@@ -1190,7 +1189,7 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
         assertExactMatch(
             expected: expectedJSON_firstError,
             actual: resultEvents[0],
-            pathOptions: 
+            pathOptions:
                 ValueTypeMatch(paths: "requestEventId", "requestId"),
                 CollectionEqualCount(scope: .subtree))
 

--- a/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
+++ b/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
@@ -45,102 +45,6 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
 
     private let mockNetworkService: MockNetworkService = MockNetworkService()
 
-    /// Used to validate expected element count. Specific values not strictly validated (other than data type).
-    /// Use `pathOption` `CollectionEqualCount(scope: .subtree)` to strictly enforce count.
-    private let expectedJSON_noStoredData = #"""
-    {
-      "events": [
-        {
-          "xdm": {
-            "_id": "STRING_TYPE",
-            "testString": "STRING_TYPE",
-            "timestamp": "STRING_TYPE"
-          }
-        }
-      ],
-      "meta": {
-        "konductorConfig": {
-          "streaming": {
-            "enabled": true,
-            "lineFeed": "STRING_TYPE",
-            "recordSeparator": "STRING_TYPE"
-          }
-        }
-      },
-      "xdm": {
-        "identityMap": {
-          "ECID": [
-            {
-              "authenticatedState": "STRING_TYPE",
-              "id": "STRING_TYPE",
-              "primary": false
-            }
-          ]
-        },
-        "implementationDetails": {
-          "environment": "STRING_TYPE",
-          "name": "STRING_TYPE",
-          "version": "STRING_TYPE"
-        }
-      }
-    }
-    """#
-
-    /// Used to validate `meta.state.entries` using wildcard match since collection items can be in any order and can change
-    /// between runs. Also asserts expected element count.
-    let expectedJSON_withStoredData = #"""
-    {
-      "events": [
-        {
-          "xdm": {
-            "_id": "STRING_TYPE",
-            "testString": "STRING_TYPE",
-            "timestamp": "STRING_TYPE"
-          }
-        }
-      ],
-      "meta": {
-        "konductorConfig": {
-          "streaming": {
-            "enabled": true,
-            "lineFeed": "STRING_TYPE",
-            "recordSeparator": "STRING_TYPE"
-          }
-        },
-        "state": {
-          "entries": [
-            {
-              "key": "kndctr_testOrg_AdobeOrg_identity",
-              "maxAge": 34128000,
-              "value": "hashed_value"
-            },
-            {
-              "key": "kndctr_testOrg_AdobeOrg_consent_check",
-              "maxAge": 7200,
-              "value": "1"
-            }
-          ]
-        }
-      },
-      "xdm": {
-        "identityMap": {
-          "ECID": [
-            {
-              "authenticatedState": "STRING_TYPE",
-              "id": "STRING_TYPE",
-              "primary": false
-            }
-          ]
-        },
-        "implementationDetails": {
-          "environment": "STRING_TYPE",
-          "name": "STRING_TYPE",
-          "version": "STRING_TYPE"
-        }
-      }
-    }
-    """#
-
     // Runs before each test case
     override func setUp() {
         ServiceProvider.shared.networkService = mockNetworkService
@@ -149,7 +53,6 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
 
         continueAfterFailure = true
         TestBase.debugEnabled = true
-        FileManager.default.clearCache()
         FileManager.default.removeAdobeCacheDirectory()
 
         // hub shared state update for 1 extension versions (InstrumentedExtension (registered in TestBase), IdentityEdge, Edge) IdentityEdge XDM, Config, and Edge shared state updates
@@ -416,34 +319,9 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
 
         // Note that `recordSeparator` is set in the format required by the JSON spec to be properly decoded,
         // not the various Swift formats
-        let expectedJSON = #"""
-        {
-          "meta": {
-            "konductorConfig": {
-              "streaming": {
-                "enabled": true,
-                "recordSeparator": "\u0000",
-                "lineFeed": "\n"
-              }
-            }
-          },
-          "xdm": {
-            "identityMap": {
-              "ECID": [
-                {
-                  "id": "STRING_TYPE",
-                  "authenticatedState": "STRING_TYPE",
-                  "primary": true
-                }
-              ]
-            },
-            "implementationDetails": {
-              "environment": "app",
-              "version": "\#(MobileCore.extensionVersion)+\#(Edge.extensionVersion)",
-              "name": "\#(EXPECTED_BASE_PATH)"
-            }
-          },
-          "events": [
+        let expectedJSON = createExpectedPayload(
+            eventsPayload:
+            #"""
             {
               "xdm": {
                 "_id": "STRING_TYPE",
@@ -462,9 +340,9 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
                 }
               }
             }
-          ]
-        }
-        """#
+            """#
+        )
+
         assertExactMatch(
             expected: expectedJSON,
             actual: resultNetworkRequests[0],
@@ -504,58 +382,33 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
         mockNetworkService.assertAllNetworkRequestExpectations()
         let resultNetworkRequests = mockNetworkService.getNetworkRequestsWith(url: TestConstants.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post)
 
-        let expectedJSON = #"""
-        {
-          "meta": {
-            "konductorConfig": {
-              "streaming": {
-                "enabled": true,
-                "recordSeparator": "\u0000",
-                "lineFeed": "\n"
-              }
-            }
-          },
-          "xdm": {
-            "identityMap": {
-              "ECID": [
-                {
-                  "id": "STRING_TYPE",
-                  "authenticatedState": "STRING_TYPE",
-                  "primary": true
-                }
-              ]
-            },
-            "implementationDetails": {
-              "environment": "app",
-              "version": "\#(MobileCore.extensionVersion)+\#(Edge.extensionVersion)",
-              "name": "\#(EXPECTED_BASE_PATH)"
-            }
-          },
-          "events": [
+        let expectedJSON = createExpectedPayload(
+            eventsPayload:
+            #"""
             {
-              "xdm": {
-                "_id": "STRING_TYPE",
-                "timestamp": "STRING_TYPE",
-                "testString": "xdm"
-              },
               "data": {
-                "testDataString": "stringValue",
-                "testDataInt": 101,
-                "testDataBool": true,
-                "testDataDouble": 13.66,
                 "testDataArray": [
                   "arrayElem1",
                   2,
                   true
                 ],
+                "testDataBool": true,
                 "testDataDictionary": {
                   "key": "val"
-                }
+                },
+                "testDataDouble": 13.66,
+                "testDataInt": 101,
+                "testDataString": "stringValue"
+              },
+              "xdm": {
+                "_id": "STRING_TYPE",
+                "testString": "xdm",
+                "timestamp": "STRING_TYPE"
               }
             }
-          ]
-        }
-        """#
+            """#
+        )
+
         assertExactMatch(
             expected: expectedJSON,
             actual: resultNetworkRequests[0],
@@ -599,34 +452,9 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
         mockNetworkService.assertAllNetworkRequestExpectations()
         let resultNetworkRequests = mockNetworkService.getNetworkRequestsWith(url: TestConstants.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post)
 
-        let expectedJSON = #"""
-        {
-          "meta": {
-            "konductorConfig": {
-              "streaming": {
-                "enabled": true,
-                "recordSeparator": "\u0000",
-                "lineFeed": "\n"
-              }
-            }
-          },
-          "xdm": {
-            "identityMap": {
-              "ECID": [
-                {
-                  "id": "STRING_TYPE",
-                  "authenticatedState": "STRING_TYPE",
-                  "primary": true
-                }
-              ]
-            },
-            "implementationDetails": {
-              "environment": "app",
-              "version": "\#(MobileCore.extensionVersion)+\#(Edge.extensionVersion)",
-              "name": "\#(EXPECTED_BASE_PATH)"
-            }
-          },
-          "events": [
+        let expectedJSON = createExpectedPayload(
+            eventsPayload:
+            #"""
             {
               "meta": {
                 "collect": {
@@ -645,9 +473,9 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
                 }
               }
             }
-          ]
-        }
-        """#
+            """#
+        )
+
         assertExactMatch(
             expected: expectedJSON,
             actual: resultNetworkRequests[0],
@@ -823,7 +651,7 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
 
         // Validating element count
         assertTypeMatch(
-            expected: expectedJSON_noStoredData,
+            expected: createExpectedPayload(),
             actual: resultNetworkRequests[0],
             pathOptions: CollectionEqualCount(scope: .subtree))
 
@@ -840,9 +668,28 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
         resultNetworkRequests = mockNetworkService.getNetworkRequestsWith(url: TestConstants.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post)
         XCTAssertEqual(1, resultNetworkRequests.count)
 
+        let expectedJSON = createExpectedPayload(
+            metaPayload: """
+            "state": {
+              "entries": [
+                {
+                  "key": "kndctr_testOrg_AdobeOrg_identity",
+                  "maxAge": 34128000,
+                  "value": "hashed_value"
+                },
+                {
+                  "key": "kndctr_testOrg_AdobeOrg_consent_check",
+                  "maxAge": 7200,
+                  "value": "1"
+                }
+              ]
+            }
+            """
+        )
+
         // NOTE: meta.state.entries can be in any order and can change between runs
         assertTypeMatch(
-            expected: expectedJSON_withStoredData,
+            expected: expectedJSON,
             actual: resultNetworkRequests[0],
             pathOptions:
                 ValueExactMatch(paths: "meta.state.entries", scope: .subtree),
@@ -882,7 +729,7 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
         XCTAssertEqual(1, resultNetworkRequests.count)
 
         assertTypeMatch(
-            expected: expectedJSON_noStoredData,
+            expected: createExpectedPayload(),
             actual: resultNetworkRequests[0],
             pathOptions: CollectionEqualCount(scope: .subtree))
 
@@ -900,8 +747,26 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
         resultNetworkRequests = mockNetworkService.getNetworkRequestsWith(url: TestConstants.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post)
         XCTAssertEqual(1, resultNetworkRequests.count)
 
+        let expectedJSON = createExpectedPayload(
+            metaPayload: """
+            "state": {
+              "entries": [
+                {
+                  "key": "kndctr_testOrg_AdobeOrg_identity",
+                  "maxAge": 34128000,
+                  "value": "hashed_value"
+                },
+                {
+                  "key": "kndctr_testOrg_AdobeOrg_consent_check",
+                  "maxAge": 7200,
+                  "value": "1"
+                }
+              ]
+            }
+            """
+        )
         assertTypeMatch(
-            expected: expectedJSON_withStoredData,
+            expected: expectedJSON,
             actual: resultNetworkRequests[0],
             pathOptions:
                 ValueExactMatch(paths: "meta.state.entries", scope: .subtree),
@@ -938,7 +803,7 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
         XCTAssertEqual(1, resultNetworkRequests.count)
 
         assertTypeMatch(
-            expected: expectedJSON_noStoredData,
+            expected: createExpectedPayload(),
             actual: resultNetworkRequests[0],
             pathOptions: CollectionEqualCount(scope: .subtree))
 
@@ -961,7 +826,7 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
         XCTAssertEqual(1, resultNetworkRequests.count)
 
         assertTypeMatch(
-            expected: expectedJSON_noStoredData,
+            expected: createExpectedPayload(),
             actual: resultNetworkRequests[0],
             pathOptions: CollectionEqualCount(scope: .subtree))
     }
@@ -1520,6 +1385,61 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
          """.data(using: .utf8)
         let decoder = JSONDecoder()
         return try! decoder.decode(EdgeEventError.self, from: data!) // swiftlint:disable:this force_unwrapping
+    }
+
+    /// Generates a JSON string representing a network request payload. It
+    /// allows the injection of custom content for `events` and `meta` sections of the payload.
+    ///
+    /// - Parameters:
+    ///   - eventsPayload: An optional JSON string to be included in the `events` section of the payload.
+    ///                    If `nil`, a default JSON structure with placeholder values is used.
+    ///   - metaPayload: A JSON string to be included in the `meta` section of the payload. Defaults
+    ///                  to an empty string, which means no additional content will be added to the `meta` section.
+    /// - Returns: A JSON string representing the complete network request payload.
+    private func createExpectedPayload(eventsPayload: String? = nil, metaPayload: String = "") -> String {
+        let eventsPayload = eventsPayload ?? """
+        {
+          "xdm": {
+            "_id": "STRING_TYPE",
+            "testString": "STRING_TYPE",
+            "timestamp": "STRING_TYPE"
+          }
+        }
+        """
+
+        return #"""
+        {
+          "events": [
+            \#(eventsPayload)
+          ],
+          "meta": {
+            "konductorConfig": {
+              "streaming": {
+                "enabled": true,
+                "recordSeparator": "\u0000",
+                "lineFeed": "\n"
+              }
+            },
+            \#(metaPayload)
+          },
+          "xdm": {
+            "identityMap": {
+              "ECID": [
+                {
+                  "authenticatedState": "STRING_TYPE",
+                  "id": "STRING_TYPE",
+                  "primary": false
+                }
+              ]
+            },
+            "implementationDetails": {
+              "environment": "app",
+              "version": "\#(MobileCore.extensionVersion)+\#(Edge.extensionVersion)",
+              "name": "\#(EXPECTED_BASE_PATH)"
+            }
+          }
+        }
+        """#
     }
 }
 

--- a/Tests/FunctionalTests/CompletionHandlerFunctionalTests.swift
+++ b/Tests/FunctionalTests/CompletionHandlerFunctionalTests.swift
@@ -40,7 +40,6 @@ class CompletionHandlerFunctionalTests: TestBase, AnyCodableAsserts {
 
         continueAfterFailure = false
         TestBase.debugEnabled = true
-        FileManager.default.clearCache()
         FileManager.default.removeAdobeCacheDirectory()
 
         // wait for async registration because the EventHub is already started in TestBase

--- a/Tests/FunctionalTests/CompletionHandlerFunctionalTests.swift
+++ b/Tests/FunctionalTests/CompletionHandlerFunctionalTests.swift
@@ -19,7 +19,7 @@ import Foundation
 import XCTest
 
 /// End-to-end testing for the AEPEdge public APIs with completion handlers
-class CompletionHandlerFunctionalTests: TestBase {
+class CompletionHandlerFunctionalTests: TestBase, AnyCodableAsserts {
     private let event1 = Event(name: "e1", type: "eventType", source: "eventSource", data: nil)
     private let event2 = Event(name: "e2", type: "eventType", source: "eventSource", data: nil)
     private let responseBody = "{\"test\": \"json\"}"
@@ -41,6 +41,7 @@ class CompletionHandlerFunctionalTests: TestBase {
         continueAfterFailure = false
         TestBase.debugEnabled = true
         FileManager.default.clearCache()
+        FileManager.default.removeAdobeCacheDirectory()
 
         // wait for async registration because the EventHub is already started in TestBase
         let waitForRegistration = CountDownLatch(1)
@@ -89,13 +90,25 @@ class CompletionHandlerFunctionalTests: TestBase {
         XCTAssertEqual(1, receivedHandles.count)
 
         XCTAssertEqual("personalization:decisions", receivedHandles[0].type)
-        XCTAssertEqual(1, receivedHandles[0].payload?.count)
-        let data = flattenDictionary(dict: receivedHandles[0].payload?[0] ?? [:])
-        XCTAssertEqual(4, data.count)
-        XCTAssertEqual("AT:eyJhY3Rpdml0eUlkIjoiMTE3NTg4IiwiZXhwZXJpZW5jZUlkIjoiMSJ9", data["id"] as? String)
-        XCTAssertEqual("#D41DBA", data["items[0].data.content.value"] as? String)
-        XCTAssertEqual("https://ns.adobe.com/personalization/json-content-item", data["items[0].schema"] as? String)
-        XCTAssertEqual("buttonColor", data["scope"] as? String)
+
+        let expectedJSON = #"""
+        {
+          "id": "AT:eyJhY3Rpdml0eUlkIjoiMTE3NTg4IiwiZXhwZXJpZW5jZUlkIjoiMSJ9",
+          "items": [
+            {
+              "data": {
+                "content": {
+                  "value": "#D41DBA"
+                }
+              },
+              "schema": "https://ns.adobe.com/personalization/json-content-item"
+            }
+          ],
+          "scope": "buttonColor"
+        }
+        """#
+
+        assertEqual(expected: expectedJSON, actual: receivedHandles[0].payload?[0])
     }
 
     func testSendEventx2_withCompletionHandler_whenResponseHandle_callsCompletionCorrectly() {

--- a/Tests/FunctionalTests/Edge+ConsentTests.swift
+++ b/Tests/FunctionalTests/Edge+ConsentTests.swift
@@ -67,7 +67,6 @@ class EdgeConsentTests: TestBase, AnyCodableAsserts {
 
         continueAfterFailure = false
         TestBase.debugEnabled = true
-        FileManager.default.clearCache()
         FileManager.default.removeAdobeCacheDirectory()
 
         // hub shared state update for 5 extensions (InstrumentedExtension (registered in TestBase), Configuration, Edge, Consent, Edge Identity)

--- a/Tests/FunctionalTests/Edge+ConsentTests.swift
+++ b/Tests/FunctionalTests/Edge+ConsentTests.swift
@@ -51,8 +51,7 @@ class EdgeConsentTests: TestBase, AnyCodableAsserts {
     private var expectedRecordSeparatorString: String {
         if #available(iOS 17.2, tvOS 17.2, *) {
             return "\0"
-        }
-        else if #available(iOS 17, tvOS 17, *) {
+        } else if #available(iOS 17, tvOS 17, *) {
             return ""
         } else {
             return "\u{0000}"
@@ -272,7 +271,7 @@ class EdgeConsentTests: TestBase, AnyCodableAsserts {
         assertExactMatch(
             expected: expectedJSON,
             actual: consentRequests[0],
-            pathOptions: 
+            pathOptions:
                 ValueTypeMatch(paths: "identityMap.ECID[0].id", "consent[0].value.metadata.time"),
                 CollectionEqualCount(scope: .subtree))
     }

--- a/Tests/FunctionalTests/EdgeDatastreamConfigOverrideTests.swift
+++ b/Tests/FunctionalTests/EdgeDatastreamConfigOverrideTests.swift
@@ -64,7 +64,6 @@ class AEPEdgeDatastreamOverrideTests: TestBase, AnyCodableAsserts {
 
         continueAfterFailure = false
         TestBase.debugEnabled = true
-        FileManager.default.clearCache()
         FileManager.default.removeAdobeCacheDirectory()
 
         // hub shared state update for 1 extension versions (InstrumentedExtension (registered in TestBase), IdentityEdge, Edge) IdentityEdge XDM, Config, and Edge shared state updates
@@ -120,79 +119,41 @@ class AEPEdgeDatastreamOverrideTests: TestBase, AnyCodableAsserts {
         XCTAssertNotNil(requestUrl.queryParam("requestId"))
         XCTAssertEqual("testDatastreamIdOverride", requestUrl.queryParam("configId"))
 
-        let expectedJSON = #"""
-        {
-          "events": [
-            {
-              "data": {
-                "key": "value"
-              },
-              "xdm": {
-                "_id": "STRING_TYPE",
-                "test": {
-                  "key": "value"
+        let expectedJSON = createExpectedPayload(
+            metaProperties: 
+            """
+              "configOverrides": {
+                "com_adobe_analytics": {
+                  "reportSuites": [
+                    "rsid1",
+                    "rsid2",
+                    "rsid3"
+                  ]
                 },
-                "timestamp": "STRING_TYPE"
-              }
-            }
-          ],
-          "meta": {
-            "configOverrides": {
-              "com_adobe_analytics": {
-                "reportSuites": [
-                  "rsid1",
-                  "rsid2",
-                  "rsid3"
-                ]
-              },
-              "com_adobe_experience_platform": {
-                "datasets": {
-                  "event": {
-                    "datasetId": "eventDatasetIdOverride"
-                  },
-                  "profile": {
-                    "datasetId": "profileDatasetIdOverride"
+                "com_adobe_experience_platform": {
+                  "datasets": {
+                    "event": {
+                      "datasetId": "eventDatasetIdOverride"
+                    },
+                    "profile": {
+                      "datasetId": "profileDatasetIdOverride"
+                    }
                   }
+                },
+                "com_adobe_identity": {
+                  "idSyncContainerId": "1234567"
+                },
+                "com_adobe_target": {
+                  "propertyToken": "samplePropertyToken"
                 }
               },
-              "com_adobe_identity": {
-                "idSyncContainerId": "1234567"
-              },
-              "com_adobe_target": {
-                "propertyToken": "samplePropertyToken"
-              }
-            },
-            "konductorConfig": {
-              "streaming": {
-                "enabled": true,
-                "lineFeed": "STRING_TYPE",
-                "recordSeparator": "STRING_TYPE"
-              }
-            },
-            "sdkConfig": {
-              "datastream": {
-                "original": "originalDatastreamId"
-              }
-            }
-          },
-          "xdm": {
-            "identityMap": {
-              "ECID": [
-                {
-                  "authenticatedState": "STRING_TYPE",
-                  "id": "STRING_TYPE",
-                  "primary": false
+              "sdkConfig": {
+                "datastream": {
+                  "original": "originalDatastreamId"
                 }
-              ]
-            },
-            "implementationDetails": {
-              "environment": "app",
-              "name": "\#(EXPECTED_BASE_PATH)",
-              "version": "\#(MobileCore.extensionVersion)+\#(Edge.extensionVersion)"
-            }
-          }
-        }
-        """#
+              }
+            """
+        )
 
         assertExactMatch(
             expected: expectedJSON,
@@ -232,54 +193,16 @@ class AEPEdgeDatastreamOverrideTests: TestBase, AnyCodableAsserts {
         XCTAssertNotNil(requestUrl.queryParam("requestId"))
         XCTAssertEqual("testDatastreamIdOverride", requestUrl.queryParam("configId"))
 
-        let expectedJSON = #"""
-        {
-          "events": [
-            {
-              "data": {
-                "key": "value"
-              },
-              "xdm": {
-                "_id": "STRING_TYPE",
-                "test": {
-                  "key": "value"
-                },
-                "timestamp": "STRING_TYPE"
-              }
-            }
-          ],
-          "meta": {
-            "konductorConfig": {
-              "streaming": {
-                "enabled": true,
-                "lineFeed": "STRING_TYPE",
-                "recordSeparator": "STRING_TYPE"
-              }
-            },
-            "sdkConfig": {
-              "datastream": {
-                "original": "originalDatastreamId"
-              }
-            }
-          },
-          "xdm": {
-            "identityMap": {
-              "ECID": [
-                {
-                  "authenticatedState": "STRING_TYPE",
-                  "id": "STRING_TYPE",
-                  "primary": false
-                }
-              ]
-            },
-            "implementationDetails": {
-              "environment": "app",
-              "name": "\#(EXPECTED_BASE_PATH)",
-              "version": "\#(MobileCore.extensionVersion)+\#(Edge.extensionVersion)"
-            }
-          }
-        }
-        """#
+        let expectedJSON = createExpectedPayload(
+            metaProperties: 
+            """
+             "sdkConfig": {
+               "datastream": {
+                 "original": "originalDatastreamId"
+               }
+             }
+            """
+        )
 
         assertExactMatch(
             expected: expectedJSON,
@@ -321,7 +244,61 @@ class AEPEdgeDatastreamOverrideTests: TestBase, AnyCodableAsserts {
 
         XCTAssertEqual("originalDatastreamId", requestUrl.queryParam("configId"))
 
-        let expectedJSON = #"""
+        let expectedJSON = createExpectedPayload(
+            metaProperties:
+            """
+              "configOverrides": {
+                "com_adobe_analytics": {
+                  "reportSuites": [
+                    "rsid1",
+                    "rsid2",
+                    "rsid3"
+                  ]
+                },
+                "com_adobe_experience_platform": {
+                  "datasets": {
+                    "event": {
+                      "datasetId": "eventDatasetIdOverride"
+                    },
+                    "profile": {
+                      "datasetId": "profileDatasetIdOverride"
+                    }
+                  }
+                },
+                "com_adobe_identity": {
+                  "idSyncContainerId": "1234567"
+                },
+                "com_adobe_target": {
+                  "propertyToken": "samplePropertyToken"
+                }
+              }
+            """
+        )
+
+        assertExactMatch(
+            expected: expectedJSON,
+            actual: resultNetworkRequests[0],
+            pathOptions:
+                ValueTypeMatch(paths:
+                   "events[0].xdm._id",
+                   "events[0].xdm.timestamp",
+                   "meta.konductorConfig.streaming.lineFeed",
+                   "meta.konductorConfig.streaming.recordSeparator",
+                   "xdm.identityMap.ECID[0].authenticatedState",
+                   "xdm.identityMap.ECID[0].id",
+                   "xdm.identityMap.ECID[0].primary"),
+                CollectionEqualCount(scope: .subtree))
+    }
+
+    /// Generates a JSON string representing a network request payload. It
+    /// allows the injection of custom content for the `meta` section of the payload.
+    ///
+    /// - Parameters:
+    ///   - metaPayload: A JSON string to be included in the `meta` section of the payload. Defaults
+    ///                  to an empty string, which means no additional content will be added to the `meta` section.
+    /// - Returns: A JSON string representing the complete network request payload.
+    private func createExpectedPayload(metaProperties: String = "") -> String {
+        return """
         {
           "events": [
             {
@@ -338,38 +315,14 @@ class AEPEdgeDatastreamOverrideTests: TestBase, AnyCodableAsserts {
             }
           ],
           "meta": {
-            "configOverrides": {
-              "com_adobe_analytics": {
-                "reportSuites": [
-                  "rsid1",
-                  "rsid2",
-                  "rsid3"
-                ]
-              },
-              "com_adobe_experience_platform": {
-                "datasets": {
-                  "event": {
-                    "datasetId": "eventDatasetIdOverride"
-                  },
-                  "profile": {
-                    "datasetId": "profileDatasetIdOverride"
-                  }
-                }
-              },
-              "com_adobe_identity": {
-                "idSyncContainerId": "1234567"
-              },
-              "com_adobe_target": {
-                "propertyToken": "samplePropertyToken"
-              }
-            },
             "konductorConfig": {
               "streaming": {
                 "enabled": true,
                 "lineFeed": "STRING_TYPE",
                 "recordSeparator": "STRING_TYPE"
               }
-            }
+            },
+            \(metaProperties)
           },
           "xdm": {
             "identityMap": {
@@ -377,31 +330,17 @@ class AEPEdgeDatastreamOverrideTests: TestBase, AnyCodableAsserts {
                 {
                   "authenticatedState": "STRING_TYPE",
                   "id": "STRING_TYPE",
-                  "primary": true
+                  "primary": false
                 }
               ]
             },
             "implementationDetails": {
               "environment": "app",
-              "name": "\#(EXPECTED_BASE_PATH)",
-              "version": "\#(MobileCore.extensionVersion)+\#(Edge.extensionVersion)"
+              "name": "\(self.EXPECTED_BASE_PATH)",
+              "version": "\(MobileCore.extensionVersion)+\(Edge.extensionVersion)"
             }
           }
         }
-        """#
-
-        assertExactMatch(
-            expected: expectedJSON,
-            actual: resultNetworkRequests[0],
-            pathOptions:
-                ValueTypeMatch(paths:
-                   "events[0].xdm._id",
-                   "events[0].xdm.timestamp",
-                   "meta.konductorConfig.streaming.lineFeed",
-                   "meta.konductorConfig.streaming.recordSeparator",
-                   "xdm.identityMap.ECID[0].authenticatedState",
-                   "xdm.identityMap.ECID[0].id",
-                   "xdm.identityMap.ECID[0].primary"),
-                CollectionEqualCount(scope: .subtree))
+        """
     }
 }

--- a/Tests/FunctionalTests/EdgeDatastreamConfigOverrideTests.swift
+++ b/Tests/FunctionalTests/EdgeDatastreamConfigOverrideTests.swift
@@ -120,7 +120,6 @@ class AEPEdgeDatastreamOverrideTests: TestBase, AnyCodableAsserts {
         XCTAssertNotNil(requestUrl.queryParam("requestId"))
         XCTAssertEqual("testDatastreamIdOverride", requestUrl.queryParam("configId"))
 
-
         let expectedJSON = #"""
         {
           "events": [

--- a/Tests/FunctionalTests/EdgeDatastreamConfigOverrideTests.swift
+++ b/Tests/FunctionalTests/EdgeDatastreamConfigOverrideTests.swift
@@ -120,7 +120,7 @@ class AEPEdgeDatastreamOverrideTests: TestBase, AnyCodableAsserts {
         XCTAssertEqual("testDatastreamIdOverride", requestUrl.queryParam("configId"))
 
         let expectedJSON = createExpectedPayload(
-            metaProperties: 
+            metaProperties:
             """
               "configOverrides": {
                 "com_adobe_analytics": {
@@ -194,7 +194,7 @@ class AEPEdgeDatastreamOverrideTests: TestBase, AnyCodableAsserts {
         XCTAssertEqual("testDatastreamIdOverride", requestUrl.queryParam("configId"))
 
         let expectedJSON = createExpectedPayload(
-            metaProperties: 
+            metaProperties:
             """
              "sdkConfig": {
                "datastream": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR updates the first portion of Edge functional tests to use the JSON comparison system. Broadly, it replaces dictionary flattening with JSON comparison. Specific changes:
1. If flattened dictionary count was applied, then strict collection count checks are applied throughout the JSON validation when using the extensible comparison methods `assertExactMatch`/`assertTypeMatch` - that is, the refactor should preserve the same level of strictness for the payload being tested
2. Everywhere `FileManager.default.clearCache()` is used, `FileManager.default.removeAdobeCacheDirectory()` was also added (given Core's new persistence handling)

## Questions for reviewers
`testSendEvent_receivesResponseEventHandle_sendsResponseEvent_pairedWithTheRequestEventId`
1. Can `let requestId = resultNetworkRequests[0].url.queryParam("requestId")` ever be nil? Should that be strictly validated? Currently the refactor sets the fallback value to `"'`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
