### PR TITLE
Cache configuration with Edge hit (resolves #367)

### DIFF
--- a/AEPEdge.xcodeproj/project.pbxproj
+++ b/AEPEdge.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		BF947F9E244182B30057A6CC /* StoreResponsePayloadManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF947F9424414E3E0057A6CC /* StoreResponsePayloadManagerTests.swift */; };
 		BF947FA0244569190057A6CC /* EdgeRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF947F9F244569190057A6CC /* EdgeRequestTests.swift */; };
 		BF947FA4244613FB0057A6CC /* RequestMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF947FA3244613FB0057A6CC /* RequestMetadataTests.swift */; };
+		BFDF25AB2BD02E58002114B6 /* EdgeQueuedEntityFunctionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFDF25AA2BD02E58002114B6 /* EdgeQueuedEntityFunctionalTests.swift */; };
 		BFEEB5AB28D4E35D00B668B8 /* EdgePublicAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D45F2E8125EE1987000AC350 /* EdgePublicAPITests.swift */; };
 		D4000F35245A53FB0052C536 /* EdgeNetworkServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4000F34245A53FB0052C536 /* EdgeNetworkServiceTests.swift */; };
 		D4145F4025D1D3200019EA4C /* EdgeHitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4145F3F25D1D3200019EA4C /* EdgeHitTests.swift */; };
@@ -279,6 +280,7 @@
 		BF947F9424414E3E0057A6CC /* StoreResponsePayloadManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreResponsePayloadManagerTests.swift; sourceTree = "<group>"; };
 		BF947F9F244569190057A6CC /* EdgeRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeRequestTests.swift; sourceTree = "<group>"; };
 		BF947FA3244613FB0057A6CC /* RequestMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestMetadataTests.swift; sourceTree = "<group>"; };
+		BFDF25AA2BD02E58002114B6 /* EdgeQueuedEntityFunctionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeQueuedEntityFunctionalTests.swift; sourceTree = "<group>"; };
 		C6F54D018682F0FF8E74A16F /* Pods-UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.debug.xcconfig"; path = "Target Support Files/Pods-UnitTests/Pods-UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C71524CA05BF6E5102E01187 /* Pods-E2EFunctionalTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-E2EFunctionalTests.debug.xcconfig"; path = "Target Support Files/Pods-E2EFunctionalTests/Pods-E2EFunctionalTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C9510E11CC3DB2C62D9D17C0 /* Pods-UpstreamIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UpstreamIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-UpstreamIntegrationTests/Pods-UpstreamIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -617,6 +619,7 @@
 				4CBEE6222A1577E40084BC50 /* NoConfigFunctionalTests.swift */,
 				4CBEE6242A157CB40084BC50 /* SampleFunctionalTests.swift */,
 				D4D5B53724325AB700CAB6E4 /* Info.plist */,
+				BFDF25AA2BD02E58002114B6 /* EdgeQueuedEntityFunctionalTests.swift */,
 			);
 			name = FunctionalTests;
 			path = Tests/FunctionalTests;
@@ -1351,6 +1354,7 @@
 				4CBEE61B2A1572E50084BC50 /* Edge+PublicAPITests.swift in Sources */,
 				4CBEE6192A1571DC0084BC50 /* Edge+ConsentTests.swift in Sources */,
 				D48CBD2224A17EEA00A24BD8 /* TestXDMSchema.swift in Sources */,
+				BFDF25AB2BD02E58002114B6 /* EdgeQueuedEntityFunctionalTests.swift in Sources */,
 				4CBEE6252A157CB40084BC50 /* SampleFunctionalTests.swift in Sources */,
 				2ECFB7522AB391F400653128 /* EdgeDatastreamConfigOverrideTests.swift in Sources */,
 				4CBEE61D2A1574CE0084BC50 /* EdgePathOverwriteTests.swift in Sources */,

--- a/AEPEdge.xcodeproj/project.pbxproj
+++ b/AEPEdge.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		BF947FA0244569190057A6CC /* EdgeRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF947F9F244569190057A6CC /* EdgeRequestTests.swift */; };
 		BF947FA4244613FB0057A6CC /* RequestMetadataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF947FA3244613FB0057A6CC /* RequestMetadataTests.swift */; };
 		BFDF25AB2BD02E58002114B6 /* EdgeQueuedEntityFunctionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFDF25AA2BD02E58002114B6 /* EdgeQueuedEntityFunctionalTests.swift */; };
+		BFDF25AD2BDB077E002114B6 /* SharedStateReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFDF25AC2BDB077E002114B6 /* SharedStateReader.swift */; };
 		BFEEB5AB28D4E35D00B668B8 /* EdgePublicAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D45F2E8125EE1987000AC350 /* EdgePublicAPITests.swift */; };
 		D4000F35245A53FB0052C536 /* EdgeNetworkServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4000F34245A53FB0052C536 /* EdgeNetworkServiceTests.swift */; };
 		D4145F4025D1D3200019EA4C /* EdgeHitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4145F3F25D1D3200019EA4C /* EdgeHitTests.swift */; };
@@ -281,6 +282,7 @@
 		BF947F9F244569190057A6CC /* EdgeRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeRequestTests.swift; sourceTree = "<group>"; };
 		BF947FA3244613FB0057A6CC /* RequestMetadataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestMetadataTests.swift; sourceTree = "<group>"; };
 		BFDF25AA2BD02E58002114B6 /* EdgeQueuedEntityFunctionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeQueuedEntityFunctionalTests.swift; sourceTree = "<group>"; };
+		BFDF25AC2BDB077E002114B6 /* SharedStateReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStateReader.swift; sourceTree = "<group>"; };
 		C6F54D018682F0FF8E74A16F /* Pods-UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.debug.xcconfig"; path = "Target Support Files/Pods-UnitTests/Pods-UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C71524CA05BF6E5102E01187 /* Pods-E2EFunctionalTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-E2EFunctionalTests.debug.xcconfig"; path = "Target Support Files/Pods-E2EFunctionalTests/Pods-E2EFunctionalTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C9510E11CC3DB2C62D9D17C0 /* Pods-UpstreamIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UpstreamIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-UpstreamIntegrationTests/Pods-UpstreamIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -502,6 +504,7 @@
 				BF947F8E2440F0940057A6CC /* StateMetadata.swift */,
 				BF947F85243F24570057A6CC /* StoreResponsePayload.swift */,
 				BF947F92244126D70057A6CC /* StoreResponsePayloadManager.swift */,
+				BFDF25AC2BDB077E002114B6 /* SharedStateReader.swift */,
 			);
 			path = EdgeNetworkHandlers;
 			sourceTree = "<group>";
@@ -1267,6 +1270,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D4EC0DBB25E73FF10026EBAA /* EdgeState.swift in Sources */,
+				BFDF25AD2BDB077E002114B6 /* SharedStateReader.swift in Sources */,
 				BF0F924F27476E6C00378913 /* ImplementationDetails.swift in Sources */,
 				D4C6B437251A76CB0038F4F9 /* XDMProtocols.swift in Sources */,
 				D4C6B438251A76CB0038F4F9 /* Edge+PublicAPI.swift in Sources */,

--- a/Sources/Edge.swift
+++ b/Sources/Edge.swift
@@ -129,7 +129,7 @@ public class Edge: NSObject, Extension {
                 $0.key == EdgeConstants.SharedState.Configuration.EDGE_DOMAIN
         } as [String: Any]
 
