### PR TITLE
update weak self usage

### DIFF
--- a/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
+++ b/Sources/EdgeNetworkHandlers/EdgeHitProcessor.swift
@@ -256,9 +256,10 @@ class EdgeHitProcessor: HitProcessing {
                                  requestHeaders: headers,
                                  streaming: edgeHit.getStreamingSettings(),
                                  responseCallback: callback) { [weak self] success, retryInterval in
-            // remove any retry interval if success, otherwise add to retry mapping
-            guard let self = self else { return }
-            self.entityRetryIntervalMapping[entityId] = success ? nil : retryInterval
+            if let self = self {
+                // remove any retry interval if success, otherwise add to retry mapping
+                self.entityRetryIntervalMapping[entityId] = success ? nil : retryInterval
+            }
             completion(success)
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Allow closure from hit queue to execute if still available, passing down to the parent of this closure - this change should not make a difference as the persistent hit queue holds a strong reference to hit processor and queue, so both should still be available for processing.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
