### PR TITLE
Unrevert #481 - "Make EdgeEventHandles and completionHandlers..."

### DIFF
--- a/Sources/EdgeNetworkHandlers/CompletionHandlersManager.swift
+++ b/Sources/EdgeNetworkHandlers/CompletionHandlersManager.swift
@@ -15,14 +15,12 @@ import Foundation
 
 class CompletionHandlersManager {
     private let TAG = "CompletionHandlersManager"
-    private var completionHandlers =
-        ThreadSafeDictionary<String, (([EdgeEventHandle]) -> Void)>(identifier: "com.adobe.edge.completionHandlers")
-
+    private var completionHandlers = [String: (([EdgeEventHandle]) -> Void)]()
     // edge response handles for a event request id (key)
-    private var edgeEventHandles =
-        ThreadSafeDictionary<String, [EdgeEventHandle]>(identifier: "com.adobe.edge.edgeHandlesList")
+    private var edgeEventHandles = [String: [EdgeEventHandle]]()
 
     static let shared = CompletionHandlersManager()
+    private let queue = DispatchQueue(label: "com.adobe.edge.completionHandlersManager.queue")
 
     /// Registers a completion handler for the specified `requestEventId`. This handler is invoked when the Edge response content has been
     /// handled entirely by the Edge extension, containing a list of `EdgeEventHandle`(s). This list can be empty or can contain one or multiple items
@@ -38,8 +36,14 @@ class CompletionHandlersManager {
             return
         }
 
-        Log.trace(label: TAG, "Registering completion handler for Edge response with request event id \(forRequestEventId).")
-        completionHandlers[forRequestEventId] = unwrappedCompletion
+        queue.async { [weak self] in
+
+            guard let self = self else { return }
+
+            Log.trace(label: TAG, "Registering completion handler for Edge response with request event id \(forRequestEventId).")
+            completionHandlers[forRequestEventId] = unwrappedCompletion
+        }
+
     }
 
     /// Calls the registered completion handler (if any) with the collected `EdgeEventHandle`(s). After this operation,
@@ -48,13 +52,20 @@ class CompletionHandlersManager {
     func unregisterCompletionHandler(forRequestEventId: String) {
         guard !forRequestEventId.isEmpty else { return }
 
-        if let completionHandler = completionHandlers[forRequestEventId] {
-            completionHandler(edgeEventHandles[forRequestEventId] ?? [])
-            _ = completionHandlers.removeValue(forKey: forRequestEventId)
-            Log.trace(label: TAG, "Removing completion handler for Edge response with request event id \(forRequestEventId).")
+        queue.async { [weak self] in
+
+            guard let self = self else { return }
+
+            if let completionHandler = completionHandlers[forRequestEventId] {
+                completionHandler(edgeEventHandles[forRequestEventId] ?? [])
+
+                Log.trace(label: TAG, "Removing completion handler for Edge response with request event id \(forRequestEventId).")
+                completionHandlers.removeValue(forKey: forRequestEventId)
+            }
+
+            edgeEventHandles.removeValue(forKey: forRequestEventId)
         }
 
-        _ = edgeEventHandles.removeValue(forKey: forRequestEventId)
     }
 
     /// Updates the list of `EdgeEventHandle`(s) for current `requestEventId`.
@@ -63,10 +74,13 @@ class CompletionHandlersManager {
     ///   - eventHandle: newly received event handle
     func eventHandleReceived(forRequestEventId: String?, _ eventHandle: EdgeEventHandle) {
         guard let unwrappedRequestEventId = forRequestEventId, !unwrappedRequestEventId.isEmpty else { return }
-        if edgeEventHandles[unwrappedRequestEventId] != nil {
-            edgeEventHandles[unwrappedRequestEventId]?.append(eventHandle)
-        } else {
-            edgeEventHandles[unwrappedRequestEventId] = [eventHandle]
+
+        queue.async {[weak self] in
+
+            guard let self = self else { return }
+
+            edgeEventHandles[unwrappedRequestEventId, default: []].append(eventHandle)
         }
+
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> This PR merges back the changes in #481 to `dev` - setting this up now so we don't forget to merge back into `dev` for eventual release.

## Description

This PR un-reverts PR #481 and adds it back to the release branches. 
* Please see original PR #481 (author: @addb) for original code review - there should be no differences of the code changes there vs here.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