-        if edgeConfig[EdgeConstants.SharedState.Configuration.CONFIG_ID] == nil || (edgeConfig[EdgeConstants.SharedState.Configuration.CONFIG_ID] as? String ?? "").isEmpty {
+        if (edgeConfig[EdgeConstants.SharedState.Configuration.CONFIG_ID] as? String ?? "").isEmpty {
             Log.warning(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Unable to process the event '\(event.id.uuidString)', Configuration is missing edge.configId.")
             return // drop current event
         }

--- a/Sources/Edge.swift
+++ b/Sources/Edge.swift
@@ -237,7 +237,6 @@ public class Edge: NSObject, Extension {
         let hitProcessor = EdgeHitProcessor(networkService: networkService,
                                             networkResponseHandler: networkResponseHandler,
                                             getSharedState: getSharedState(extensionName:event:),
-                                            getXDMSharedState: getXDMSharedState(extensionName:event:barrier:),
                                             readyForEvent: readyForEvent(_:),
                                             getImplementationDetails: getImplementationDetails,
                                             getLocationHint: getLocationHint,

--- a/Sources/Edge.swift
+++ b/Sources/Edge.swift
@@ -96,27 +96,21 @@ public class Edge: NSObject, Extension {
     /// - Parameter event: an event containing ExperienceEvent data for processing
     func handleExperienceEventRequest(_ event: Event) {
         guard !shouldIgnore(event: event) else { return }
-
-        guard let data = event.data, !data.isEmpty else {
-            Log.trace(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Event with id \(event.id.uuidString) contained no data, ignoring.")
-            return
-        }
-
         processAndQueueEvent(event: event)
     }
 
     /// Handles the Consent Update event
     /// - Parameter event: current event to process
     func handleConsentUpdate(_ event: Event) {
-        guard let data = event.data, !data.isEmpty else {
-            Log.trace(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Consent update request event \(event.id.uuidString) contained no data, ignoring.")
-            return
-        }
-
         processAndQueueEvent(event: event)
     }
 
     private func processAndQueueEvent(event: Event) {
+        guard let data = event.data, !data.isEmpty else {
+            Log.trace(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Event with id \(event.id.uuidString) contains no data, ignoring.")
+            return
+        }
+
         // get Configuration shared state, this should be resolved based on readyForEvent check
         guard let edgeConfig = getEdgeConfig(event: event) else {
             Log.warning(label: EdgeConstants.LOG_TAG,

--- a/Sources/Edge.swift
+++ b/Sources/Edge.swift
@@ -117,20 +117,10 @@ public class Edge: NSObject, Extension {
     }
 
     private func processAndQueueEvent(event: Event) {
-        // get configuration needed for Edge hit, this should be resolved based on readForEvent check
-        guard let configurationState = getSharedState(extensionName: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME, event: event)?.value else {
-            Log.warning(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Unable to process the event '\(event.id.uuidString)', Configuration shared state is nil.")
-            return // drop current event
-        }
-
-        let edgeConfig = configurationState.filter {
-            return $0.key == EdgeConstants.SharedState.Configuration.CONFIG_ID ||
-                $0.key == EdgeConstants.SharedState.Configuration.EDGE_ENVIRONMENT ||
-                $0.key == EdgeConstants.SharedState.Configuration.EDGE_DOMAIN
-        } as [String: Any]
-
-        if (edgeConfig[EdgeConstants.SharedState.Configuration.CONFIG_ID] as? String ?? "").isEmpty {
-            Log.warning(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Unable to process the event '\(event.id.uuidString)', Configuration is missing edge.configId.")
+        // get Configuration shared state, this should be resolved based on readyForEvent check
+        guard let edgeConfig = getEdgeConfig(event: event) else {
+            Log.warning(label: EdgeConstants.LOG_TAG,
+                        "\(SELF_TAG) - Unable to process the event '\(event.id.uuidString)', either Configuration is not set or is missing 'edge.configId'.")
             return // drop current event
         }
 
@@ -298,4 +288,27 @@ public class Edge: NSObject, Extension {
         return state?.getLocationHint()
     }
 
+    /// Get the Edge configuration by quering the Configuration shared state and filtering out only the key needed for Edge requests.
+    /// - Parameter event: the `Event` to get the configuration
+    /// - Returns: A dictionary of Edge configuration values, or nil if the Configuration shared state could not be retrieved or if the `edge.configId` key is missing or empty.
+    private func getEdgeConfig(event: Event) -> [String: Any]? {
+        // get configuration needed for Edge hit, this should be resolved based on readForEvent check
+        guard let configurationState = getSharedState(extensionName: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME, event: event)?.value else {
+            Log.trace(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Configuration shared state is nil for event '\(event.id.uuidString)'.")
+            return nil
+        }
+
+        let edgeConfig = configurationState.filter {
+            return $0.key == EdgeConstants.SharedState.Configuration.CONFIG_ID ||
+                $0.key == EdgeConstants.SharedState.Configuration.EDGE_ENVIRONMENT ||
+                $0.key == EdgeConstants.SharedState.Configuration.EDGE_DOMAIN
+        } as [String: Any]
+
+        if (edgeConfig[EdgeConstants.SharedState.Configuration.CONFIG_ID] as? String ?? "").isEmpty {
+            Log.trace(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Configuration is missing edge.configId for event '\(event.id.uuidString)'.")
+            return nil
+        }
+
+        return edgeConfig
+    }
 }

--- a/Sources/EdgeNetworkHandlers/EdgeDataEntity.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeDataEntity.swift
@@ -19,6 +19,9 @@ struct EdgeDataEntity: Codable {
     /// The `Event` responsible for the hit
     let event: Event
 
+    /// The current configuration shared state at the time `Event` was queued
+    let configuration: [String: AnyCodable]
+
     /// The current identity shared state at the time `Event` was queued
     let identityMap: [String: AnyCodable]
 }

--- a/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
@@ -20,7 +20,6 @@ class EdgeHitProcessor: HitProcessing {
     private var networkService: EdgeNetworkService
     private var networkResponseHandler: NetworkResponseHandler
     private var getSharedState: (String, Event?) -> SharedStateResult?
-    private var getXDMSharedState: (String, Event?, Bool) -> SharedStateResult?
     private var readyForEvent: (Event) -> Bool
     private var getImplementationDetails: () -> [String: Any]?
     private var getLocationHint: () -> String?
@@ -31,7 +30,6 @@ class EdgeHitProcessor: HitProcessing {
     init(networkService: EdgeNetworkService,
          networkResponseHandler: NetworkResponseHandler,
          getSharedState: @escaping (String, Event?) -> SharedStateResult?,
-         getXDMSharedState: @escaping (String, Event?, Bool) -> SharedStateResult?,
          readyForEvent: @escaping (Event) -> Bool,
          getImplementationDetails: @escaping () -> [String: Any]?,
          getLocationHint: @escaping () -> String?,
@@ -39,7 +37,6 @@ class EdgeHitProcessor: HitProcessing {
         self.networkService = networkService
         self.networkResponseHandler = networkResponseHandler
         self.getSharedState = getSharedState
-        self.getXDMSharedState = getXDMSharedState
         self.readyForEvent = readyForEvent
         self.getImplementationDetails = getImplementationDetails
         self.getLocationHint = getLocationHint

--- a/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
@@ -113,7 +113,7 @@ class EdgeHitProcessor: HitProcessing {
         guard var datastreamId = edgeConfig[EdgeConstants.SharedState.Configuration.CONFIG_ID], !datastreamId.isEmpty else {
             Log.warning(label: EdgeConstants.LOG_TAG,
                         "\(SELF_TAG) - Unable to process the event '\(event.id.uuidString)' " +
-                            "due to invalid edge.configId in configuration.")
+                            "due to missing or empty edge.configId in configuration.")
             completion(true)
             return // drop the current event
         }
@@ -180,7 +180,7 @@ class EdgeHitProcessor: HitProcessing {
         guard let datastreamId = edgeConfig[EdgeConstants.SharedState.Configuration.CONFIG_ID], !datastreamId.isEmpty else {
             Log.warning(label: EdgeConstants.LOG_TAG,
                         "\(SELF_TAG) - Unable to process the event '\(event.id.uuidString)' " +
-                            "due to invalid edge.configId in configuration.")
+                            "due to missing or empty edge.configId in configuration.")
             completion(true)
             return // drop current event
         }

--- a/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
@@ -64,7 +64,10 @@ class EdgeHitProcessor: HitProcessing {
         var edgeConfig: [String: String]
 
         // Check which workflow is used to obtain configuration
-        if edgeEntity.configuration.isEmpty {
+        if !edgeEntity.configuration.isEmpty {
+            // Current workflow includes needed configuration in EdgeDataEntity before queuing hit
+            edgeConfig = AnyCodable.toAnyDictionary(dictionary: edgeEntity.configuration) as? [String: String] ?? [:]
+        } else {
             // Older workflow is supported in cases where persisted hits were queued before upgrade, but processed after upgrade
             // These hits will not have configuration in EdgeDataEntity, so the Configuration shared state is queried
             guard readyForEvent(event) else {
@@ -74,9 +77,6 @@ class EdgeHitProcessor: HitProcessing {
             }
 
             edgeConfig = getEdgeConfig(event: event)
-        } else {
-            // Current workflow includes needed configuration in EdgeDataEntity before queuing hit
-            edgeConfig = AnyCodable.toAnyDictionary(dictionary: edgeEntity.configuration) as? [String: String] ?? [:]
         }
 
         // Build Request object

--- a/Sources/EdgeNetworkHandlers/SharedStateReader.swift
+++ b/Sources/EdgeNetworkHandlers/SharedStateReader.swift
@@ -23,7 +23,7 @@ struct SharedStateReader {
 
     /// Get the Edge configuration by quering the Configuration shared state and filtering out only the key needed for Edge requests.
     /// - Parameter event: the `Event` to get the configuration
-    /// - Returns: A dictionary of Edge configuration values, or nil if the Configuration shared state could not be retrieved or if the `edge.configId` key is missing or empty.
+    /// - Returns: A dictionary of Edge configuration values, or empty dictionary if the Configuration shared state could not be retrieved.
     func getEdgeConfig(event: Event) -> [String: String] {
         guard let configurationState = getSharedState(EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME, event, false)?.value else {
             Log.trace(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Configuration shared state is nil for event '\(event.id.uuidString)'.")

--- a/Sources/EdgeNetworkHandlers/SharedStateReader.swift
+++ b/Sources/EdgeNetworkHandlers/SharedStateReader.swift
@@ -1,0 +1,53 @@
+//
+// Copyright 2024 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+import AEPCore
+import AEPServices
+
+struct SharedStateReader {
+    private let SELF_TAG = "SharedStateReader"
+    private var getSharedState: (String, Event?, Bool) -> SharedStateResult?
+
+    init(getSharedState: @escaping (String, Event?, Bool) -> SharedStateResult?) {
+        self.getSharedState = getSharedState
+    }
+
+    /// Get the Edge configuration by quering the Configuration shared state and filtering out only the key needed for Edge requests.
+    /// - Parameter event: the `Event` to get the configuration
+    /// - Returns: A dictionary of Edge configuration values, or nil if the Configuration shared state could not be retrieved or if the `edge.configId` key is missing or empty.
+    func getEdgeConfig(event: Event) -> [String: String] {
+        guard let configurationState = getSharedState(EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME, event, false)?.value else {
+            Log.trace(label: EdgeConstants.LOG_TAG, "\(SELF_TAG) - Configuration shared state is nil for event '\(event.id.uuidString)'.")
+            return [:]
+        }
+
+        let edgeConfig = configurationState.filter {
+            return $0.key == EdgeConstants.SharedState.Configuration.CONFIG_ID ||
+                $0.key == EdgeConstants.SharedState.Configuration.EDGE_ENVIRONMENT ||
+                $0.key == EdgeConstants.SharedState.Configuration.EDGE_DOMAIN
+        } as? [String: String]
+
+        return edgeConfig ?? [:]
+    }
+
+    /// Get the Assurance integration ID from the Assurance shared state for the given `event`.
+    /// - Parameter event: the `Event` used to retrieve the Assurance shared state.
+    /// - Returns: the `integrationid` from the Assurance shared state or nil if the shared state or integration id is does not exist.
+    func getAssuranceIntegrationId(event: Event) -> String? {
+        if let assuranceSharedState = getSharedState(EdgeConstants.SharedState.Assurance.STATE_OWNER_NAME, event, false)?.value {
+            if let assuranceIntegrationId = assuranceSharedState[EdgeConstants.SharedState.Assurance.INTEGRATION_ID] as? String {
+                return assuranceIntegrationId
+            }
+        }
+        return nil
+    }
+}

--- a/Tests/FunctionalTests/EdgeQueuedEntityFunctionalTests.swift
+++ b/Tests/FunctionalTests/EdgeQueuedEntityFunctionalTests.swift
@@ -1,0 +1,156 @@
+//
+// Copyright 2024 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+@testable import AEPCore
+@testable import AEPEdge
+import AEPEdgeIdentity
+@testable import AEPServices
+import AEPTestUtils
+import Foundation
+import XCTest
+
+class EdgeQueuedEntityFunctionalTests: TestBase, AnyCodableAsserts {
+
+    private let exEdgeInteractProdUrl = URL(string: TestConstants.EX_EDGE_INTERACT_PROD_URL_STR)! // swiftlint:disable:this force_unwrapping
+
+    private let mockNetworkService: MockNetworkService = MockNetworkService()
+
+    override func setUp() {
+        ServiceProvider.shared.networkService = mockNetworkService
+
+        super.setUp()
+
+        continueAfterFailure = true
+        TestBase.debugEnabled = true
+        NamedCollectionDataStore.clear()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        mockNetworkService.reset()
+        resetTestExpectations()
+    }
+
+    // Tests a queued data entity which does not contain Edge configuration is processed using "old" path which
+    // sets the Edge configuration when hit is processed instead of when hit is queued.
+    // Requires Edge version 5.0.1
+    func testQueuedDataEntity_withoutEdgeConfiguration_isSentWhenEdgeStarts_usesConfigIdFromSharedState() {
+        // Add EdgeDataEntity without configuration to data queue
+        // Simulates hit queued from previous session
+        guard let dataQueue = getDataQueue() else {
+            XCTFail("Failed to get DataQueue.")
+            return
+        }
+
+        let experienceEvent = Event(name: "test-experience-event", type: EventType.edge, source: EventSource.requestContent, data: ["xdm": ["test": "data"]])
+        let edgeEntity = EdgeDataEntity(event: experienceEvent, configuration: [:], identityMap: [:])
+        let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
+
+        dataQueue.add(dataEntity: entity)
+
+        // Setup network response and expected network requests
+        let responseConnection: HttpConnection = HttpConnection(data: "{\"test\": \"json\"}".data(using: .utf8),
+                                                                response: HTTPURLResponse(url: exEdgeInteractProdUrl,
+                                                                                          statusCode: 200,
+                                                                                          httpVersion: nil,
+                                                                                          headerFields: nil),
+                                                                error: nil)
+        mockNetworkService.setMockResponse(url: TestConstants.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post, responseConnection: responseConnection)
+        mockNetworkService.setExpectationForNetworkRequest(url: TestConstants.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post, expectedCount: 1)
+
+        // Start SDK, which will then process queue
+        startMobileSDK()
+
+        // Wait for expected network requests
+        mockNetworkService.assertAllNetworkRequestExpectations()
+        let resultNetworkRequests = mockNetworkService.getNetworkRequestsWith(url: TestConstants.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post)
+
+        // Validate result - hit uses configId from Configuration shared state
+        XCTAssertEqual(1, resultNetworkRequests.count)
+        XCTAssertEqual("12345-example", resultNetworkRequests[0].url.queryParam("configId"))
+
+    }
+
+    // Tests two queued data entities, one without an Edge Configuration and one with an Edge Configuration.
+    // Validates the queued entity uses the configId from the Configuration shared state while
+    // the other uses the configId contained in the data entity.
+    // Requires Edge version 5.0.1
+    func testQueuedDataEntity_withAndWithoutEdgeConfiguration_isSentWhenEdgeStart_usesCorrectConfigId() {
+        // Add EdgeDataEntity to data queue
+        // Simulates hit queued from previous session
+        guard let dataQueue = getDataQueue() else {
+            XCTFail("Failed to get DataQueue.")
+            return
+        }
+
+        let experienceEvent = Event(name: "test-experience-event", type: EventType.edge, source: EventSource.requestContent, data: ["xdm": ["test": "data"]])
+        var edgeEntity = EdgeDataEntity(event: experienceEvent, configuration: [:], identityMap: [:])
+        var entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
+
+        dataQueue.add(dataEntity: entity) // Add DataEntity without configuration
+
+        edgeEntity = EdgeDataEntity(event: experienceEvent, configuration: ["edge.configId": "sample-configId"], identityMap: [:])
+        entity = DataEntity(uniqueIdentifier: "test-uuid2", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
+
+        dataQueue.add(dataEntity: entity) // Add DataEntity with configuration
+
+        // Setup network response and expected network requests
+        let responseConnection: HttpConnection = HttpConnection(data: "{\"test\": \"json\"}".data(using: .utf8),
+                                                                response: HTTPURLResponse(url: exEdgeInteractProdUrl,
+                                                                                          statusCode: 200,
+                                                                                          httpVersion: nil,
+                                                                                          headerFields: nil),
+                                                                error: nil)
+        mockNetworkService.setMockResponse(url: TestConstants.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post, responseConnection: responseConnection)
+        mockNetworkService.setExpectationForNetworkRequest(url: TestConstants.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post, expectedCount: 2)
+
+        // Start SDK, which will then process queue
+        startMobileSDK()
+
+        // Wait for expected network requests
+        mockNetworkService.assertAllNetworkRequestExpectations()
+        let resultNetworkRequests = mockNetworkService.getNetworkRequestsWith(url: TestConstants.EX_EDGE_INTERACT_PROD_URL_STR, httpMethod: HttpMethod.post)
+
+        // Validate result
+        XCTAssertEqual(2, resultNetworkRequests.count)
+        // First hit uses configId from Configuration shared state
+        XCTAssertEqual("12345-example", resultNetworkRequests[0].url.queryParam("configId"))
+        // Second hit uses configId from EdgeDataEntity
+        XCTAssertEqual("sample-configId", resultNetworkRequests[1].url.queryParam("configId"))
+    }
+
+    private func startMobileSDK() {
+        // hub shared state update for 1 extension versions (InstrumentedExtension (registered in TestBase), IdentityEdge, Edge) IdentityEdge XDM, Config, and Edge shared state updates
+        setExpectationEvent(type: TestConstants.EventType.HUB, source: TestConstants.EventSource.SHARED_STATE, expectedCount: 4)
+        // expectations for update config request&response events
+        setExpectationEvent(type: TestConstants.EventType.CONFIGURATION, source: TestConstants.EventSource.REQUEST_CONTENT, expectedCount: 1)
+        setExpectationEvent(type: TestConstants.EventType.CONFIGURATION, source: TestConstants.EventSource.RESPONSE_CONTENT, expectedCount: 1)
+
+        // wait for async registration because the EventHub is already started in TestBase
+        let waitForRegistration = CountDownLatch(1)
+        MobileCore.registerExtensions([Identity.self, Edge.self], {
+            print("Extensions registration is complete")
+            waitForRegistration.countDown()
+        })
+        XCTAssertEqual(DispatchTimeoutResult.success, waitForRegistration.await(timeout: 2))
+        MobileCore.updateConfigurationWith(configDict: ["edge.configId": "12345-example"])
+
+        assertExpectedEvents(ignoreUnexpectedEvents: true, timeout: 2)
+    }
+
+    private func getDataQueue() -> DataQueue? {
+        let serialQueue = DispatchQueue(label: "com.adobe.marketing.mobile.dataqueueservice")
+        return SQLiteDataQueue(databaseName: EdgeConstants.EXTENSION_NAME, serialQueue: serialQueue)
+    }
+
+}

--- a/Tests/FunctionalTests/EdgeQueuedEntityFunctionalTests.swift
+++ b/Tests/FunctionalTests/EdgeQueuedEntityFunctionalTests.swift
@@ -153,7 +153,7 @@ class EdgeQueuedEntityFunctionalTests: TestBase, AnyCodableAsserts {
     }
 
     /// Get the `DataQueue` used by the `Edge` extension.
-    /// - Returns: <#description#>
+    /// - Returns: the `SQLiteDataQueue` for the `Edge` extension
     private func getDataQueue() -> DataQueue? {
         let serialQueue = DispatchQueue(label: "com.adobe.marketing.mobile.dataqueueservice")
         return SQLiteDataQueue(databaseName: EdgeConstants.EXTENSION_NAME, serialQueue: serialQueue)

--- a/Tests/UnitTests/EdgeExtensionTests.swift
+++ b/Tests/UnitTests/EdgeExtensionTests.swift
@@ -258,8 +258,8 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
         mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
                                         data: ([EdgeConstants.SharedState.Configuration.CONFIG_ID: "12345-example"], .set))
         edge.state?.updateCurrentConsent(status: ConsentStatus.yes)
-        // updateCurrentConsent is async, so verify it completes before continuing
-        XCTAssertEqual(ConsentStatus.yes, edge.state?.currentCollectConsent)
+        // UpdateCurrentConsent will enabled hit queue, suspend to capture hit in queue
+        edge.state?.hitQueue.suspend()
 
         mockRuntime.simulateComingEvents(experienceEvent)
 
@@ -270,8 +270,8 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
         mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Identity.STATE_OWNER_NAME,
                                            data: ([:], .set))
         edge.state?.updateCurrentConsent(status: ConsentStatus.yes)
-        // updateCurrentConsent is async, so verify it completes before continuing
-        XCTAssertEqual(ConsentStatus.yes, edge.state?.currentCollectConsent)
+        // UpdateCurrentConsent will enabled hit queue, suspend to capture hit in queue
+        edge.state?.hitQueue.suspend()
 
         mockRuntime.simulateComingEvents(experienceEvent)
 
@@ -284,8 +284,8 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
         mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
                                         data: ([:], .set))
         edge.state?.updateCurrentConsent(status: ConsentStatus.yes)
-        // updateCurrentConsent is async, so verify it completes before continuing
-        XCTAssertEqual(ConsentStatus.yes, edge.state?.currentCollectConsent)
+        // UpdateCurrentConsent will enabled hit queue, suspend to capture hit in queue
+        edge.state?.hitQueue.suspend()
 
         mockRuntime.simulateComingEvents(experienceEvent)
 
@@ -298,8 +298,8 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
         mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
                                         data: ([EdgeConstants.SharedState.Configuration.CONFIG_ID: "12345-example"], .set))
         edge.state?.updateCurrentConsent(status: ConsentStatus.yes)
-        // updateCurrentConsent is async, so verify it completes before continuing
-        XCTAssertEqual(ConsentStatus.yes, edge.state?.currentCollectConsent)
+        // UpdateCurrentConsent will enabled hit queue, suspend to capture hit in queue
+        edge.state?.hitQueue.suspend()
 
         mockRuntime.simulateComingEvents(experienceEvent)
 
@@ -312,8 +312,6 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
         mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
                                         data: ([EdgeConstants.SharedState.Configuration.CONFIG_ID: "12345-example"], .set))
         edge.state?.updateCurrentConsent(status: ConsentStatus.pending)
-        // updateCurrentConsent is async, so verify it completes before continuing
-        XCTAssertEqual(ConsentStatus.pending, edge.state?.currentCollectConsent)
 
         mockRuntime.simulateComingEvents(experienceEvent)
 
@@ -322,8 +320,8 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
 
     func testHandleExperienceEventRequest_validData_consentNo_dropsEvent() {
         edge.state?.updateCurrentConsent(status: ConsentStatus.no)
-        // updateCurrentConsent is async, so verify it completes before continuing
-        XCTAssertEqual(ConsentStatus.no, edge.state?.currentCollectConsent)
+        // UpdateCurrentConsent will enabled hit queue, suspend to capture hit in queue
+        edge.state?.hitQueue.suspend()
 
         mockRuntime.simulateComingEvents(experienceEvent)
 
@@ -341,8 +339,8 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
 
     func testHandleExperienceEventRequest_consentXDMSharedStateNo_dropsEvent() {
         edge.state?.updateCurrentConsent(status: ConsentStatus.yes)
-        // updateCurrentConsent is async, so verify it completes before continuing
-        XCTAssertEqual(ConsentStatus.yes, edge.state?.currentCollectConsent)
+        // UpdateCurrentConsent will enabled hit queue, suspend to capture hit in queue
+        edge.state?.hitQueue.suspend()
 
         mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Consent.SHARED_OWNER_NAME, data: (["consents": ["collect": ["val": "n"]]], .set))
         mockRuntime.simulateComingEvents(experienceEvent)
@@ -356,8 +354,8 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
         mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
                                         data: ([EdgeConstants.SharedState.Configuration.CONFIG_ID: "12345-example"], .set))
         edge.state?.updateCurrentConsent(status: ConsentStatus.no)
-        // updateCurrentConsent is async, so verify it completes before continuing
-        XCTAssertEqual(ConsentStatus.no, edge.state?.currentCollectConsent)
+        // UpdateCurrentConsent will enabled hit queue, suspend to capture hit in queue
+        edge.state?.hitQueue.suspend()
 
         mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Consent.SHARED_OWNER_NAME, data: (["consents": ["invalid": "data"]], .set))
         mockRuntime.simulateComingEvents(experienceEvent)
@@ -378,8 +376,8 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
         mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
                                         data: (configuration, .set))
         edge.state?.updateCurrentConsent(status: ConsentStatus.yes)
-        // updateCurrentConsent is async, so verify it completes before continuing
-        XCTAssertEqual(ConsentStatus.yes, edge.state?.currentCollectConsent)
+        // UpdateCurrentConsent will enabled hit queue, suspend to capture hit in queue
+        edge.state?.hitQueue.suspend()
 
         mockRuntime.simulateComingEvents(experienceEvent)
 
@@ -419,8 +417,8 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
         mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
                                         data: ([EdgeConstants.SharedState.Configuration.CONFIG_ID: "12345-example"], .set))
         edge.state?.updateCurrentConsent(status: ConsentStatus.yes)
-        // updateCurrentConsent is async, so verify it completes before continuing
-        XCTAssertEqual(ConsentStatus.yes, edge.state?.currentCollectConsent)
+        // UpdateCurrentConsent will enabled hit queue, suspend to capture hit in queue
+        edge.state?.hitQueue.suspend()
 
         mockRuntime.simulateComingEvents(experienceEvent)
 
@@ -442,8 +440,8 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
 
     func testHandleExperienceEventRequest_consentXDMSharedStateInvalid_usesCurrentConsent() {
         edge.state?.updateCurrentConsent(status: ConsentStatus.no)
-        // updateCurrentConsent is async, so verify it completes before continuing
-        XCTAssertEqual(ConsentStatus.no, edge.state?.currentCollectConsent)
+        // UpdateCurrentConsent will enabled hit queue, suspend to capture hit in queue
+        edge.state?.hitQueue.suspend()
 
         // no consent shared state for current event
         mockRuntime.simulateComingEvents(experienceEvent)

--- a/Tests/UnitTests/EdgeExtensionTests.swift
+++ b/Tests/UnitTests/EdgeExtensionTests.swift
@@ -197,10 +197,15 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
         }
 
         // Verify EdgeDataEntity only contains config ID, domain, and environment
-        XCTAssertEqual(3, edgeDataEntity.configuration.count)
-        XCTAssertEqual("12345-example", edgeDataEntity.configuration[EdgeConstants.SharedState.Configuration.CONFIG_ID])
-        XCTAssertEqual("edge.com", edgeDataEntity.configuration[EdgeConstants.SharedState.Configuration.EDGE_DOMAIN])
-        XCTAssertEqual("dev", edgeDataEntity.configuration[EdgeConstants.SharedState.Configuration.EDGE_ENVIRONMENT])
+        let expectedConfigJSON = """
+            {
+              "edge.configId": "12345-example",
+              "edge.domain": "edge.com",
+              "edge.environment": "dev"
+            }
+        """
+
+        assertEqual(expected: expectedConfigJSON, actual: edgeDataEntity.configuration)
     }
 
     func testHandleConsentUpdate_queuedDataEntityContainsIdentityMap() {
@@ -363,10 +368,15 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
         }
 
         // Verify EdgeDataEntity only contains config ID, domain, and environment
-        XCTAssertEqual(3, edgeDataEntity.configuration.count)
-        XCTAssertEqual("12345-example", edgeDataEntity.configuration[EdgeConstants.SharedState.Configuration.CONFIG_ID])
-        XCTAssertEqual("edge.com", edgeDataEntity.configuration[EdgeConstants.SharedState.Configuration.EDGE_DOMAIN])
-        XCTAssertEqual("dev", edgeDataEntity.configuration[EdgeConstants.SharedState.Configuration.EDGE_ENVIRONMENT])
+        let expectedConfigJSON = """
+            {
+              "edge.configId": "12345-example",
+              "edge.domain": "edge.com",
+              "edge.environment": "dev"
+            }
+        """
+
+        assertEqual(expected: expectedConfigJSON, actual: edgeDataEntity.configuration)
     }
 
     func testHandleExperienceEventRequest_queuedDataEntityContainsIdentityMap() {

--- a/Tests/UnitTests/EdgeExtensionTests.swift
+++ b/Tests/UnitTests/EdgeExtensionTests.swift
@@ -115,11 +115,11 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
         let actualDetails = edge.state?.implementationDetails
 
         let expectedDetailsJSON = #"""
-        {
-          "version": "3.0.0+\#(EdgeConstants.EXTENSION_VERSION)",
-          "environment": "app",
-          "name": "\#(EXPECTED_BASE_PATH)/reactnative"
-        }
+            {
+            "version": "3.0.0+\#(EdgeConstants.EXTENSION_VERSION)",
+            "environment": "app",
+            "name": "\#(EXPECTED_BASE_PATH)/reactnative"
+            }
         """#
 
         assertEqual(expected: expectedDetailsJSON, actual: actualDetails)
@@ -136,6 +136,26 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
     }
 
     func testHandleConsentUpdate_noIdentitySharedState_doesNotQueue() {
+        mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
+                                        data: ([EdgeConstants.SharedState.Configuration.CONFIG_ID: "12345-example"], .set))
+        mockRuntime.simulateComingEvents(Event(name: "Consent update", type: EventType.edge, source: EventSource.updateConsent, data: ["consents": ["collect": ["val": "y"]]]))
+
+        XCTAssertEqual(0, mockDataQueue.count())
+    }
+
+    func testHandleConsentUpdate_noConfigurationSharedState_doesNotQueue() {
+        mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Identity.STATE_OWNER_NAME,
+                                           data: ([:], .set))
+        mockRuntime.simulateComingEvents(Event(name: "Consent update", type: EventType.edge, source: EventSource.updateConsent, data: ["consents": ["collect": ["val": "y"]]]))
+
+        XCTAssertEqual(0, mockDataQueue.count())
+    }
+
+    func testHandleConsentUpdate_ConfigurationSharedStateWithoutConfigId_doesNotQueue() {
+        mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Identity.STATE_OWNER_NAME,
+                                           data: ([:], .set))
+        mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
+                                        data: ([:], .set))
         mockRuntime.simulateComingEvents(Event(name: "Consent update", type: EventType.edge, source: EventSource.updateConsent, data: ["consents": ["collect": ["val": "y"]]]))
 
         XCTAssertEqual(0, mockDataQueue.count())
@@ -144,9 +164,72 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
     func testHandleConsentUpdate_validData_queues() {
         mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Identity.STATE_OWNER_NAME,
                                            data: ([:], .set))
+        mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
+                                        data: ([EdgeConstants.SharedState.Configuration.CONFIG_ID: "12345-example"], .set))
         mockRuntime.simulateComingEvents(Event(name: "Consent update", type: EventType.edge, source: EventSource.updateConsent, data: ["consents": ["collect": ["val": "y"]]]))
 
         XCTAssertEqual(1, mockDataQueue.count())
+    }
+
+    func testHandleConsentUpdate_queuedDataEntityContainsConfiguration() {
+        let configuration = [
+            "edge.configId": "12345-example",
+            "edge.domain": "edge.com",
+            "edge.environment": "dev",
+            "experience.orgId": "12345-org"
+        ]
+
+        mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Identity.STATE_OWNER_NAME,
+                                           data: ([:], .set))
+        mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
+                                        data: (configuration, .set))
+        mockRuntime.simulateComingEvents(Event(name: "Consent update", type: EventType.edge, source: EventSource.updateConsent, data: ["consents": ["collect": ["val": "y"]]]))
+
+        XCTAssertEqual(1, mockDataQueue.count())
+        guard let dataEntity = mockDataQueue.peek() else {
+            XCTFail("DataEntity was not in MockDataQueue as expected!")
+            return
+        }
+
+        guard let data = dataEntity.data, let edgeDataEntity = try? JSONDecoder().decode(EdgeDataEntity.self, from: data) else {
+            XCTFail("Unable to decode EdgeEntity from DataEntity!")
+            return
+        }
+
+        // Verify EdgeDataEntity only contains config ID, domain, and environment
+        XCTAssertEqual(3, edgeDataEntity.configuration.count)
+        XCTAssertEqual("12345-example", edgeDataEntity.configuration[EdgeConstants.SharedState.Configuration.CONFIG_ID])
+        XCTAssertEqual("edge.com", edgeDataEntity.configuration[EdgeConstants.SharedState.Configuration.EDGE_DOMAIN])
+        XCTAssertEqual("dev", edgeDataEntity.configuration[EdgeConstants.SharedState.Configuration.EDGE_ENVIRONMENT])
+    }
+
+    func testHandleConsentUpdate_queuedDataEntityContainsIdentityMap() {
+        let identityMap: [String: AnyCodable] =
+            [
+                "ECID": [
+                    ["id": "12345-ecid", "authenticatedState": "ambiguous", "primary": false]
+                ]
+            ]
+
+        mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Identity.STATE_OWNER_NAME,
+                                           data: (identityMap, .set))
+        mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
+                                        data: ([EdgeConstants.SharedState.Configuration.CONFIG_ID: "12345-example"], .set))
+        mockRuntime.simulateComingEvents(Event(name: "Consent update", type: EventType.edge, source: EventSource.updateConsent, data: ["consents": ["collect": ["val": "y"]]]))
+
+        XCTAssertEqual(1, mockDataQueue.count())
+        guard let dataEntity = mockDataQueue.peek() else {
+            XCTFail("DataEntity was not in MockDataQueue as expected!")
+            return
+        }
+
+        guard let data = dataEntity.data, let edgeDataEntity = try? JSONDecoder().decode(EdgeDataEntity.self, from: data) else {
+            XCTFail("Unable to decode EdgeEntity from DataEntity!")
+            return
+        }
+
+        // Verify EdgeDataEntity contains identity map
+        assertEqual(expected: identityMap, actual: edgeDataEntity.identityMap)
     }
 
     // MARK: Consent preferences update
@@ -167,6 +250,28 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
 
     // MARK: Experience event
     func testHandleExperienceEventRequest_noIdentitySharedState_doesNotQueue() {
+        mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
+                                        data: ([EdgeConstants.SharedState.Configuration.CONFIG_ID: "12345-example"], .set))
+        edge.state?.updateCurrentConsent(status: ConsentStatus.yes)
+        mockRuntime.simulateComingEvents(experienceEvent)
+
+        XCTAssertEqual(0, mockDataQueue.count())
+    }
+
+    func testHandleExperienceEventRequest_noConfigurationSharedState_doesNotQueue() {
+        mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Identity.STATE_OWNER_NAME,
+                                           data: ([:], .set))
+        edge.state?.updateCurrentConsent(status: ConsentStatus.yes)
+        mockRuntime.simulateComingEvents(experienceEvent)
+
+        XCTAssertEqual(0, mockDataQueue.count())
+    }
+
+    func testHandleExperienceEventRequest_ConfigurationSharedStateWithoutConfigId_doesNotQueue() {
+        mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Identity.STATE_OWNER_NAME,
+                                           data: ([:], .set))
+        mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
+                                        data: ([:], .set))
         edge.state?.updateCurrentConsent(status: ConsentStatus.yes)
         mockRuntime.simulateComingEvents(experienceEvent)
 
@@ -176,6 +281,8 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
     func testHandleExperienceEventRequest_validData_consentYes_queues() {
         mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Identity.STATE_OWNER_NAME,
                                            data: ([:], .set))
+        mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
+                                        data: ([EdgeConstants.SharedState.Configuration.CONFIG_ID: "12345-example"], .set))
         edge.state?.updateCurrentConsent(status: ConsentStatus.yes)
         mockRuntime.simulateComingEvents(experienceEvent)
 
@@ -185,6 +292,8 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
     func testHandleExperienceEventRequest_validData_consentPending_queues() {
         mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Identity.STATE_OWNER_NAME,
                                            data: ([:], .set))
+        mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
+                                        data: ([EdgeConstants.SharedState.Configuration.CONFIG_ID: "12345-example"], .set))
         edge.state?.updateCurrentConsent(status: ConsentStatus.pending)
         mockRuntime.simulateComingEvents(experienceEvent)
 
@@ -218,11 +327,77 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
     func testHandleExperienceEventRequest_consentXDMSharedStateInvalid_usesDefaultPending() {
         mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Identity.STATE_OWNER_NAME,
                                            data: ([:], .set))
+        mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
+                                        data: ([EdgeConstants.SharedState.Configuration.CONFIG_ID: "12345-example"], .set))
         edge.state?.updateCurrentConsent(status: ConsentStatus.no)
         mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Consent.SHARED_OWNER_NAME, data: (["consents": ["invalid": "data"]], .set))
         mockRuntime.simulateComingEvents(experienceEvent)
 
         XCTAssertEqual(1, mockDataQueue.count())
+    }
+
+    func testHandleExperienceEventRequest_queuedDataEntityContainsConfiguration() {
+        let configuration = [
+            "edge.configId": "12345-example",
+            "edge.domain": "edge.com",
+            "edge.environment": "dev",
+            "experience.orgId": "12345-org"
+        ]
+
+        mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Identity.STATE_OWNER_NAME,
+                                           data: ([:], .set))
+        mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
+                                        data: (configuration, .set))
+        edge.state?.updateCurrentConsent(status: ConsentStatus.yes)
+        mockRuntime.simulateComingEvents(experienceEvent)
+
+        XCTAssertEqual(1, mockDataQueue.count())
+        guard let dataEntity = mockDataQueue.peek() else {
+            XCTFail("DataEntity was not in MockDataQueue as expected!")
+            return
+        }
+
+        guard let data = dataEntity.data, let edgeDataEntity = try? JSONDecoder().decode(EdgeDataEntity.self, from: data) else {
+            XCTFail("Unable to decode EdgeEntity from DataEntity!")
+            return
+        }
+
+        // Verify EdgeDataEntity only contains config ID, domain, and environment
+        XCTAssertEqual(3, edgeDataEntity.configuration.count)
+        XCTAssertEqual("12345-example", edgeDataEntity.configuration[EdgeConstants.SharedState.Configuration.CONFIG_ID])
+        XCTAssertEqual("edge.com", edgeDataEntity.configuration[EdgeConstants.SharedState.Configuration.EDGE_DOMAIN])
+        XCTAssertEqual("dev", edgeDataEntity.configuration[EdgeConstants.SharedState.Configuration.EDGE_ENVIRONMENT])
+    }
+
+    func testHandleExperienceEventRequest_queuedDataEntityContainsIdentityMap() {
+        let identityMap: [String: AnyCodable] =
+            [
+                "ECID": [
+                    ["id": "12345-ecid", "authenticatedState": "ambiguous", "primary": false]
+                ]
+            ]
+
+        mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Identity.STATE_OWNER_NAME,
+                                           data: (identityMap, .set))
+        mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
+                                        data: ([EdgeConstants.SharedState.Configuration.CONFIG_ID: "12345-example"], .set))
+        edge.state?.updateCurrentConsent(status: ConsentStatus.yes)
+        mockRuntime.simulateComingEvents(experienceEvent)
+
+        XCTAssertEqual(1, mockDataQueue.count())
+        guard let dataEntity = mockDataQueue.peek() else {
+            XCTFail("DataEntity was not in MockDataQueue as expected!")
+            return
+        }
+
+        guard let data = dataEntity.data, let edgeDataEntity = try? JSONDecoder().decode(EdgeDataEntity.self, from: data) else {
+            XCTFail("Unable to decode EdgeEntity from DataEntity!")
+            return
+        }
+
+        // Verify EdgeDataEntity contains identity map
+        XCTAssertEqual(1, edgeDataEntity.identityMap.count)
+        assertEqual(expected: identityMap, actual: edgeDataEntity.identityMap)
     }
 
     func testHandleExperienceEventRequest_consentXDMSharedStateInvalid_usesCurrentConsent() {

--- a/Tests/UnitTests/EdgeExtensionTests.swift
+++ b/Tests/UnitTests/EdgeExtensionTests.swift
@@ -258,6 +258,9 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
         mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
                                         data: ([EdgeConstants.SharedState.Configuration.CONFIG_ID: "12345-example"], .set))
         edge.state?.updateCurrentConsent(status: ConsentStatus.yes)
+        // updateCurrentConsent is async, so verify it completes before continuing
+        XCTAssertEqual(ConsentStatus.yes, edge.state?.currentCollectConsent)
+
         mockRuntime.simulateComingEvents(experienceEvent)
 
         XCTAssertEqual(0, mockDataQueue.count())
@@ -267,6 +270,9 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
         mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Identity.STATE_OWNER_NAME,
                                            data: ([:], .set))
         edge.state?.updateCurrentConsent(status: ConsentStatus.yes)
+        // updateCurrentConsent is async, so verify it completes before continuing
+        XCTAssertEqual(ConsentStatus.yes, edge.state?.currentCollectConsent)
+
         mockRuntime.simulateComingEvents(experienceEvent)
 
         XCTAssertEqual(0, mockDataQueue.count())
@@ -278,6 +284,9 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
         mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
                                         data: ([:], .set))
         edge.state?.updateCurrentConsent(status: ConsentStatus.yes)
+        // updateCurrentConsent is async, so verify it completes before continuing
+        XCTAssertEqual(ConsentStatus.yes, edge.state?.currentCollectConsent)
+
         mockRuntime.simulateComingEvents(experienceEvent)
 
         XCTAssertEqual(0, mockDataQueue.count())
@@ -289,6 +298,9 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
         mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
                                         data: ([EdgeConstants.SharedState.Configuration.CONFIG_ID: "12345-example"], .set))
         edge.state?.updateCurrentConsent(status: ConsentStatus.yes)
+        // updateCurrentConsent is async, so verify it completes before continuing
+        XCTAssertEqual(ConsentStatus.yes, edge.state?.currentCollectConsent)
+
         mockRuntime.simulateComingEvents(experienceEvent)
 
         XCTAssertEqual(1, mockDataQueue.count())
@@ -300,6 +312,9 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
         mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
                                         data: ([EdgeConstants.SharedState.Configuration.CONFIG_ID: "12345-example"], .set))
         edge.state?.updateCurrentConsent(status: ConsentStatus.pending)
+        // updateCurrentConsent is async, so verify it completes before continuing
+        XCTAssertEqual(ConsentStatus.pending, edge.state?.currentCollectConsent)
+
         mockRuntime.simulateComingEvents(experienceEvent)
 
         XCTAssertEqual(1, mockDataQueue.count())
@@ -307,6 +322,9 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
 
     func testHandleExperienceEventRequest_validData_consentNo_dropsEvent() {
         edge.state?.updateCurrentConsent(status: ConsentStatus.no)
+        // updateCurrentConsent is async, so verify it completes before continuing
+        XCTAssertEqual(ConsentStatus.no, edge.state?.currentCollectConsent)
+
         mockRuntime.simulateComingEvents(experienceEvent)
 
         XCTAssertEqual(0, mockDataQueue.count())
@@ -323,6 +341,9 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
 
     func testHandleExperienceEventRequest_consentXDMSharedStateNo_dropsEvent() {
         edge.state?.updateCurrentConsent(status: ConsentStatus.yes)
+        // updateCurrentConsent is async, so verify it completes before continuing
+        XCTAssertEqual(ConsentStatus.yes, edge.state?.currentCollectConsent)
+
         mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Consent.SHARED_OWNER_NAME, data: (["consents": ["collect": ["val": "n"]]], .set))
         mockRuntime.simulateComingEvents(experienceEvent)
 
@@ -335,6 +356,9 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
         mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
                                         data: ([EdgeConstants.SharedState.Configuration.CONFIG_ID: "12345-example"], .set))
         edge.state?.updateCurrentConsent(status: ConsentStatus.no)
+        // updateCurrentConsent is async, so verify it completes before continuing
+        XCTAssertEqual(ConsentStatus.no, edge.state?.currentCollectConsent)
+
         mockRuntime.simulateXDMSharedState(for: EdgeConstants.SharedState.Consent.SHARED_OWNER_NAME, data: (["consents": ["invalid": "data"]], .set))
         mockRuntime.simulateComingEvents(experienceEvent)
 
@@ -354,6 +378,9 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
         mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
                                         data: (configuration, .set))
         edge.state?.updateCurrentConsent(status: ConsentStatus.yes)
+        // updateCurrentConsent is async, so verify it completes before continuing
+        XCTAssertEqual(ConsentStatus.yes, edge.state?.currentCollectConsent)
+
         mockRuntime.simulateComingEvents(experienceEvent)
 
         XCTAssertEqual(1, mockDataQueue.count())
@@ -392,6 +419,9 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
         mockRuntime.simulateSharedState(for: EdgeConstants.SharedState.Configuration.STATE_OWNER_NAME,
                                         data: ([EdgeConstants.SharedState.Configuration.CONFIG_ID: "12345-example"], .set))
         edge.state?.updateCurrentConsent(status: ConsentStatus.yes)
+        // updateCurrentConsent is async, so verify it completes before continuing
+        XCTAssertEqual(ConsentStatus.yes, edge.state?.currentCollectConsent)
+
         mockRuntime.simulateComingEvents(experienceEvent)
 
         XCTAssertEqual(1, mockDataQueue.count())
@@ -412,6 +442,9 @@ class EdgeExtensionTests: XCTestCase, AnyCodableAsserts {
 
     func testHandleExperienceEventRequest_consentXDMSharedStateInvalid_usesCurrentConsent() {
         edge.state?.updateCurrentConsent(status: ConsentStatus.no)
+        // updateCurrentConsent is async, so verify it completes before continuing
+        XCTAssertEqual(ConsentStatus.no, edge.state?.currentCollectConsent)
+
         // no consent shared state for current event
         mockRuntime.simulateComingEvents(experienceEvent)
 

--- a/Tests/UnitTests/EdgeHitProcessorTests.swift
+++ b/Tests/UnitTests/EdgeHitProcessorTests.swift
@@ -92,12 +92,6 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
         return nil
     }
 
-    // Mock for `getXDMSharedState` closure in `EdgeHitProcessor`. Reassign variable in test to change behavior.
-    private var mockGetXDMSharedState: (String, Event?, Bool) -> SharedStateResult? = {extensionName, _, _ in
-        XCTFail("Test called 'getXDMSharedState(\(extensionName))' but was not expected.")
-        return nil
-    }
-
     // Mock for `readyForEvent` closure in `EdgeHitProcessor`. Reassign variable in test to change behavior.
     private var mockReadyForEvent: (Event) -> Bool = {_ in
         XCTFail("Test called 'readyForEvent' but was not expected.")
@@ -135,7 +129,6 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
         hitProcessor = EdgeHitProcessor(networkService: networkService,
                                         networkResponseHandler: networkResponseHandler,
                                         getSharedState: {extensionName, event in self.mockGetSharedState(extensionName, event)},
-                                        getXDMSharedState: {extensionName, event, barrier in self.mockGetXDMSharedState(extensionName, event, barrier)},
                                         readyForEvent: {event in self.mockReadyForEvent(event)},
                                         getImplementationDetails: {self.mockGetImplementationDetails()},
                                         getLocationHint: {self.mockGetLocationHint()},
@@ -836,9 +829,6 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
         let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
         self.mockReadyForEvent = {_ in return true }
         self.mockGetEdgeConfig = {_ in return self.defaultEdgeConfig}
-        self.mockGetXDMSharedState = {_, _, _ in
-            return SharedStateResult(status: .set, value: self.defaultIdentityMap)
-        }
 
         assertProcessHit(entity: entity, sendsNetworkRequest: true, returns: true)
     }
@@ -861,9 +851,6 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
 
         self.mockReadyForEvent = {_ in return true}
         self.mockGetEdgeConfig = {_ in return [:]}
-        self.mockGetXDMSharedState = {_, _, _ in
-            return SharedStateResult(status: .set, value: self.defaultIdentityMap)
-        }
 
         assertProcessHit(entity: entity, sendsNetworkRequest: false, returns: true)
     }
@@ -876,9 +863,6 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
 
         self.mockReadyForEvent = {_ in return true}
         self.mockGetEdgeConfig = {_ in return ["edge.configId": ""]}
-        self.mockGetXDMSharedState = {_, _, _ in
-            return SharedStateResult(status: .set, value: self.defaultIdentityMap)
-        }
 
         assertProcessHit(entity: entity, sendsNetworkRequest: false, returns: true)
     }
@@ -890,9 +874,6 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
         let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
         self.mockReadyForEvent = {_ in return true }
         self.mockGetEdgeConfig = {_ in return self.defaultEdgeConfig}
-        self.mockGetXDMSharedState = {_, _, _ in
-            return SharedStateResult(status: .set, value: self.defaultIdentityMap)
-        }
 
         assertProcessHit(entity: entity, urlString: CONSENT_ENDPOINT, sendsNetworkRequest: true, returns: true)
     }
@@ -915,9 +896,6 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
 
         self.mockReadyForEvent = {_ in return true}
         self.mockGetEdgeConfig = {_ in return [:]}
-        self.mockGetXDMSharedState = { _, _, _ in
-            return SharedStateResult(status: .set, value: self.defaultIdentityMap)
-        }
 
         assertProcessHit(entity: entity, urlString: CONSENT_ENDPOINT, sendsNetworkRequest: false, returns: true)
     }
@@ -930,9 +908,6 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
 
         self.mockReadyForEvent = {_ in return true}
         self.mockGetEdgeConfig = {_ in return ["edge.configId": ""]}
-        self.mockGetXDMSharedState = { _, _, _ in
-            return SharedStateResult(status: .set, value: self.defaultIdentityMap)
-        }
 
         assertProcessHit(entity: entity, urlString: CONSENT_ENDPOINT, sendsNetworkRequest: false, returns: true)
     }

--- a/Tests/UnitTests/EdgeHitProcessorTests.swift
+++ b/Tests/UnitTests/EdgeHitProcessorTests.swift
@@ -155,7 +155,7 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
     /// Tests that when `readyForEvent` returns false that we retry the hit
     func testProcessHit_experienceEvent_readyForEventReturnsFalse() {
         // setup
-        let edgeEntity = EdgeDataEntity(event: experienceEvent, identityMap: [:])
+        let edgeEntity = EdgeDataEntity(event: experienceEvent, configuration: [:], identityMap: [:])
         let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
         hitProcessor = EdgeHitProcessor(networkService: networkService,
                                         networkResponseHandler: networkResponseHandler,
@@ -174,7 +174,7 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
     /// Tests that when an nil configuration is provided that the hit is dropped
     func testProcessHit_experienceEvent_nilConfiguration() {
         // setup
-        let edgeEntity = EdgeDataEntity(event: experienceEvent, identityMap: [:])
+        let edgeEntity = EdgeDataEntity(event: experienceEvent, configuration: [:], identityMap: [:])
         let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
         hitProcessor = EdgeHitProcessor(networkService: networkService,
                                         networkResponseHandler: networkResponseHandler,
@@ -197,7 +197,7 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
     /// Tests that when no edge config id is in configuration shared state that we drop the hit
     func testProcessHit_experienceEvent_noEdgeConfigId() {
         // setup
-        let edgeEntity = EdgeDataEntity(event: experienceEvent, identityMap: [:])
+        let edgeEntity = EdgeDataEntity(event: experienceEvent, configuration: [:], identityMap: [:])
         let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
         hitProcessor = EdgeHitProcessor(networkService: networkService,
                                         networkResponseHandler: networkResponseHandler,
@@ -220,7 +220,7 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
     /// Tests that when a good hit is processed that a network request is made and the request returns 200
     func testProcessHit_experienceEvent_happy_sendsNetworkRequest_returnsTrue() {
         // setup
-        let edgeEntity = EdgeDataEntity(event: experienceEvent, identityMap: [:])
+        let edgeEntity = EdgeDataEntity(event: experienceEvent, configuration: [:], identityMap: [:])
         let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
 
         // test
@@ -230,7 +230,7 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
     /// Tests that when a good hit is processed that a network request is made and the request returns 200
     func testProcessHit_experienceEvent_withDatastreamOverrideSet_sendsNetworkRequest_returnsTrue() {
         // setup
-        let edgeEntity = EdgeDataEntity(event: experienceEventWithDatastreamIdOverride, identityMap: [:])
+        let edgeEntity = EdgeDataEntity(event: experienceEventWithDatastreamIdOverride, configuration: [:], identityMap: [:])
         let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
 
         // test
@@ -269,12 +269,12 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
                 responseConnection: HttpConnection(
                     data: responseData,
                     response: HTTPURLResponse(url: url,
-                    statusCode: code,
-                    httpVersion: nil,
-                    headerFields: ["Retry-After": retryValueTuple.0]),
+                                              statusCode: code,
+                                              httpVersion: nil,
+                                              headerFields: ["Retry-After": retryValueTuple.0]),
                     error: nil))
 
-            let edgeEntity = EdgeDataEntity(event: experienceEvent, identityMap: [:])
+            let edgeEntity = EdgeDataEntity(event: experienceEvent, configuration: [:], identityMap: [:])
             let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
 
             // test
@@ -305,7 +305,7 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
                     headerFields: nil),
                 error: nil))
 
-        let edgeEntity = EdgeDataEntity(event: experienceEvent, identityMap: [:])
+        let edgeEntity = EdgeDataEntity(event: experienceEvent, configuration: [:], identityMap: [:])
         let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
 
         // test
@@ -329,7 +329,7 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
                     headerFields: nil),
                 error: nil))
 
-        let edgeEntity = EdgeDataEntity(event: experienceEvent, identityMap: [:])
+        let edgeEntity = EdgeDataEntity(event: experienceEvent, configuration: [:], identityMap: [:])
         let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
 
         // test
@@ -367,7 +367,7 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
                     headerFields: nil),
                 error: nil))
 
-        let edgeEntity = EdgeDataEntity(event: experienceEvent, identityMap: [:])
+        let edgeEntity = EdgeDataEntity(event: experienceEvent, configuration: [:], identityMap: [:])
         let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
 
         // test
@@ -522,7 +522,7 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
                 error: nil))
 
         let event = Event(name: "test-consent-event", type: EventType.edge, source: EventSource.updateConsent, data: nil)
-        let edgeEntity = EdgeDataEntity(event: event, identityMap: [:])
+        let edgeEntity = EdgeDataEntity(event: event, configuration: [:], identityMap: [:])
 
         let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
 
@@ -532,14 +532,14 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
 
     func testProcessHit_experienceEvent_emptyPayloadDueToInvalidData_doesNotSendNetworkRequest_returnsTrue() {
         let event = Event(name: "test-experience-event", type: EventType.edge, source: EventSource.requestContent, data: [:])
-        let edgeEntity = EdgeDataEntity(event: event, identityMap: [:])
+        let edgeEntity = EdgeDataEntity(event: event, configuration: [:], identityMap: [:])
 
         let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
         assertProcessHit(entity: entity, sendsNetworkRequest: false, returns: true)
     }
 
     func testProcessHit_experienceEvent_addsEventToWaitingEventsList() {
-        let edgeEntity = EdgeDataEntity(event: experienceEvent, identityMap: [:])
+        let edgeEntity = EdgeDataEntity(event: experienceEvent, configuration: [:], identityMap: [:])
         let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
 
         let expectation = XCTestExpectation(description: "Callback should be invoked signaling if the hit was processed or not")
@@ -592,7 +592,7 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
                     headerFields: nil),
                 error: nil))
 
-        let edgeEntity = EdgeDataEntity(event: consentUpdateEvent, identityMap: [:])
+        let edgeEntity = EdgeDataEntity(event: consentUpdateEvent, configuration: [:], identityMap: [:])
         let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
 
         // test
@@ -603,7 +603,7 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
 
     func testProcessHit_consentUpdateEvent_emptyData_doesNotSendNetworkRequest_returnsTrue() {
         let event = Event(name: "test-consent-event", type: EventType.edge, source: EventSource.updateConsent, data: nil)
-        let edgeEntity = EdgeDataEntity(event: event, identityMap: [:])
+        let edgeEntity = EdgeDataEntity(event: event, configuration: [:], identityMap: [:])
 
         let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
         assertProcessHit(entity: entity, urlString: CONSENT_ENDPOINT, sendsNetworkRequest: false, returns: true)
@@ -611,14 +611,14 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
 
     func testProcessHit_consentUpdateEvent_emptyPayloadDueToInvalidData_doesNotSendNetworkRequest_returnsTrue() {
         let event = Event(name: "test-consent-event", type: EventType.edge, source: EventSource.updateConsent, data: ["some": "consent"])
-        let edgeEntity = EdgeDataEntity(event: event, identityMap: [:])
+        let edgeEntity = EdgeDataEntity(event: event, configuration: [:], identityMap: [:])
 
         let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
         assertProcessHit(entity: entity, sendsNetworkRequest: false, returns: true)
     }
 
     func testProcessHit_consentUpdateEvent_addsEventToWaitingEventsList() {
-        let edgeEntity = EdgeDataEntity(event: consentUpdateEvent, identityMap: [:])
+        let edgeEntity = EdgeDataEntity(event: consentUpdateEvent, configuration: [:], identityMap: [:])
         let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
 
         let expectation = XCTestExpectation(description: "Callback should be invoked signaling if the hit was processed or not")
@@ -664,7 +664,7 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
                           type: EventType.genericIdentity,
                           source: EventSource.requestReset,
                           data: nil)
-        let edgeEntity = EdgeDataEntity(event: event, identityMap: [:])
+        let edgeEntity = EdgeDataEntity(event: event, configuration: [:], identityMap: [:])
         let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
 
         assertProcessHit(entity: entity, sendsNetworkRequest: false, returns: true)
@@ -702,7 +702,7 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
                     headerFields: nil),
                 error: nil))
 
-        let edgeEntity = EdgeDataEntity(event: experienceEvent, identityMap: [:])
+        let edgeEntity = EdgeDataEntity(event: experienceEvent, configuration: [:], identityMap: [:])
         let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
 
         // test
@@ -714,15 +714,15 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
         }
 
         let expectedJSON = #"""
-        {
-          "xdm": {
+            {
+            "xdm": {
             "implementationDetails": {
-              "environment": "app",
-              "name": "https://ns.adobe.com/experience/mobilesdk/ios",
-              "version": "3.3.1+1.0.0"
+            "environment": "app",
+            "name": "https://ns.adobe.com/experience/mobilesdk/ios",
+            "version": "3.3.1+1.0.0"
             }
-          }
-        }
+            }
+            }
         """#
 
         assertExactMatch(expected: expectedJSON, actual: networkRequest)
@@ -750,7 +750,7 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
                     headerFields: nil),
                 error: nil))
 
-        let edgeEntity = EdgeDataEntity(event: experienceEvent, identityMap: [:])
+        let edgeEntity = EdgeDataEntity(event: experienceEvent, configuration: [:], identityMap: [:])
         let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
 
         // test
@@ -768,8 +768,8 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
             actual: networkRequest,
             pathOptions: KeyMustBeAbsent(paths:
                                             "xdm.implementationDetails.environment",
-                                            "xdm.implementationDetails.name",
-                                            "xdm.implementationDetails.version"))
+                                         "xdm.implementationDetails.name",
+                                         "xdm.implementationDetails.version"))
     }
 
     // tests Implementation Details is not added to Consent events
@@ -800,7 +800,7 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
                     headerFields: nil),
                 error: nil))
 
-        let edgeEntity = EdgeDataEntity(event: consentUpdateEvent, identityMap: [:])
+        let edgeEntity = EdgeDataEntity(event: consentUpdateEvent, configuration: [:], identityMap: [:])
         let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
 
         // test
@@ -819,8 +819,8 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
             actual: networkRequest,
             pathOptions: KeyMustBeAbsent(paths:
                                             "xdm.implementationDetails.environment",
-                                            "xdm.implementationDetails.name",
-                                            "xdm.implementationDetails.version"))
+                                         "xdm.implementationDetails.name",
+                                         "xdm.implementationDetails.version"))
     }
 
     func assertProcessHit(entity: DataEntity, urlString: String? = nil, sendsNetworkRequest: Bool, returns: Bool, file: StaticString = #file, line: UInt = #line) {
@@ -879,7 +879,7 @@ class EdgeHitProcessorTests: XCTestCase, AnyCodableAsserts {
                     headerFields: nil),
                 error: nil))
 
-        let edgeEntity = EdgeDataEntity(event: event, identityMap: [:])
+        let edgeEntity = EdgeDataEntity(event: event, configuration: [:], identityMap: [:])
         let entity = DataEntity(uniqueIdentifier: "test-uuid", timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
 
         // test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Cache the Edge configuration with the queued data entity instead of retrieving the configuration when the hit is processed. This update preserves the previous EdgeHitProcessor workflow to handle cases where queued data entities without a configuration are present after upgrading to this newer version.

- Edge extension will now bundle the edge configuration in the EdgeDataEntity when adding entity to queue.
- EdgeHitProcessor now reads the edge configuration from the EdgeDataEntity instead of getting it from the current Configuration shared state.
- EdgeHitProcess continues to use old workflow of validating against `readyForEvent` and reading the Configuration shared state if the current data entity contains an empty configuration.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
