### PR TITLE
Retry Edge Hits for Recoverable URLErrors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 orbs:
   # codecov: codecov/codecov@3.2.5
   macos: circleci/macos@2
-  
+
 # Workflows orchestrate a set of jobs to be run
 workflows:
   build-test:
@@ -36,7 +36,7 @@ workflows:
                 - main
                 - staging
 
-commands: 
+commands:
   install_dependencies:
     steps:
       # restore pods related caches
@@ -61,9 +61,9 @@ commands:
       - restore_cache:
           name: Restoring CocoaPods Cache
           keys:
-            - cocoapods-cache-v5-{{ arch }}-{{ .Branch }}-{{ checksum "Podfile.lock" }}
-            - cocoapods-cache-v5-{{ arch }}-{{ .Branch }}
-            - cocoapods-cache-v5
+            - cocoapods-cache-v6-{{ arch }}-{{ .Branch }}-{{ checksum "Podfile.lock" }}
+            - cocoapods-cache-v6-{{ arch }}-{{ .Branch }}
+            - cocoapods-cache-v6
 
       # install CocoaPods - using default CocoaPods version, not the bundle
       - run:
@@ -73,7 +73,7 @@ commands:
       # save pods related files
       - save_cache:
           name: Saving CocoaPods Cache
-          key: cocoapods-cache-v5-{{ arch }}-{{ .Branch }}-{{ checksum "Podfile.lock" }}
+          key: cocoapods-cache-v6-{{ arch }}-{{ .Branch }}-{{ checksum "Podfile.lock" }}
           paths:
             - ./Pods
             - ./SampleApps/TestApp/Pods
@@ -139,7 +139,7 @@ jobs:
       #     flags: ios-functional-tests
       #     upload_name: Coverage report for iOS functional tests
       #     xtra_args: -c -v --xc --xp build/reports/iosFunctionalResults.xcresult
-  
+
   test-ios-integration:
     macos:
       xcode: 15.1.0 # Specify the Xcode version to use
@@ -166,7 +166,7 @@ jobs:
       - install_dependencies
 
       - prestart_tvos_simulator
-      
+
       - run:
           name: Run tvOS Unit Tests
           command: make unit-test-tvos
@@ -187,11 +187,11 @@ jobs:
       #     flags: tvos-functional-tests
       #     upload_name: Coverage report for tvOS functional tests
       #     xtra_args: -c -v --xc --xp build/reports/tvosFunctionalResults.xcresult
-      
-  build_xcframework_and_app:  
+
+  build_xcframework_and_app:
     macos:
       xcode: 15.1.0 # Specify the Xcode version to use
-    
+
     steps:
       - checkout
       # Verify XCFramework archive builds
@@ -202,4 +202,4 @@ jobs:
       - run:
           name: Build Test App
           command: make build-app
-        
+

--- a/.github/workflows/upstream-integration-test.yml
+++ b/.github/workflows/upstream-integration-test.yml
@@ -1,8 +1,6 @@
 # Action to execute upstream integration tests - Edge Network (Konductor)
 name: Integration Tests
 
-# Controls when the action will run. Workflow runs when manually triggered using the UI
-# or API.
 on:
   # `*` is a special character in YAML so you have to quote this string
   # Avoiding start of hour and other common times to avoid conflicts with peak times
@@ -46,15 +44,10 @@ on:
 
 run-name: ${{ inputs.id }}
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   test-integration-upstream:
-    # The type of runner that the job will run on
-    runs-on: macos-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
+    runs-on: macos-13
     steps:
-
     - name: Job run identifier ${{ github.event.inputs.id }}
       id: job-run-identifier
       run: |
@@ -70,6 +63,10 @@ jobs:
       with:
         ref: ${{ github.event.inputs.branch }}
 
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '15.0.1'
+
     - name: Cache Cocoapods
       id: cache-cocoapods
       uses: actions/cache@v3
@@ -79,7 +76,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pods-
 
-    # Runs a single command using the runners shell
     - name: Execute Edge Network integration tests
       id: execute-integration-tests
       run: make test-integration-upstream EDGE_ENVIRONMENT=${{ github.event.inputs.environment }} EDGE_LOCATION_HINT=${{ github.event.inputs.edge-location-hint }}
