### PR TITLE
Wait for Configuration update in Integration tests

### DIFF
--- a/Tests/TestUtils/TestConstants.swift
+++ b/Tests/TestUtils/TestConstants.swift
@@ -25,6 +25,7 @@ enum TestConstants {
         static let CONFIGURATION = "com.adobe.eventType.configuration"
         static let IDENTITY = "com.adobe.eventType.identity"
         static let CONSENT = "com.adobe.eventType.edgeConsent"
+        static let RULES_ENGINE = "com.adobe.eventType.rulesEngine"
     }
 
     enum EventSource {
@@ -33,6 +34,7 @@ enum TestConstants {
         static let RESPONSE_CONTENT = "com.adobe.eventSource.responseContent"
         static let ERROR_RESPONSE_CONTENT = "com.adobe.eventSource.errorResponseContent"
         static let SHARED_STATE_REQUEST = "com.adobe.eventSource.requestState"
+        static let REQUEST_RESET = "com.adobe.eventSource.requestReset"
         static let SHARED_STATE_RESPONSE = "com.adobe.eventSource.responseState"
         static let UNREGISTER_EXTENSION = "com.adobe.eventSource.unregisterExtension"
         static let SHARED_STATE = "com.adobe.eventSource.sharedState"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes failures in `UpstreamIntegrationTests.testSendEvent_withInvalidDatastreamID_receivesExpectedError()` due to `updateConfigurationWith(config:)` not being processed fast enough. The issue is since the integration tests perform a remote download of their configuration during setup, the `sendEvent` call in the test case gets dispatched before the initial Configuration state is set. In the failing test case, a second Configuration update is made to set an invalid `edge.configId`, however it is processed after the experience event is queued. Recent updates now set the configuration with the queued experience event, instead of resolving the configuration at the time the event is processed. 
The fix is to wait for the Configuration response content event during setup before starting each test case.

Updates calls to `assertExactMatch` and `assertTypeMatch` to use `pathOptions`, as the old APIs are deprecated.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
