### PR TITLE
Update integration test workflow to use reusable workflow

### DIFF
--- a/.github/workflows/upstream-integration-test.yml
+++ b/.github/workflows/upstream-integration-test.yml
@@ -51,83 +51,30 @@ on:
           - 'EmptyString'
           - 'Invalid'
           - 'None'
+      ios-device-names:
+        description: |
+          The iOS device names to use for testing. Must be formatted as a valid JSON array string.
+          Example: '["iPhone 15", "iPhone 15 Pro"]'
+            - Notice the use of single quotes to wrap the JSON array string, and double quotes for each array element.
+        type: string
+        default: '["iPhone 15"]'
+      ios-versions:
+        description: |
+          The iOS versions to use for testing. Must be formatted as a valid JSON array string.
+          Example: '["18.0", "18.1"]'
+            - Notice the use of single quotes to wrap the JSON array string, and double quotes for each array element.
+        type: string
+        default: '["18.0"]'
           
 
 run-name: ${{ inputs.id }}
 
 jobs:
-  test-integration-upstream:
-    runs-on: macos-latest
-    steps:
-    - name: Job run identifier ${{ github.event.inputs.id }}
-      id: job-run-identifier
-      run: |
-        if [ -z "${{ github.event.inputs.id }}" ]; then \
-          echo No job run identifier was set.
-        else
-          echo 'Job run identifier is:' ${{ inputs.id }}
-        fi;
-
-    - name: Checkout
-      id: checkout
-      uses: actions/checkout@v4.2.0
-      with:
-        ref: ${{ github.event.inputs.branch }}
-
-    - name: Cache Cocoapods
-      id: cache-cocoapods
-      uses: actions/cache@v4.0.2
-      with:
-        path: Pods
-        key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-pods-
-
-    - name: Execute Edge Network integration tests
-      id: execute-integration-tests
-      run: make test-integration-upstream TAGS_MOBILE_PROPERTY_ID=${{ github.event.inputs.tags-mobile-property-id }} EDGE_LOCATION_HINT=${{ github.event.inputs.edge-location-hint }}
-
-    # Potential workflow solutions on job failure
-    # All workflow setup step failures give exit code 2, with 3 as fallback
-    # Actual integration test failures give exit code 1
-    - name: On failure
-      id: on-failure
-      if: ${{ failure() }}
-      env:
-        BRANCH: ${{ github.event.inputs.branch }}
-      run: |
-        echo "Job used branch: $BRANCH. Please make sure this is the branch to run off of."
-        
-        EXIT_CODE=3
-
-        if [[ "${{ steps.job-run-identifier.conclusion }}" == "failure" ]]; then
-          echo "Job step failed: Job run identifier."
-          EXIT_CODE=2
-        elif [[ "${{ steps.checkout.conclusion }}" == "failure" ]]; then
-          echo "Job step failed: Checkout."
-          EXIT_CODE=2
-        elif [[ "${{ steps.cache-cocoapods.conclusion }}" == "failure" ]]; then
-          echo "Job step failed: Cache Cocoapods."
-          EXIT_CODE=2
-        elif [[ "${{ steps.execute-integration-tests.conclusion }}" == "failure" ]]; then
-          echo "Job step failed: Execute Edge Network integration tests."
-          EXIT_CODE=1
-        else
-          echo "Job failed: Failure cause not identified."
-        fi
-
-        echo "EXIT_CODE=$EXIT_CODE" >> $GITHUB_OUTPUT
-    
-    # Dynamic step name in JSON format, examples on job: 
-    # - During job run (before this step): {"exitCode":${{ steps.on-failure.outputs.EXIT_CODE || 0 }}}
-    # - Failure: {"exitCode":1}
-    # - Success: {"exitCode":0}
-    - name: "{\"exitCode\":${{ steps.on-failure.outputs.EXIT_CODE || 0 }}}"
-      id: failure-data
-      if: ${{ failure() }}
-      run: |
-        echo 'exit code in the body: ${{ steps.on-failure.outputs.EXIT_CODE }}'
-        echo 'on-failure outputs: ${{ toJson(steps.on-failure.outputs) }}'
-        
-    
-
+  test-ios-integration:
+    name: Integration Test (iOS)
+    uses: adobe/aepsdk-commons/.github/workflows/ios-custom-command-build-and-test.yml@gha-ios-5.0.0
+    with:
+      ios-device-names: ${{ inputs.ios-device-names }}
+      ios-versions: ${{ inputs.ios-versions }}
+      command: make integration-test-ios TAGS_MOBILE_PROPERTY_ID=${{ github.event.inputs.tags-mobile-property-id }} EDGE_LOCATION_HINT=${{ github.event.inputs.edge-location-hint }}
+    secrets: inherit

--- a/.github/workflows/upstream-integration-test.yml
+++ b/.github/workflows/upstream-integration-test.yml
@@ -77,4 +77,5 @@ jobs:
       ios-device-names: ${{ inputs.ios-device-names }}
       ios-versions: ${{ inputs.ios-versions }}
       command: make integration-test-ios TAGS_MOBILE_PROPERTY_ID=${{ github.event.inputs.tags-mobile-property-id }} EDGE_LOCATION_HINT=${{ github.event.inputs.edge-location-hint }}
+      enable-codecov: false
     secrets: inherit

--- a/Tests/UpstreamIntegrationTests/ConfigOverrideTests.swift
+++ b/Tests/UpstreamIntegrationTests/ConfigOverrideTests.swift
@@ -20,7 +20,7 @@ import XCTest
 
 /// Performs validation on integration with the Edge Network upstream service
 class ConfigOverrideTests: TestBase, AnyCodableAsserts {
-    private let TIMEOUT_SEC: TimeInterval = 30
+    private let TIMEOUT_SEC: TimeInterval = 45
     private var edgeLocationHint: String? = TestEnvironment.defaultLocationHint
     private var networkService: RealNetworkService = RealNetworkService()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR updates the integration test workflow to use the reusable workflow for custom commands, but still keeps it on a cron job.

It also increases the timeout for ConfigOverrideTests from 30->45 to help address network response time/event processing flakiness issues.

Example run:
https://github.com/timkimadobe/aepsdk-edge-ios/actions/runs/12439610942

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