@@ -115,7 +111,6 @@ jobs:
 
         echo "EXIT_CODE=$EXIT_CODE" >> $GITHUB_OUTPUT
 
-    #
     - name: "{\"exitCode\":${{ steps.on-failure.outputs.EXIT_CODE || 0 }}}"
       id: failure-data
       if: ${{ failure() }}

--- a/AEPEdge.podspec
+++ b/AEPEdge.podspec
@@ -20,6 +20,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = { 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }
   s.dependency 'AEPCore', '>= 5.0.0', '< 6.0.0'
   s.dependency 'AEPEdgeIdentity', '>= 5.0.0', '< 6.0.0'
+  s.dependency 'AEPServices', '>= 5.1.0', '< 6.0.0'
 
   s.source_files = 'Sources/**/*.swift'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -20,13 +20,14 @@ let package = Package(
         .library(name: "AEPEdge", targets: ["AEPEdge"])
     ],
     dependencies: [
-        .package(url: "https://github.com/adobe/aepsdk-core-ios.git", .upToNextMajor(from: "5.0.0")),
+        .package(url: "https://github.com/adobe/aepsdk-core-ios.git", .upToNextMajor(from: "5.1.0")),
         .package(url: "https://github.com/adobe/aepsdk-edgeidentity-ios.git", .upToNextMajor(from: "5.0.0"))
     ],
     targets: [
         .target(name: "AEPEdge",
                 dependencies: [
-                    .product(name: "AEPCore", package: "aepsdk-core-ios"), 
+                    .product(name: "AEPCore", package: "aepsdk-core-ios"),
+                    .product(name: "AEPServices", package: "aepsdk-core-ios"),
                     .product(name: "AEPEdgeIdentity", package: "aepsdk-edgeidentity-ios")
                 ],
                 path: "Sources")

--- a/Podfile
+++ b/Podfile
@@ -10,9 +10,8 @@ project 'AEPEdge.xcodeproj'
 pod 'SwiftLint', '0.52.0'
 
 def core_pods
-      # TODO update to the production pods after release
-  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v5.1.0'
-  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v5.1.0'
+  pod 'AEPCore'
+  pod 'AEPServices'
 end
 
 def edge_pods

--- a/Podfile
+++ b/Podfile
@@ -10,8 +10,8 @@ project 'AEPEdge.xcodeproj'
 pod 'SwiftLint', '0.52.0'
 
 def core_pods
-  pod 'AEPCore'
-    # TODO update to the production AEPServices pod once it is released
+      # TODO update to the production pods after release
+  pod 'AEPCore', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v5.1.0'
   pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v5.1.0'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -11,6 +11,8 @@ pod 'SwiftLint', '0.52.0'
 
 def core_pods
   pod 'AEPCore'
+    # TODO update to the production AEPServices pod once it is released
+  pod 'AEPServices', :git => 'https://github.com/adobe/aepsdk-core-ios.git', :branch => 'dev-v5.1.0'
 end
 
 def edge_pods

--- a/Podfile
+++ b/Podfile
@@ -15,7 +15,7 @@ end
 
 def edge_pods
     pod 'AEPEdgeIdentity'
-    pod 'AEPEdgeConsent', :git => 'https://github.com/adobe/aepsdk-edgeconsent-ios.git', :branch => 'staging'
+    pod 'AEPEdgeConsent'
     pod 'AEPEdge', :path => './AEPEdge.podspec'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - AEPAssurance (4.1.1):
-    - AEPCore (>= 4.0.0)
-    - AEPServices (>= 4.0.0)
+  - AEPAssurance (5.0.0):
+    - AEPCore (< 6.0.0, >= 5.0.0)
+    - AEPServices (< 6.0.0, >= 5.0.0)
   - AEPCore (5.0.0):
     - AEPRulesEngine (< 6.0.0, >= 5.0.0)
     - AEPServices (< 6.0.0, >= 5.0.0)
@@ -24,7 +24,7 @@ DEPENDENCIES:
   - AEPAssurance
   - AEPCore
   - AEPEdge (from `./AEPEdge.podspec`)
-  - AEPEdgeConsent (from `https://github.com/adobe/aepsdk-edgeconsent-ios.git`, branch `staging`)
+  - AEPEdgeConsent
   - AEPEdgeIdentity
   - AEPTestUtils (from `https://github.com/adobe/aepsdk-testutils-ios.git`, tag `5.0.0`)
   - SwiftLint (= 0.52.0)
@@ -33,6 +33,7 @@ SPEC REPOS:
   trunk:
     - AEPAssurance
     - AEPCore
+    - AEPEdgeConsent
     - AEPEdgeIdentity
     - AEPRulesEngine
     - AEPServices
@@ -41,23 +42,17 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   AEPEdge:
     :path: "./AEPEdge.podspec"
-  AEPEdgeConsent:
-    :branch: staging
-    :git: https://github.com/adobe/aepsdk-edgeconsent-ios.git
   AEPTestUtils:
     :git: https://github.com/adobe/aepsdk-testutils-ios.git
     :tag: 5.0.0
 
 CHECKOUT OPTIONS:
-  AEPEdgeConsent:
-    :commit: e5897846c716e8cbdfa43c8ea68d95223c7bd0fe
-    :git: https://github.com/adobe/aepsdk-edgeconsent-ios.git
   AEPTestUtils:
     :git: https://github.com/adobe/aepsdk-testutils-ios.git
     :tag: 5.0.0
 
 SPEC CHECKSUMS:
-  AEPAssurance: 765587ef65481bab544aa25efcfa294e14161d49
+  AEPAssurance: 7f260ded4df38a70a06efebade8c33a3e3221984
   AEPCore: f1c3e9238bb12e7e1103f4407c341ebc65aeab5b
   AEPEdge: 6bc7c3f6573fdf0a12fb3ddfd32420112a89c80b
   AEPEdgeConsent: d7db1d19eb4c1e2146360ed3c8df315f671b26d5
@@ -67,6 +62,6 @@ SPEC CHECKSUMS:
   AEPTestUtils: 20495b368da57904ca2e9f241d1d8b114f9887b5
   SwiftLint: 13280e21cdda6786ad908dc6e416afe5acd1fcb7
 
-PODFILE CHECKSUM: d99001e08e7f2aa2fdc0a37b8004964ae6f37042
+PODFILE CHECKSUM: 559b845c969523123ac98dd7a3e4559871b3c2aa
 
 COCOAPODS: 1.14.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -26,6 +26,7 @@ DEPENDENCIES:
   - AEPEdge (from `./AEPEdge.podspec`)
   - AEPEdgeConsent
   - AEPEdgeIdentity
+  - AEPServices (from `https://github.com/adobe/aepsdk-core-ios.git`, branch `dev-v5.1.0`)
   - AEPTestUtils (from `https://github.com/adobe/aepsdk-testutils-ios.git`, tag `5.0.0`)
   - SwiftLint (= 0.52.0)
 
@@ -36,17 +37,22 @@ SPEC REPOS:
     - AEPEdgeConsent
     - AEPEdgeIdentity
     - AEPRulesEngine
-    - AEPServices
     - SwiftLint
 
 EXTERNAL SOURCES:
   AEPEdge:
     :path: "./AEPEdge.podspec"
+  AEPServices:
+    :branch: dev-v5.1.0
+    :git: https://github.com/adobe/aepsdk-core-ios.git
   AEPTestUtils:
     :git: https://github.com/adobe/aepsdk-testutils-ios.git
     :tag: 5.0.0
 
 CHECKOUT OPTIONS:
+  AEPServices:
+    :commit: 2097e4f22ee2a058ee77dc11970902c0981a43aa
+    :git: https://github.com/adobe/aepsdk-core-ios.git
   AEPTestUtils:
     :git: https://github.com/adobe/aepsdk-testutils-ios.git
     :tag: 5.0.0
@@ -62,6 +68,6 @@ SPEC CHECKSUMS:
   AEPTestUtils: 20495b368da57904ca2e9f241d1d8b114f9887b5
   SwiftLint: 13280e21cdda6786ad908dc6e416afe5acd1fcb7
 
-PODFILE CHECKSUM: 559b845c969523123ac98dd7a3e4559871b3c2aa
+PODFILE CHECKSUM: cfa7477c06df85fa080e61ef71dabc53827f2b8b
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.13.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -53,10 +53,10 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   AEPCore:
-    :commit: 2097e4f22ee2a058ee77dc11970902c0981a43aa
+    :commit: 53a2af15cf53dac950ff072bff7f0acd3b7012a4
     :git: https://github.com/adobe/aepsdk-core-ios.git
   AEPServices:
-    :commit: 2097e4f22ee2a058ee77dc11970902c0981a43aa
+    :commit: 53a2af15cf53dac950ff072bff7f0acd3b7012a4
     :git: https://github.com/adobe/aepsdk-core-ios.git
   AEPTestUtils:
     :git: https://github.com/adobe/aepsdk-testutils-ios.git

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ PODS:
 
 DEPENDENCIES:
   - AEPAssurance
-  - AEPCore
+  - AEPCore (from `https://github.com/adobe/aepsdk-core-ios.git`, branch `dev-v5.1.0`)
   - AEPEdge (from `./AEPEdge.podspec`)
   - AEPEdgeConsent
   - AEPEdgeIdentity
@@ -33,13 +33,15 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - AEPAssurance
-    - AEPCore
     - AEPEdgeConsent
     - AEPEdgeIdentity
     - AEPRulesEngine
     - SwiftLint
 
 EXTERNAL SOURCES:
+  AEPCore:
+    :branch: dev-v5.1.0
+    :git: https://github.com/adobe/aepsdk-core-ios.git
   AEPEdge:
     :path: "./AEPEdge.podspec"
   AEPServices:
@@ -50,6 +52,9 @@ EXTERNAL SOURCES:
     :tag: 5.0.0
 
 CHECKOUT OPTIONS:
+  AEPCore:
+    :commit: 2097e4f22ee2a058ee77dc11970902c0981a43aa
+    :git: https://github.com/adobe/aepsdk-core-ios.git
   AEPServices:
     :commit: 2097e4f22ee2a058ee77dc11970902c0981a43aa
     :git: https://github.com/adobe/aepsdk-core-ios.git
@@ -68,6 +73,6 @@ SPEC CHECKSUMS:
   AEPTestUtils: 20495b368da57904ca2e9f241d1d8b114f9887b5
   SwiftLint: 13280e21cdda6786ad908dc6e416afe5acd1fcb7
 
-PODFILE CHECKSUM: cfa7477c06df85fa080e61ef71dabc53827f2b8b
+PODFILE CHECKSUM: efc47e4924bf6b5ae85e269cdc5db5b91020175c
 
 COCOAPODS: 1.13.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,19 +2,20 @@ PODS:
   - AEPAssurance (5.0.0):
     - AEPCore (< 6.0.0, >= 5.0.0)
     - AEPServices (< 6.0.0, >= 5.0.0)
-  - AEPCore (5.0.0):
+  - AEPCore (5.1.0):
     - AEPRulesEngine (< 6.0.0, >= 5.0.0)
-    - AEPServices (< 6.0.0, >= 5.0.0)
+    - AEPServices (< 6.0.0, >= 5.1.0)
   - AEPEdge (5.0.1):
     - AEPCore (< 6.0.0, >= 5.0.0)
     - AEPEdgeIdentity (< 6.0.0, >= 5.0.0)
+    - AEPServices (< 6.0.0, >= 5.1.0)
   - AEPEdgeConsent (5.0.0):
     - AEPCore (< 6.0.0, >= 5.0.0)
     - AEPEdge (< 6.0.0, >= 5.0.0)
   - AEPEdgeIdentity (5.0.0):
     - AEPCore (< 6.0.0, >= 5.0.0)
   - AEPRulesEngine (5.0.0)
-  - AEPServices (5.0.0)
+  - AEPServices (5.1.0)
   - AEPTestUtils (5.0.0):
     - AEPCore
     - AEPServices
@@ -22,57 +23,47 @@ PODS:
 
 DEPENDENCIES:
   - AEPAssurance
-  - AEPCore (from `https://github.com/adobe/aepsdk-core-ios.git`, branch `dev-v5.1.0`)
+  - AEPCore
   - AEPEdge (from `./AEPEdge.podspec`)
   - AEPEdgeConsent
   - AEPEdgeIdentity
-  - AEPServices (from `https://github.com/adobe/aepsdk-core-ios.git`, branch `dev-v5.1.0`)
+  - AEPServices
   - AEPTestUtils (from `https://github.com/adobe/aepsdk-testutils-ios.git`, tag `5.0.0`)
   - SwiftLint (= 0.52.0)
 
 SPEC REPOS:
   trunk:
     - AEPAssurance
+    - AEPCore
     - AEPEdgeConsent
     - AEPEdgeIdentity
     - AEPRulesEngine
+    - AEPServices
     - SwiftLint
 
 EXTERNAL SOURCES:
-  AEPCore:
-    :branch: dev-v5.1.0
-    :git: https://github.com/adobe/aepsdk-core-ios.git
   AEPEdge:
     :path: "./AEPEdge.podspec"
-  AEPServices:
-    :branch: dev-v5.1.0
-    :git: https://github.com/adobe/aepsdk-core-ios.git
   AEPTestUtils:
     :git: https://github.com/adobe/aepsdk-testutils-ios.git
     :tag: 5.0.0
 
 CHECKOUT OPTIONS:
-  AEPCore:
-    :commit: 53a2af15cf53dac950ff072bff7f0acd3b7012a4
-    :git: https://github.com/adobe/aepsdk-core-ios.git
-  AEPServices:
-    :commit: 53a2af15cf53dac950ff072bff7f0acd3b7012a4
-    :git: https://github.com/adobe/aepsdk-core-ios.git
   AEPTestUtils:
     :git: https://github.com/adobe/aepsdk-testutils-ios.git
     :tag: 5.0.0
 
 SPEC CHECKSUMS:
   AEPAssurance: 7f260ded4df38a70a06efebade8c33a3e3221984
-  AEPCore: f1c3e9238bb12e7e1103f4407c341ebc65aeab5b
-  AEPEdge: 0873041dfb29f3126260f2dc16d548a1fefbe0c4
+  AEPCore: 55489e1c4e48a88659055f8e96290f2cccce9747
+  AEPEdge: 013661d205b3d4a12432201c6f6c50ad707df18b
   AEPEdgeConsent: d7db1d19eb4c1e2146360ed3c8df315f671b26d5
   AEPEdgeIdentity: 3161ff33434586962946912d6b8e9e8fca1c4d23
   AEPRulesEngine: fe5800653a4bee07b1e41e61b4d5551f0dba557b
-  AEPServices: e42e5118128e81c0f797fdfb1dc9c4a714d644b8
+  AEPServices: c38b809c32336f10f773525e65c71a949abe54a7
   AEPTestUtils: 20495b368da57904ca2e9f241d1d8b114f9887b5
   SwiftLint: 13280e21cdda6786ad908dc6e416afe5acd1fcb7
 
-PODFILE CHECKSUM: efc47e4924bf6b5ae85e269cdc5db5b91020175c
+PODFILE CHECKSUM: 0beefce457cb2f47f1caa5a1f85d8e90e4fd47d4
 
 COCOAPODS: 1.13.0

--- a/Sources/EdgeNetworkHandlers/EdgeNetworkService.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeNetworkService.swift
@@ -100,12 +100,8 @@ class EdgeNetworkService {
 
         ServiceProvider.shared.networkService.connectAsync(networkRequest: networkRequest) { (connection: HttpConnection) in
             if connection.error != nil {
-                // handle network transport error
-                if let urlError = connection.error as? URLError {
-                   let urlErrorCode = urlError.code
-
-                   // retry for recoverable url error codes
-                   if NetworkServiceConstants.RECOVERABLE_URL_ERROR_CODES.contains(urlErrorCode) {
+                // retry for recoverable url error codes
+                if let urlError = connection.error as? URLError, urlError.isRecoverable {
                        let retryInterval = EdgeConstants.Defaults.RETRY_INTERVAL
                        let errorMessage = "failed with recoverable URL error:(\(urlError.localizedDescription)) code:(\(urlError.errorCode))."
 
@@ -114,7 +110,6 @@ class EdgeNetworkService {
 
                        completion(false, retryInterval) // failed, but recoverable so retry
                        return
-                   }
                 }
 
                 // handle non-recoverable URLErrors and other non URLErrors
@@ -309,5 +304,11 @@ extension String {
             return nil
         }
         return character
+    }
+}
+
+extension URLError {
+    var isRecoverable: Bool {
+        NetworkServiceConstants.RECOVERABLE_URL_ERROR_CODES.contains(self.code)
     }
 }

--- a/Sources/EdgeNetworkHandlers/EdgeNetworkService.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeNetworkService.swift
@@ -115,7 +115,7 @@ class EdgeNetworkService {
                 // handle non-recoverable URLErrors and other non URLErrors
                 let errorMessage = "failed with unrecoverable error:(\(connection.error?.localizedDescription ?? "Unknown Error")) code:(\(connection.responseCode ?? -1))"
                 Log.warning(label: EdgeConstants.LOG_TAG,
-                           "\(self.SELF_TAG) - Edge request with url:\(url.absoluteString) \(errorMessage). Dropping the request.")
+                            "\(self.SELF_TAG) - Edge request with url:\(url.absoluteString) \(errorMessage). Dropping the request.")
                 self.handleError(connection: connection, responseCallback: responseCallback)
                 responseCallback.onComplete()
                 completion(true, nil) // don't retry
@@ -304,11 +304,5 @@ extension String {
             return nil
         }
         return character
-    }
-}
-
-extension URLError {
-    var isRecoverable: Bool {
-        NetworkServiceConstants.RECOVERABLE_URL_ERROR_CODES.contains(self.code)
     }
 }

--- a/Sources/EdgeNetworkHandlers/EdgeNetworkService.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeNetworkService.swift
@@ -100,7 +100,27 @@ class EdgeNetworkService {
 
         ServiceProvider.shared.networkService.connectAsync(networkRequest: networkRequest) { (connection: HttpConnection) in
             if connection.error != nil {
-                // handle generic error
+                // handle network transport error
+                if let urlError = connection.error as? URLError {
+                   let urlErrorCode = urlError.code
+
+                   // retry for recoverable url error codes
+                   if NetworkServiceConstants.RECOVERABLE_URL_ERROR_CODES.contains(urlErrorCode) {
+                       let retryInterval = EdgeConstants.Defaults.RETRY_INTERVAL
+                       let errorMessage = "failed with recoverable URL error:(\(urlError.localizedDescription)) code:(\(urlError.errorCode))."
+
+                       Log.debug(label: EdgeConstants.LOG_TAG,
+                                 "\(self.SELF_TAG) - Edge request with url:\(url.absoluteString) \(errorMessage)). Will retry request in \(retryInterval) seconds.")
+
+                       completion(false, retryInterval) // failed, but recoverable so retry
+                       return
+                   }
+                }
+
+                // handle non-recoverable URLErrors and other non URLErrors
+                let errorMessage = "failed with unrecoverable error:(\(connection.error?.localizedDescription ?? "Unknown Error")) code:(\(connection.responseCode ?? -1))"
+                Log.warning(label: EdgeConstants.LOG_TAG,
+                           "\(self.SELF_TAG) - Edge request with url:\(url.absoluteString) \(errorMessage). Dropping the request.")
                 self.handleError(connection: connection, responseCallback: responseCallback)
                 responseCallback.onComplete()
                 completion(true, nil) // don't retry
@@ -108,7 +128,7 @@ class EdgeNetworkService {
             }
 
             guard let responseCode = connection.responseCode else {
-                Log.warning(label: EdgeConstants.LOG_TAG, "\(self.SELF_TAG) - Connection to Experience Edge returned unknown error")
+                Log.warning(label: EdgeConstants.LOG_TAG, "\(self.SELF_TAG) - Edge request with url:\(url.absoluteString) failed with unknown error. Dropping the request.")
                 self.handleError(connection: connection, responseCallback: responseCallback)
                 responseCallback.onComplete()
                 completion(true, nil) // failed, but unrecoverable, don't retry

--- a/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
+++ b/Tests/FunctionalTests/AEPEdgeFunctionalTests.swift
@@ -1246,7 +1246,7 @@ class AEPEdgeFunctionalTests: TestBase, AnyCodableAsserts {
 
             XCTAssertEqual(expectedEdgeEventError, edgeEventError)
         }
-    
+
     // MARK: Test Send Event with Configurable Endpoint
     func testSendEvent_withConfigurableEndpoint_withEmptyConfigEndpoint_UsesProduction() {
         let responseConnection: HttpConnection = HttpConnection(data: responseBody.data(using: .utf8),

--- a/Tests/FunctionalTests/Edge+ConsentTests.swift
+++ b/Tests/FunctionalTests/Edge+ConsentTests.swift
@@ -259,7 +259,7 @@ class EdgeConsentTests: TestBase, AnyCodableAsserts {
             "konductorConfig": {
               "streaming": {
                 "enabled": true,
-                "recordSeparator": "\u0000",
+                "recordSeparator": "STRING_TYPE",
                 "lineFeed": "\n"
               }
             }
@@ -271,8 +271,8 @@ class EdgeConsentTests: TestBase, AnyCodableAsserts {
             expected: expectedJSON,
             actual: consentRequests[0],
             pathOptions:
-                ValueTypeMatch(paths: "identityMap.ECID[0].id", "consent[0].value.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+                CollectionEqualCount(scope: .subtree),
+                ValueTypeMatch(paths: "identityMap.ECID[0].id", "consent[0].value.metadata.time", "meta.konductorConfig.streaming.recordSeparator"))
     }
 
     func testCollectConsentYes_sendsRequestToEdgeNetwork() {
@@ -322,7 +322,7 @@ class EdgeConsentTests: TestBase, AnyCodableAsserts {
             "konductorConfig": {
               "streaming": {
                 "enabled": true,
-                "recordSeparator": "\u0000",
+                "recordSeparator": "STRING_TYPE",
                 "lineFeed": "\n"
               }
             }
@@ -333,8 +333,8 @@ class EdgeConsentTests: TestBase, AnyCodableAsserts {
             expected: expectedJSON,
             actual: consentRequests[0],
             pathOptions:
-                ValueTypeMatch(paths: "identityMap.ECID[0].id", "consent[0].value.metadata.time"),
-                CollectionEqualCount(scope: .subtree))
+                CollectionEqualCount(scope: .subtree),
+                ValueTypeMatch(paths: "identityMap.ECID[0].id", "consent[0].value.metadata.time", "meta.konductorConfig.streaming.recordSeparator"))
     }
 
     func testCollectConsentOtherThanYesNo_doesNotSendRequestToEdgeNetwork() {

--- a/Tests/FunctionalTests/EdgeQueuedEntityFunctionalTests.swift
+++ b/Tests/FunctionalTests/EdgeQueuedEntityFunctionalTests.swift
@@ -146,8 +146,8 @@ class EdgeQueuedEntityFunctionalTests: TestBase, AnyCodableAsserts {
     ///   - entityId: the UUID to identify the `DataEntity`
     private func mockQueuedEvent(dataQueue: DataQueue, edgeConfig: [String: AnyCodable], entityId: String = "entity-uuid") {
         let experienceEvent = Event(name: "queued event", type: EventType.edge, source: EventSource.requestContent, data: ["xdm": ["test": "data"]])
-        var edgeEntity = EdgeDataEntity(event: experienceEvent, configuration: edgeConfig, identityMap: [:])
-        var entity = DataEntity(uniqueIdentifier: entityId, timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
+        let edgeEntity = EdgeDataEntity(event: experienceEvent, configuration: edgeConfig, identityMap: [:])
+        let entity = DataEntity(uniqueIdentifier: entityId, timestamp: Date(), data: try? JSONEncoder().encode(edgeEntity))
 
         dataQueue.add(dataEntity: entity)
     }

--- a/Tests/UnitTests/EdgeNetworkServiceTests.swift
+++ b/Tests/UnitTests/EdgeNetworkServiceTests.swift
@@ -219,7 +219,7 @@ class EdgeNetworkServiceTests: XCTestCase {
 
         wait(for: [expectation], timeout: 0.5)
     }
-    
+
     func testDoRequest_whenConnection_RecoverableTransportErrorCode_CallsCompletionFalse_AndNoResponseCallback() {
             // setup
             let error: NSError = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet, userInfo: nil)

--- a/Tests/UnitTests/EdgeNetworkServiceTests.swift
+++ b/Tests/UnitTests/EdgeNetworkServiceTests.swift
@@ -219,14 +219,40 @@ class EdgeNetworkServiceTests: XCTestCase {
 
         wait(for: [expectation], timeout: 0.5)
     }
+    
+    func testDoRequest_whenConnection_RecoverableTransportErrorCode_CallsCompletionFalse_AndNoResponseCallback() {
+            // setup
+            let error: NSError = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet, userInfo: nil)
+            let expectation = XCTestExpectation(description: "Network callback is invoked")
 
-    func testDoRequest_whenConnection_UnrecoverableResponseCode_WhenContentTypeJson_WithError_ReturnFormattedError() {
+            // test
+            let mockHttpConnection = HttpConnection(data: nil, response: nil, error: error)
+            mockNetworkService.setMockResponse(url: url, httpMethod: .post, responseConnection: mockHttpConnection)
+            networkService.doRequest(url: url,
+                                     requestBody: edgeHitPayload,
+                                     requestHeaders: [:],
+                                     streaming: nil,
+                                     responseCallback: mockResponseCallback,
+                                     completion: { success, retryInterval in
+                                        // verify
+                                        XCTAssertFalse(success)
+                                        XCTAssertEqual(5.0, retryInterval)
+                                        XCTAssertFalse(self.mockResponseCallback.onResponseCalled)
+                                        XCTAssertFalse(self.mockResponseCallback.onErrorCalled)
+                                        XCTAssertEqual([], self.mockResponseCallback.onResponseJsonResponse)
+                                        expectation.fulfill()
+                                     })
+
+            wait(for: [expectation], timeout: 0.5)
+        }
+
+    func testDoRequest_whenConnection_UnrecoverableTransportErrorCode_WhenContentTypeJson_WithError_ReturnFormattedError() {
         // setup
         let error: NSError = NSError(domain: NSURLErrorDomain, code: NSURLErrorAppTransportSecurityRequiresSecureConnection, userInfo: nil)
         let expectation = XCTestExpectation(description: "Network callback is invoked")
 
         // test
-        let mockHttpConnection = HttpConnection(data: nil, response: HTTPURLResponse(url: url, statusCode: 503, httpVersion: nil, headerFields: nil), error: error)
+        let mockHttpConnection = HttpConnection(data: nil, response: nil, error: error)
         mockNetworkService.setMockResponse(url: url, httpMethod: .post, responseConnection: mockHttpConnection)
         networkService.doRequest(url: url,
                                  requestBody: edgeHitPayload,
@@ -242,7 +268,7 @@ class EdgeNetworkServiceTests: XCTestCase {
                                     XCTAssertEqual(1, self.mockResponseCallback.onErrorJsonError.capacity)
                                     let errorJson = self.mockResponseCallback.onErrorJsonError[0]
                                     XCTAssertTrue(errorJson.contains("\"title\":\"Unexpected Error\""))
-                                    XCTAssertTrue(errorJson.contains("\"detail\":\"service unavailable\""))
+                                    XCTAssertTrue(errorJson.contains("\"detail\":\"Request to Experience Edge failed with an unknown exception\""))
                                     expectation.fulfill()
                                  })
 

--- a/Tests/UnitTests/RequestMetadataTests.swift
+++ b/Tests/UnitTests/RequestMetadataTests.swift
@@ -108,7 +108,7 @@ class RequestMetadataTests: XCTestCase, AnyCodableAsserts {
     }
 
     func testEncode_paramSDKConfig_originalDatastreamIdMetadata() {
-        let payload = StorePayload(key: "key", value: "value", maxAge: 3600)
+
         let metadata = RequestMetadata(konductorConfig: KonductorConfig(streaming: nil), sdkConfig: SDKConfig(datastream: Datastream(original: "OriginalDatastreamID")), configOverrides: nil, state: nil)
 
         guard let data = try? encoder.encode(metadata), let metadataString = String(data: data, encoding: .utf8) else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
![Screenshot 2024-05-15 at 1 18 33 PM](https://github.com/adobe/aepsdk-edge-ios/assets/4697559/1db5c91e-3610-46cc-b919-3ba546ab9a32)

- Added logic to retry hits failed with a recoverable URLError, which were previously discarded.
- Added unit tests and functional tests.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
